### PR TITLE
Don't require config file for measure subcommand

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -215,7 +215,7 @@ func measureCmd() *cobra.Command {
 				GlobalConfig: config.GlobalConfig{
 					UUID: uuid,
 					Measurements: []types.Measurement{
-						types.Measurement{
+						{
 							Name: "podLatency",
 						},
 					},

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/burner"
 	"github.com/cloud-bulldozer/kube-burner/pkg/config"
 	"github.com/cloud-bulldozer/kube-burner/pkg/measurements"
+	"github.com/cloud-bulldozer/kube-burner/pkg/measurements/types"
 	"github.com/cloud-bulldozer/kube-burner/pkg/util"
 	"github.com/cloud-bulldozer/kube-burner/pkg/util/metrics"
 
@@ -197,8 +198,7 @@ func measureCmd() *cobra.Command {
 	var uuid string
 	var rawNamespaces string
 	var selector string
-	var configFile string
-	var jobName string
+	var jobName, esServer, esIndex, metricsDirectory string
 	var userMetadata string
 	var indexer *indexers.Indexer
 	metadata := make(map[string]interface{})
@@ -210,24 +210,34 @@ func measureCmd() *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			f, err := util.ReadConfig(configFile)
-			if err != nil {
-				log.Fatalf("Error reading configuration file %s: %s", configFile, err)
+			var err error
+			configSpec := config.Spec{
+				GlobalConfig: config.GlobalConfig{
+					UUID: uuid,
+					Measurements: []types.Measurement{
+						types.Measurement{
+							Name: "podLatency",
+						},
+					},
+				},
 			}
-			configSpec, err := config.Parse(configFile, f)
-			if err != nil {
-				log.Fatal(err.Error())
-			}
-			if len(configSpec.Jobs) > 0 {
-				log.Fatal("No jobs are allowed in a measure subcommand config file")
-			}
-			if configSpec.GlobalConfig.IndexerConfig.Type != "" {
-				indexerConfig := configSpec.GlobalConfig.IndexerConfig
-				log.Infof("📁 Creating indexer: %s", indexerConfig.Type)
-				indexer, err = indexers.NewIndexer(indexerConfig)
-				if err != nil {
-					log.Fatalf("%v indexer: %v", indexerConfig.Type, err.Error())
+			if esServer != "" && esIndex != "" {
+				configSpec.GlobalConfig.IndexerConfig = indexers.IndexerConfig{
+					Type:    indexers.ElasticIndexer,
+					Servers: []string{esServer},
+					Index:   esIndex,
 				}
+			} else {
+				configSpec.GlobalConfig.IndexerConfig = indexers.IndexerConfig{
+					Type:             indexers.LocalIndexer,
+					MetricsDirectory: metricsDirectory,
+				}
+			}
+			indexerConfig := configSpec.GlobalConfig.IndexerConfig
+			log.Infof("📁 Creating indexer: %s", indexerConfig.Type)
+			indexer, err = indexers.NewIndexer(indexerConfig)
+			if err != nil {
+				log.Fatalf("%v indexer: %v", indexerConfig.Type, err.Error())
 			}
 			if userMetadata != "" {
 				metadata, err = util.ReadUserMetadata(userMetadata)
@@ -244,7 +254,6 @@ func measureCmd() *cobra.Command {
 			for _, req := range labelRequirements {
 				namespaceLabels[req.Key()] = req.Values().List()[0]
 			}
-			log.Infof("%v", namespaceLabels)
 			measurements.NewMeasurementFactory(configSpec, indexer, metadata)
 			measurements.SetJobConfig(&config.Job{
 				Name:            jobName,
@@ -257,9 +266,11 @@ func measureCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&uuid, "uuid", "", "UUID")
+	cmd.Flags().StringVar(&uuid, "uuid", uid.NewV4().String(), "Measurement UUID")
+	cmd.Flags().StringVar(&metricsDirectory, "metrics-directory", "collected-metrics", "Directory to dump the metrics files in, when using default local indexing")
+	cmd.Flags().StringVar(&esServer, "es-server", "", "Elastic Search endpoint")
+	cmd.Flags().StringVar(&esIndex, "es-index", "", "Elastic Search index")
 	cmd.Flags().StringVar(&userMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
-	cmd.Flags().StringVarP(&configFile, "config", "c", "config.yml", "Config file path or URL")
 	cmd.Flags().StringVarP(&jobName, "job-name", "j", "kube-burner-measure", "Measure job name")
 	cmd.Flags().StringVarP(&rawNamespaces, "namespaces", "n", corev1.NamespaceAll, "comma-separated list of namespaces")
 	cmd.Flags().StringVarP(&selector, "selector", "l", "", "namespace label selector. (e.g. -l key1=value1,key2=value2)")

--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -115,8 +115,10 @@ WARN[2020-12-15 12:37:08] P99 Ready latency (2929ms) higher than configured thre
 In case of not meeting any of the configured thresholds, like the example above, **kube-burner return code will be 1**.
 
 ### Measure subcommand CLI example
-Measure subcommand example with relevant options. It is used to fetch measurements on top of resources that were a part of workload ran in past.
-```
+
+This subcommand can be used to collect and index pod latency metrics from pods already present on the cluster.
+
+```shell
 kube-burner measure --uuid=vchalla --namespaces=cluster-density-v2-0,cluster-density-v2-1,cluster-density-v2-2,cluster-density-v2-3,cluster-density-v2-4 --selector=kube-burner-job=cluster-density-v2 
 time="2023-11-19 17:46:05" level=info msg="📁 Creating indexer: elastic" file="kube-burner.go:226"
 time="2023-11-19 17:46:05" level=info msg="map[kube-burner-job:cluster-density-v2]" file="kube-burner.go:247"

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -223,6 +223,8 @@ func (p *podLatency) stop() error {
 	if errorRate > 10.00 {
 		log.Error("Latency errors beyond 10%. Hence invalidating the results")
 		return fmt.Errorf("Something is wrong with system under test. Pod latencies error rate was: %.2f", errorRate)
+	} else if errorRate > 0 {
+		log.Infof("Pod latencies error rate was: %.2f", errorRate)
 	}
 	p.calcQuantiles()
 	if len(p.config.LatencyThresholds) > 0 {
@@ -238,9 +240,6 @@ func (p *podLatency) stop() error {
 	for _, q := range p.latencyQuantiles {
 		pq := q.(metrics.LatencyQuantiles)
 		log.Infof("%s: %s 50th: %v 99th: %v max: %v avg: %v", factory.jobConfig.Name, pq.QuantileName, pq.P50, pq.P99, pq.Max, pq.Avg)
-	}
-	if len(p.latencyQuantiles) > 0 {
-		log.Infof("Pod latencies error rate was: %.2f", errorRate)
 	}
 	// Reset latency slices, required in multi-job benchmarks
 	p.latencyQuantiles, p.normLatencies = nil, nil


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Easier to use now

```
$ ./bin/amd64/kube-burner measure  -n dittybopper 
time="2023-11-22 11:51:23" level=info msg="📁 Creating indexer: local" file="kube-burner.go:237"
time="2023-11-22 11:51:23" level=info msg="📈 Registered measurement: podLatency" file="factory.go:85"
time="2023-11-22 11:51:24" level=info msg="Stopping measurement: podLatency" file="factory.go:118"
time="2023-11-22 11:51:24" level=info msg="Indexing pod latency data for job: kube-burner-measure" file="pod_latency.go:244"
time="2023-11-22 11:51:24" level=info msg="File collected-metrics/podLatencyMeasurement-kube-burner-measure.json created with 1 documents" file="pod_latency.go:261"
time="2023-11-22 11:51:24" level=info msg="File collected-metrics/podLatencyQuantilesMeasurement-kube-burner-measure.json created with 4 documents" file="pod_latency.go:261"
time="2023-11-22 11:51:24" level=info msg="kube-burner-measure: ContainersReady 50th: 0 99th: 0 max: 0 avg: 20000" file="pod_latency.go:235"
time="2023-11-22 11:51:24" level=info msg="kube-burner-measure: Initialized 50th: 0 99th: 0 max: 0 avg: 0" file="pod_latency.go:235"
time="2023-11-22 11:51:24" level=info msg="kube-burner-measure: Ready 50th: 0 99th: 0 max: 0 avg: 20000" file="pod_latency.go:235"
time="2023-11-22 11:51:24" level=info msg="kube-burner-measure: PodScheduled 50th: 0 99th: 0 max: 0 avg: 0" file="pod_latency.go:235"
time="2023-11-22 11:51:24" level=info msg="👋 Exiting kube-burner d94714e9-9427-43b3-89ea-f458878c42fe" file="kube-burner.go:209"
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
