### PR TITLE
Index job summary regardless prometheus endpoint is set or not

### DIFF
--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -54,7 +54,6 @@ func indexjobSummaryInfo(indexer *indexers.Indexer, uuid string, jobTimings timi
 		},
 	}
 	log.Infof("Indexing metric %s", jobSummaryMetric)
-	log.Debugf("Indexing [%d] documents", len(metadataInfo))
 	indexingOpts := indexers.IndexingOpts{
 		MetricName: fmt.Sprintf("%s-%s", jobSummaryMetric, jobConfig.Name),
 	}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

With the previous implementation, job's summary indexing was skipped when a prometheus endpoint wasn't specified, we should index this document whenever indexing is enabled.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
