### PR TITLE
Add uuid, runid and timeout as config variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.51.2
+    rev: v1.55.2
     hooks:
       - id: golangci-lint
         args: [--timeout=5m]

--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
+	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/workloads"
 	uid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -43,8 +44,8 @@ func openShiftCmd() *cobra.Command {
 	localIndexing := ocpCmd.PersistentFlags().Bool("local-indexing", false, "Enable local indexing")
 	ocpCmd.PersistentFlags().StringVar(&workloadConfig.MetricsEndpoint, "metrics-endpoint", "", "YAML file with a list of metric endpoints")
 	ocpCmd.PersistentFlags().BoolVar(&workloadConfig.Alerting, "alerting", true, "Enable alerting")
-	ocpCmd.PersistentFlags().StringVar(&workloadConfig.UUID, "uuid", uid.NewV4().String(), "Benchmark UUID")
-	ocpCmd.PersistentFlags().DurationVar(&workloadConfig.Timeout, "timeout", 4*time.Hour, "Benchmark timeout")
+	ocpCmd.PersistentFlags().StringVar(&config.UUID, "uuid", uid.NewV4().String(), "Benchmark UUID")
+	ocpCmd.PersistentFlags().DurationVar(&config.BenchmarkTimeout, "timeout", 4*time.Hour, "Benchmark timeout")
 	ocpCmd.PersistentFlags().IntVar(&workloadConfig.QPS, "qps", 20, "QPS")
 	ocpCmd.PersistentFlags().IntVar(&workloadConfig.Burst, "burst", 20, "Burst")
 	ocpCmd.PersistentFlags().BoolVar(&workloadConfig.Gc, "gc", true, "Garbage collect created namespaces")

--- a/pkg/alerting/alert_manager.go
+++ b/pkg/alerting/alert_manager.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
+	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/prometheus"
 	"github.com/kube-burner/kube-burner/pkg/util"
 	"github.com/prometheus/common/model"
@@ -66,7 +67,6 @@ type AlertManager struct {
 	alertProfile alertProfile
 	prometheus   *prometheus.Prometheus
 	indexer      *indexers.Indexer
-	uuid         string
 }
 
 var baseTemplate = []string{
@@ -80,11 +80,10 @@ type descriptionTemplate struct {
 }
 
 // NewAlertManager creates a new alert manager
-func NewAlertManager(alertProfileCfg, uuid string, indexer *indexers.Indexer, prometheusClient *prometheus.Prometheus, embedConfig bool) (*AlertManager, error) {
+func NewAlertManager(alertProfileCfg string, indexer *indexers.Indexer, prometheusClient *prometheus.Prometheus, embedConfig bool) (*AlertManager, error) {
 	log.Infof("🔔 Initializing alert manager for prometheus: %v", prometheusClient.Endpoint)
 	a := AlertManager{
 		prometheus: prometheusClient,
-		uuid:       uuid,
 		indexer:    indexer,
 	}
 	if err := a.readProfile(alertProfileCfg, embedConfig); err != nil {
@@ -139,7 +138,7 @@ func (a *AlertManager) Evaluate(start, end time.Time) error {
 			errs = append(errs, err)
 		}
 		for _, alertSet := range alertData {
-			alertSet.UUID = a.uuid
+			alertSet.UUID = config.UUID
 			alertList = append(alertList, alertSet)
 		}
 	}

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -102,8 +102,8 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 	waitRateLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
 	nsLabels := map[string]string{
 		"kube-burner-job":   ex.Name,
-		"kube-burner-uuid":  ex.uuid,
-		"kube-burner-runid": ex.runid,
+		"kube-burner-uuid":  config.UUID,
+		"kube-burner-runid": config.RunID,
 	}
 	var wg sync.WaitGroup
 	var ns string
@@ -143,10 +143,10 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 		}
 		for objectIndex, obj := range ex.objects {
 			labels := map[string]string{
-				"kube-burner-uuid":  ex.uuid,
+				"kube-burner-uuid":  config.UUID,
 				"kube-burner-job":   ex.Name,
 				"kube-burner-index": strconv.Itoa(objectIndex),
-				"kube-burner-runid": ex.runid,
+				"kube-burner-runid": config.RunID,
 			}
 			ex.objects[objectIndex].labelSelector = labels
 			ex.replicaHandler(labels, obj, ns, i, &wg)
@@ -219,7 +219,7 @@ func (ex *Executor) replicaHandler(labels map[string]string, obj object, ns stri
 			templateData := map[string]interface{}{
 				jobName:      ex.Name,
 				jobIteration: iteration,
-				jobUUID:      ex.uuid,
+				jobUUID:      config.UUID,
 				replica:      r,
 			}
 			for k, v := range obj.InputVars {

--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -42,10 +42,10 @@ type jobSummary struct {
 const jobSummaryMetric = "jobSummary"
 
 // indexMetadataInfo Generates and indexes a document with metadata information of the passed job
-func indexjobSummaryInfo(indexer *indexers.Indexer, uuid string, jobTimings timings, jobConfig config.Job, metadata map[string]interface{}) {
+func indexjobSummaryInfo(indexer *indexers.Indexer, jobTimings timings, jobConfig config.Job, metadata map[string]interface{}) {
 	metadataInfo := []interface{}{
 		jobSummary{
-			UUID:       uuid,
+			UUID:       config.UUID,
 			JobConfig:  jobConfig,
 			MetricName: jobSummaryMetric,
 			Metadata:   metadata,

--- a/pkg/burner/patch.go
+++ b/pkg/burner/patch.go
@@ -135,7 +135,7 @@ func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructu
 		templateData := map[string]interface{}{
 			jobName:      ex.Name,
 			jobIteration: iteration,
-			jobUUID:      ex.uuid,
+			jobUUID:      config.UUID,
 		}
 		for k, v := range obj.InputVars {
 			templateData[k] = v

--- a/pkg/burner/utils.go
+++ b/pkg/burner/utils.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/openshift/client-go/config/clientset/versioned"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -86,7 +87,7 @@ func (ex *Executor) Verify() bool {
 	log.Info("Verifying created objects")
 	for objectIndex, obj := range ex.objects {
 		listOptions := metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("kube-burner-uuid=%s,kube-burner-job=%s,kube-burner-index=%d", ex.uuid, ex.Name, objectIndex),
+			LabelSelector: fmt.Sprintf("kube-burner-uuid=%s,kube-burner-job=%s,kube-burner-index=%d", config.UUID, ex.Name, objectIndex),
 			Limit:         objectLimit,
 		}
 		err := RetryWithExponentialBackOff(func() (done bool, err error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kube-burner/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
 
-	uid "github.com/satori/go.uuid"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -41,7 +40,6 @@ import (
 
 var configSpec = Spec{
 	GlobalConfig: GlobalConfig{
-		RUNID:          uid.NewV4().String(),
 		GC:             false,
 		GCMetrics:      false,
 		GCTimeout:      1 * time.Hour,
@@ -106,7 +104,7 @@ func (j *Job) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // Parse parses a configuration file
-func Parse(uuid string, f io.Reader) (Spec, error) {
+func Parse(f io.Reader) (Spec, error) {
 	cfg, err := io.ReadAll(f)
 	if err != nil {
 		return configSpec, fmt.Errorf("error reading configuration file: %s", err)
@@ -145,9 +143,8 @@ func Parse(uuid string, f io.Reader) (Spec, error) {
 			configSpec.Jobs[i].PreLoadImages = false
 		}
 	}
-	configSpec.GlobalConfig.UUID = uuid
 	if configSpec.GlobalConfig.IndexerConfig.MetricsDirectory == "collected-metrics" {
-		configSpec.GlobalConfig.IndexerConfig.MetricsDirectory += "-" + uuid
+		configSpec.GlobalConfig.IndexerConfig.MetricsDirectory += "-" + UUID
 	}
 	return configSpec, nil
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
 	mtypes "github.com/kube-burner/kube-burner/pkg/measurements/types"
+	uid "github.com/satori/go.uuid"
 )
 
 // JobType type of job
@@ -46,12 +47,17 @@ type Spec struct {
 	EmbedFSDir string
 }
 
+// UUID
+var UUID string
+
+// Benchmark RUNID
+var RunID = uid.NewV4().String()
+
+// Benchmark Timeout
+var BenchmarkTimeout time.Duration
+
 // GlobalConfig holds the global configuration
 type GlobalConfig struct {
-	// Benchmark UUID
-	UUID string
-	// Benchmark RUNID
-	RUNID string
 	// IndexerConfig contains a IndexerConfig definition
 	IndexerConfig indexers.IndexerConfig `yaml:"indexerConfig"`
 	// Measurements describes a list of measurements kube-burner

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -83,7 +83,7 @@ func (p *podLatency) handleCreatePod(obj interface{}) {
 			Namespace:  pod.Namespace,
 			Name:       pod.Name,
 			MetricName: podLatencyMeasurement,
-			UUID:       globalCfg.UUID,
+			UUID:       config.UUID,
 			JobConfig:  *factory.jobConfig,
 			JobName:    factory.jobConfig.Name,
 			Metadata:   factory.metadata,
@@ -147,7 +147,7 @@ func (p *podLatency) start(measurementWg *sync.WaitGroup) {
 		"pods",
 		corev1.NamespaceAll,
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%s", globalCfg.RUNID)
+			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%s", config.RunID)
 		},
 	)
 	p.watcher.Informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -198,7 +198,7 @@ func (p *podLatency) collect(measurementWg *sync.WaitGroup) {
 			Name:            pod.Name,
 			MetricName:      podLatencyMeasurement,
 			NodeName:        pod.Spec.NodeName,
-			UUID:            globalCfg.UUID,
+			UUID:            config.UUID,
 			JobConfig:       *factory.jobConfig,
 			JobName:         factory.jobConfig.Name,
 			Metadata:        factory.metadata,
@@ -339,7 +339,7 @@ func (p *podLatency) calcQuantiles() {
 	for quantileName, v := range quantileMap {
 		podQ := metrics.LatencyQuantiles{
 			QuantileName: string(quantileName),
-			UUID:         globalCfg.UUID,
+			UUID:         config.UUID,
 			Timestamp:    time.Now().UTC(),
 			JobName:      factory.jobConfig.Name,
 			JobConfig:    *jc,

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -109,7 +109,7 @@ func (p *vmiLatency) handleCreateVM(obj interface{}) {
 				Namespace:  vm.Namespace,
 				Name:       vm.Name,
 				MetricName: vmiLatencyMeasurement,
-				UUID:       globalCfg.UUID,
+				UUID:       config.UUID,
 				JobName:    factory.jobConfig.Name,
 				JobConfig:  *factory.jobConfig,
 				Metadata:   factory.metadata,
@@ -154,7 +154,7 @@ func (p *vmiLatency) handleCreateVMI(obj interface{}) {
 				Namespace:  vmi.Namespace,
 				Name:       vmi.Name,
 				MetricName: vmiLatencyMeasurement,
-				UUID:       globalCfg.UUID,
+				UUID:       config.UUID,
 				JobName:    factory.jobConfig.Name,
 			}
 		}
@@ -302,7 +302,7 @@ func (p *vmiLatency) start(measurementWg *sync.WaitGroup) {
 		"virtualmachines",
 		corev1.NamespaceAll,
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%s", globalCfg.RUNID)
+			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%s", config.RunID)
 		},
 	)
 	p.vmWatcher.Informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -322,7 +322,7 @@ func (p *vmiLatency) start(measurementWg *sync.WaitGroup) {
 		"virtualmachineinstances",
 		corev1.NamespaceAll,
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%s", globalCfg.RUNID)
+			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%s", config.RunID)
 		},
 	)
 	p.vmiWatcher.Informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -342,7 +342,7 @@ func (p *vmiLatency) start(measurementWg *sync.WaitGroup) {
 		"pods",
 		corev1.NamespaceAll,
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%s", globalCfg.RUNID)
+			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%s", config.RunID)
 		},
 	)
 	p.vmiPodWatcher.Informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -473,7 +473,7 @@ func (p *vmiLatency) calcQuantiles() {
 	for quantileName, v := range quantileMap {
 		quantile := metrics.LatencyQuantiles{
 			QuantileName: quantileName,
-			UUID:         globalCfg.UUID,
+			UUID:         config.UUID,
 			Timestamp:    time.Now().UTC(),
 			JobName:      factory.jobConfig.Name,
 			MetricName:   vmiLatencyQuantilesMeasurement,

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -36,7 +36,6 @@ func NewPrometheusClient(configSpec config.Spec, url string, auth Auth, step tim
 	var err error
 	p := Prometheus{
 		Step:        step,
-		UUID:        configSpec.GlobalConfig.UUID,
 		ConfigSpec:  configSpec,
 		Endpoint:    url,
 		metadata:    metadata,
@@ -157,7 +156,7 @@ func (p *Prometheus) ReadProfile(metricsProfile string) error {
 func (p *Prometheus) createMetric(query, metricName string, jobConfig config.Job, labels model.Metric, value model.SampleValue, timestamp time.Time) metric {
 	m := metric{
 		Labels:     make(map[string]string),
-		UUID:       p.UUID,
+		UUID:       config.UUID,
 		Query:      query,
 		MetricName: metricName,
 		JobConfig:  jobConfig,

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -35,7 +35,6 @@ type Prometheus struct {
 	profileName   string
 	MetricProfile []metricDefinition
 	Step          time.Duration
-	UUID          string
 	ConfigSpec    config.Spec
 	JobList       []Job
 	metadata      map[string]interface{}

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -81,7 +81,7 @@ func ProcessMetricsScraperConfig(metricsScraperConfig ScraperConfig) Scraper {
 			}
 		}
 		if metricsEndpoint.AlertProfile != "" {
-			if alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, metricsScraperConfig.ConfigSpec.GlobalConfig.UUID, indexer, p, false); err != nil {
+			if alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, indexer, p, false); err != nil {
 				log.Fatalf("Error creating alert manager: %s", err)
 			}
 		}

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -109,7 +109,7 @@ func (wh *WorkloadHelper) GatherMetadata(userMetadata string) error {
 		}
 		wh.Metadata.UserMetadata = userMetadataContent
 	}
-	wh.Metadata.UUID = wh.UUID
+	wh.Metadata.UUID = config.UUID
 	wh.Metadata.Timestamp = time.Now().UTC()
 	return nil
 }
@@ -149,7 +149,7 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 			log.Fatalf("Error reading configuration file %s: %s", configFile, err)
 		}
 	}
-	configSpec, err = config.Parse(wh.UUID, f)
+	configSpec, err = config.Parse(f)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 				log.Fatal(err)
 			}
 			if wh.Alerting && metricsEndpoint.AlertProfile != "" {
-				alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, wh.Metadata.UUID, indexer, p, embedConfig)
+				alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, indexer, p, embedConfig)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -220,7 +220,7 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 		}
 		configSpec.GlobalConfig.GCMetrics = wh.GcMetrics
 	}
-	rc, err = burner.Run(configSpec, prometheusClients, alertMs, indexer, wh.Timeout, metadata)
+	rc, err = burner.Run(configSpec, prometheusClients, alertMs, indexer, metadata)
 	if err != nil {
 		wh.Metadata.ExecutionErrors = err.Error()
 		log.Error(err)
@@ -229,11 +229,11 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 	if wh.Indexing {
 		IndexMetadata(indexer, wh.Metadata)
 	}
-	log.Info("👋 Exiting kube-burner ", wh.UUID)
+	log.Info("👋 Exiting kube-burner ", config.UUID)
 	os.Exit(rc)
 }
 
-// ExtractWorkload extracts the given workload and metrics profile to the current diretory
+// ExtractWorkload extracts the given workload and metrics profile to the current directory
 func (wh *WorkloadHelper) ExtractWorkload(workload, metricsProfile string) error {
 	dirContent, err := wh.ocpConfig.ReadDir(path.Join(ocpCfgDir, workload))
 	if err != nil {

--- a/pkg/workloads/index.go
+++ b/pkg/workloads/index.go
@@ -54,7 +54,7 @@ func NewIndex(metricsEndpoint *string, ocpMetaAgent *ocpmetadata.Metadata) *cobr
 			}
 			esServer, _ := cmd.Flags().GetString("es-server")
 			esIndex, _ := cmd.Flags().GetString("es-index")
-			configSpec.GlobalConfig.UUID = uuid
+			config.UUID = uuid
 			if esServer != "" && esIndex != "" {
 				configSpec.GlobalConfig.IndexerConfig = indexers.IndexerConfig{
 					Type:    indexers.ElasticIndexer,

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -32,7 +32,6 @@ const (
 )
 
 type Config struct {
-	UUID            string
 	EsServer        string
 	Esindex         string
 	QPS             int
@@ -42,7 +41,6 @@ type Config struct {
 	Indexer         indexers.IndexerType
 	Alerting        bool
 	Indexing        bool
-	Timeout         time.Duration
 	MetricsEndpoint string
 	ProfileType     string
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

These three values are passed as arguments along many functions and are set by flags or automatically, we can have them as variables within the config package instead of attributes of an struct.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
