### PR TITLE
Pass the indexer instance to NewPrometheusClient

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -308,8 +308,7 @@ func indexCmd() *cobra.Command {
 				Username:        username,
 				UserMetaData:    userMetadata,
 			})
-			docsToIndex := make(map[string][]interface{})
-			for _, prometheusClients := range metricsScraper.PrometheusClients {
+			for _, prometheusClient := range metricsScraper.PrometheusClients {
 				prometheusJob := prometheus.Job{
 					Start: time.Unix(start, 0),
 					End:   time.Unix(end, 0),
@@ -317,13 +316,11 @@ func indexCmd() *cobra.Command {
 						Name: jobName,
 					},
 				}
-				prometheusClients.JobList = append(prometheusClients.JobList, prometheusJob)
-				if err := prometheusClients.ScrapeJobsMetrics(docsToIndex); err != nil {
+				prometheusClient.JobList = append(prometheusClient.JobList, prometheusJob)
+				if err := prometheusClient.ScrapeJobsMetrics(); err != nil {
 					log.Fatal(err)
 				}
 			}
-			log.Infof("Indexing metrics with UUID %s", uuid)
-			metrics.IndexDatapoints(docsToIndex, metricsScraper.Indexer)
 			if configSpec.GlobalConfig.IndexerConfig.Type == indexers.LocalIndexer && tarballName != "" {
 				if err := metrics.CreateTarball(configSpec.GlobalConfig.IndexerConfig, tarballName); err != nil {
 					log.Fatal(err)
@@ -434,7 +431,7 @@ func alertCmd() *cobra.Command {
 				Token:         token,
 				SkipTLSVerify: skipTLSVerify,
 			}
-			p, err := prometheus.NewPrometheusClient(configSpec, url, auth, prometheusStep, map[string]interface{}{}, false)
+			p, err := prometheus.NewPrometheusClient(configSpec, url, auth, prometheusStep, nil, indexer, false)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -234,7 +234,6 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 			}
 		}
 		if len(prometheusClients) > 0 {
-			docsToIndex := make(map[string][]interface{})
 			for idx, prometheusClient := range prometheusClients {
 				// If alertManager is configured
 				if alertMs[idx] != nil {
@@ -246,12 +245,10 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				prometheusClient.JobList = executedJobs
 				// If prometheus is enabled query metrics from the start of the first job to the end of the last one
 				if indexer != nil {
-					prometheusClient.ScrapeJobsMetrics(docsToIndex)
+					prometheusClient.ScrapeJobsMetrics()
 				}
 			}
 			if indexer != nil {
-				log.Infof("Indexing metrics with UUID %s", uuid)
-				metrics.IndexDatapoints(docsToIndex, indexer)
 				if globalConfig.IndexerConfig.Type == indexers.LocalIndexer && globalConfig.IndexerConfig.CreateTarball {
 					metrics.CreateTarball(globalConfig.IndexerConfig, globalConfig.IndexerConfig.TarballName)
 				}

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -95,7 +95,6 @@ func (p *Prometheus) ScrapeJobsMetrics() error {
 			}
 		}
 	}
-	log.Infof("Indexing metrics with UUID %s", p.UUID)
 	p.indexDatapoints(docsToIndex)
 	return nil
 }

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -17,6 +17,7 @@ package prometheus
 import (
 	"time"
 
+	"github.com/cloud-bulldozer/go-commons/indexers"
 	"github.com/cloud-bulldozer/go-commons/prometheus"
 	"github.com/kube-burner/kube-burner/pkg/config"
 )
@@ -40,6 +41,7 @@ type Prometheus struct {
 	JobList       []Job
 	metadata      map[string]interface{}
 	embedConfig   bool
+	indexer       *indexers.Indexer
 }
 
 type Job struct {

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -70,7 +70,7 @@ func ProcessMetricsScraperConfig(metricsScraperConfig ScraperConfig) Scraper {
 			Token:         metricsEndpoint.Token,
 			SkipTLSVerify: metricsScraperConfig.SkipTLSVerify,
 		}
-		p, err := prometheus.NewPrometheusClient(metricsScraperConfig.ConfigSpec, metricsEndpoint.Endpoint, auth, metricsScraperConfig.PrometheusStep, metadata, false)
+		p, err := prometheus.NewPrometheusClient(metricsScraperConfig.ConfigSpec, metricsEndpoint.Endpoint, auth, metricsScraperConfig.PrometheusStep, metadata, indexer, false)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/util/metrics/utils.go
+++ b/pkg/util/metrics/utils.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/cloud-bulldozer/go-commons/indexers"
 	"github.com/kube-burner/kube-burner/pkg/prometheus"
 	"github.com/kube-burner/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
@@ -50,18 +49,5 @@ func DecodeMetricsEndpoint(metricsEndpoint string, metricsEndpoints *[]prometheu
 	yamlDec.KnownFields(true)
 	if err := yamlDec.Decode(&metricsEndpoints); err != nil {
 		log.Fatalf("Error decoding metricsEndpoint %s: %s", metricsEndpoint, err)
-	}
-}
-
-// Indexes datapoints to a specified indexer.
-func IndexDatapoints(docsToIndex map[string][]interface{}, indexer *indexers.Indexer) {
-	for metricName, docs := range docsToIndex {
-		log.Infof("Indexing [%d] documents from metric %s", len(docs), metricName)
-		resp, err := (*indexer).Index(docs, indexers.IndexingOpts{MetricName: metricName})
-		if err != nil {
-			log.Error(err.Error())
-		} else {
-			log.Info(resp)
-		}
 	}
 }

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -200,7 +200,7 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 				Token:         metricsEndpoint.Token,
 				SkipTLSVerify: true,
 			}
-			p, err := prometheus.NewPrometheusClient(configSpec, metricsEndpoint.Endpoint, auth, stepSize, metadata, embedConfig)
+			p, err := prometheus.NewPrometheusClient(configSpec, metricsEndpoint.Endpoint, auth, stepSize, metadata, indexer, embedConfig)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/workloads/index.go
+++ b/pkg/workloads/index.go
@@ -96,7 +96,6 @@ func NewIndex(metricsEndpoint *string, ocpMetaAgent *ocpmetadata.Metadata) *cobr
 				UserMetaData:    userMetadata,
 				RawMetadata:     metadata,
 			})
-			docsToIndex := make(map[string][]interface{})
 			for _, prometheusClients := range metricsScraper.PrometheusClients {
 				prometheusJob := prometheus.Job{
 					Start: time.Unix(start, 0),
@@ -106,12 +105,10 @@ func NewIndex(metricsEndpoint *string, ocpMetaAgent *ocpmetadata.Metadata) *cobr
 					},
 				}
 				prometheusClients.JobList = append(prometheusClients.JobList, prometheusJob)
-				if prometheusClients.ScrapeJobsMetrics(docsToIndex) != nil {
+				if prometheusClients.ScrapeJobsMetrics() != nil {
 					rc = 1
 				}
 			}
-			log.Infof("Indexing metrics with UUID %s", uuid)
-			metrics.IndexDatapoints(docsToIndex, metricsScraper.Indexer)
 			if configSpec.GlobalConfig.IndexerConfig.Type == indexers.LocalIndexer && tarballName != "" {
 				if err := metrics.CreateTarball(configSpec.GlobalConfig.IndexerConfig, tarballName); err != nil {
 					log.Fatal(err)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Passing a pointer to the indexer to the PrometheuClient saves some lines, reduces complexity and will enable kube-burner to have a different indexer in each PrometheusClient in the future.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
