### PR TITLE
Add sleep before checking metrics in OS/ES

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -87,6 +87,7 @@ print_events() {
 }
 
 check_metric_value() {
+  sleep 3s # There's some delay on the documents to show up in OpenSearch
   for metric in "${@}"; do
     endpoint="${ES_SERVER}/${ES_INDEX}/_search?q=uuid.keyword:${UUID}+AND+metricName.keyword:${metric}"
     RESULT=$(curl -sS ${endpoint} | jq '.hits.total.value // error')


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Sometimes metric documents are not immediately searchable, let's give them an extra time

```shell
 time="2024-01-04 01:30:13" level=info msg="Indexing [2] documents from metric prometheusBuildInfo" file="utils.go:59"
   time="2024-01-04 01:30:13" level=info msg="Indexing finished in 81ms: created=2" file="utils.go:64"
   time="2024-01-04 01:30:13" level=info msg="Indexing [4] documents from metric prometheusRSS" file="utils.go:59"
   time="2024-01-04 01:30:14" level=info msg="Indexing finished in 122ms: created=4" file="utils.go:64"
   time="2024-01-04 01:30:14" level=info msg="Indexing [1] documents from metric top2PrometheusCPU-start" file="utils.go:59"
   time="2024-01-04 01:30:14" level=info msg="Indexing finished in 41ms: created=1" file="utils.go:64"
   time="2024-01-04 01:30:14" level=info msg="Indexing [2] documents from metric top2PrometheusCPU" file="utils.go:59"
   time="2024-01-04 01:30:14" level=info msg="Indexing finished in 80ms: created=2" file="utils.go:64"
   time="2024-01-04 01:30:14" level=info msg="Indexing [2] documents from metric prometheusBuildInfo-start" file="utils.go:59"
   time="2024-01-04 01:30:14" level=info msg="Indexing finished in 81ms: created=2" file="utils.go:64"
   time="2024-01-04 01:30:14" level=info msg="Finished execution with UUID: fa574056-ccfa-4799-be26-420fd2f7bd2d" file="job.go:267"
   time="2024-01-04 01:30:14" level=info msg="👋 Exiting kube-burner fa574056-ccfa-4799-be26-420fd2f7bd2d" file="kube-burner.go:100"
   Checking namespace "kube-burner-job=not-namespaced,kube-burner-uuid=fa574056-ccfa-4799-be26-420fd2f7bd2d" has been destroyed
   jobSummary not found in https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com/kube-burner/_search?q=uuid.keyword:fa574056-ccfa-4799-be26-420fd2f7bd2d+AND+metricName.keyword:jobSummary
   No resources found
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
