### PR TITLE
option to create an object only once in multi-iteration jobs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -86,7 +86,7 @@ Each object element supports the following parameters:
 | `inputVars`            | Map of arbitrary input variables to inject to the object template | Object  | -       |
 | `wait`                 | Wait for object to be ready                                       | Boolean | true    |
 | `waitOptions`          | Customize [how to wait](#wait-options) for object to be ready     | Object  | {}       |
-| `runonce`              | Create or delete this object only once during the entire job    | Boolean | false   |
+| `runOnce`              | Create or delete this object only once during the entire job    | Boolean | false   |
 
 !!! warning
     Kube-burner is only able to wait for a subset of resources, unless `waitOptions` are specified.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -288,3 +288,30 @@ spec:
 ## Template functions
 
 In addition to the default [golang template semantics](https://golang.org/pkg/text/template/), kube-burner is compiled with the [sprig library](http://masterminds.github.io/sprig/), which adds over 70 template functions for Go’s template language.
+
+## RunOnce 
+
+All objects within the job will iteratively run based on the JobIteration number, 
+but there may be a situation if an object need to be created only once (ex. clusterrole), in such cases
+we can add an optional field as `runOnce` for that particular object to execute only once in the entire job.
+
+An example scenario as below template, a job iteration of 100 but create the clusterrole only once.
+
+```yaml
+jobs:
+- name: cluster-density
+  jobIterations: 100
+  namespacedIterations: true
+  namespace: cluster-density
+  objects:
+  - objectTemplate: clusterrole.yml
+    replicas: 1
+    runOnce: true
+
+  - objectTemplate: clusterrolebinding.yml
+    replicas: 1
+    runOnce: true
+
+  - objectTemplate: deployment.yml
+    replicas: 10
+```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -86,6 +86,7 @@ Each object element supports the following parameters:
 | `inputVars`            | Map of arbitrary input variables to inject to the object template | Object  | -       |
 | `wait`                 | Wait for object to be ready                                       | Boolean | true    |
 | `waitOptions`          | Customize [how to wait](#wait-options) for object to be ready     | Object  | {}       |
+| `runonce`              | Create or delete this object only once during the entire job    | Boolean | false   |
 
 !!! warning
     Kube-burner is only able to wait for a subset of resources, unless `waitOptions` are specified.

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -152,7 +152,7 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 			if obj.RunOnce {
 				if i == 0 {
 					// this executes only once during the first iteration of an object
-					log.Infof("RunOnce set to %s, so creating object once", obj.ObjectTemplate)
+					log.Debugf("RunOnce set to %s, so creating object once", obj.ObjectTemplate)
 					ex.replicaHandler(labels, obj, ns, i, &wg)
 				}
 			} else {

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -149,7 +149,15 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 				"kube-burner-runid": ex.runid,
 			}
 			ex.objects[objectIndex].labelSelector = labels
-			ex.replicaHandler(labels, obj, ns, i, &wg)
+			if obj.RunOnce {
+				if i == 0 {
+					// this executes only once during the first iteration of an object
+					log.Infof("RunOnce set to %s, so creating object once", obj.ObjectTemplate)
+					ex.replicaHandler(labels, obj, ns, i, &wg)
+				}
+			} else {
+				ex.replicaHandler(labels, obj, ns, i, &wg)
+			}
 		}
 		if !ex.WaitWhenFinished && ex.PodWait {
 			if !ex.NamespacedIterations || !namespacesWaited[ns] {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -92,6 +92,8 @@ type Object struct {
 	Wait bool `yaml:"wait" json:"wait"`
 	// WaitOptions define custom behaviors when waiting for objects creation
 	WaitOptions WaitOptions `yaml:"waitOptions" json:"waitOptions,omitempty"`
+	// Run Once to create the object only once incase of multiple iterative jobs
+	RunOnce bool `yaml:"runonce" json:"runonce,omitempty"`
 }
 
 // Job defines a kube-burner job

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -93,7 +93,7 @@ type Object struct {
 	// WaitOptions define custom behaviors when waiting for objects creation
 	WaitOptions WaitOptions `yaml:"waitOptions" json:"waitOptions,omitempty"`
 	// Run Once to create the object only once incase of multiple iterative jobs
-	RunOnce bool `yaml:"runonce" json:"runonce,omitempty"`
+	RunOnce bool `yaml:"runOnce" json:"runOnce,omitempty"`
 }
 
 // Job defines a kube-burner job


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

In certain cases on creating cluster wide resources like clusterroles, operator spec CRDs, network spec, they would not have to run for every iteration although it is idempotent, this additional option let us attempt just once during the  iteration within a job. 
We have many of such scenarios with ICNI implementaion like serviceaccount, SRIOV specs, ICNI CRDs are required to run only once within a job.

example object, when jobIteration is > 1
```
      - objectTemplate: serviceaccount.yml
        replicas: 1
        runOnce: true

      - objectTemplate: pod.yml
        replicas: 1
```
## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
