### PR TITLE
Abstract container runtime

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -4,6 +4,7 @@
 
 KIND_VERSION=${KIND_VERSION:-v0.19.0}
 K8S_VERSION=${K8S_VERSION:-v1.27.0}
+OCI_BIN=${OCI_BIN:-podman}
 
 setup-kind() {
   KIND_FOLDER=$(mktemp -d)
@@ -21,7 +22,7 @@ destroy-kind() {
 
 setup-prometheus() {
   echo "Setting up prometheus instance"
-  podman run --rm -d --name prometheus --network=host docker.io/prom/prometheus:latest
+  $OCI_BIN run --rm -d --name prometheus --network=host docker.io/prom/prometheus:latest
   sleep 10
 }
 

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -30,7 +30,7 @@ teardown() {
 
 teardown_file() {
   destroy-kind
-  podman rm -f prometheus
+  $OCI_BIN rm -f prometheus
 }
 
 @test "kube-burner init: churn=true" {

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -26,7 +26,7 @@ teardown() {
 }
 
 teardown_file() {
-  podman rm -f prometheus
+  $OCI_BIN rm -f prometheus
 }
 
 @test "node-density with indexing" {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allow the user to choose the container runtime (i.e.: `docker`, `podman`, `podman --remote`, etc.).
`podman` remains the default.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.

