### PR TITLE
Code owners setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owners
+*                                       @rsevilla87
+*                                       @kube-burner/maintainers
+
+# web-burner owners
+/cmd/kube-burner/ocp-config/web-burner* @kube-burner/ocp-perfscale-telco
+/pkg/workloads/web-burner.go            @kube-burner/ocp-perfscale-telco


### PR DESCRIPTION
## Description

With the addition of new ocp-wrapper workloads the maintainer base of kube-burner is growing.
It would be great to be able to map maintainers to these workloads, so they would be responsible for its maintenance.
GitHub [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file can achieve that.

## Discussion

In this first iteration the idea was to map [existing teams](https://github.com/orgs/kube-burner/teams) in the [kube-burner organization](https://github.com/kube-burner).
However, they must be publicly visible and have write access to the repository (which they dont today, so dont merge this PR as is it now).
Options:
 - Fix the permissions of the existing kube-burner org teams
 - Create new teams in the cloud-bulldozer org

## Related Tickets & Documents

- Related PR: https://github.com/cloud-bulldozer/kube-burner/pull/525