### PR TITLE
add annotations support to namespaces that are created

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -239,6 +239,7 @@ func measureCmd() *cobra.Command {
 				log.Fatalf("Invalid selector: %v", err)
 			}
 			namespaceLabels := make(map[string]string)
+			namespaceAnnotations := make(map[string]string)
 			labelRequirements, _ := labelSelector.Requirements()
 			for _, req := range labelRequirements {
 				namespaceLabels[req.Key()] = req.Values().List()[0]
@@ -246,9 +247,10 @@ func measureCmd() *cobra.Command {
 			log.Infof("%v", namespaceLabels)
 			measurements.NewMeasurementFactory(configSpec, indexer, metadata)
 			measurements.SetJobConfig(&config.Job{
-				Name:            jobName,
-				Namespace:       rawNamespaces,
-				NamespaceLabels: namespaceLabels,
+				Name:                 jobName,
+				Namespace:            rawNamespaces,
+				NamespaceLabels:      namespaceLabels,
+				NamespaceAnnotations: namespaceAnnotations,
 			})
 			measurements.Collect()
 			if err = measurements.Stop(); err != nil {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -64,6 +64,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | `preLoadPeriod`          | How long to wait for the preload daemonset                                                                                        | Duration | 1m      |
 | `preloadNodeLabels`      | Add node selector labels for the resources created in preload stage                                                               | Object   | {}      |
 | `namespaceLabels`        | Add custom labels to the namespaces created by kube-burner                                                                        | Object   | {}      |
+| `namespaceAnnotations`   | Add custom annotations to the namespaces created by kube-burner                                                                   | Object   | {}      |
 | `churn`                  | Churn the workload. Only supports namespace based workloads                                                                       | Boolean  | false   |
 | `churnPercent`           | Percentage of the jobIterations to churn each period                                                                              | Integer  | 10      |
 | `churnDuration`          | Length of time that the job is churned for                                                                                        | Duration | 1h      |

--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-func createNamespace(namespaceName string, nsLabels map[string]string) error {
+func createNamespace(namespaceName string, nsLabels map[string]string, nsAnnotations map[string]string) error {
 	ns := corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: namespaceName, Labels: nsLabels},
+		ObjectMeta: metav1.ObjectMeta{Name: namespaceName, Labels: nsLabels, Annotations: nsAnnotations},
 	}
 	return RetryWithExponentialBackOff(func() (done bool, err error) {
 		_, err = ClientSet.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -51,7 +51,7 @@ func preLoadImages(job Executor) error {
 		log.Infof("No images found to pre-load, continuing")
 		return nil
 	}
-	err = createDSs(imageList, job.NamespaceLabels, job.PreLoadNodeLabels)
+	err = createDSs(imageList, job.NamespaceLabels, job.NamespaceAnnotations, job.PreLoadNodeLabels)
 	if err != nil {
 		return fmt.Errorf("pre-load: %v", err)
 	}
@@ -94,14 +94,18 @@ func getJobImages(job Executor) ([]string, error) {
 	return imageList, nil
 }
 
-func createDSs(imageList []string, namespaceLabels map[string]string, nodeSelectorLabels map[string]string) error {
+func createDSs(imageList []string, namespaceLabels map[string]string, namespaceAnnotations map[string]string, nodeSelectorLabels map[string]string) error {
 	nsLabels := map[string]string{
 		"kube-burner-preload": "true",
 	}
+	nsAnnotations := make(map[string]string)
 	for label, value := range namespaceLabels {
 		nsLabels[label] = value
 	}
-	if err := createNamespace(preLoadNs, nsLabels); err != nil {
+	for annotation, value := range namespaceAnnotations {
+		nsAnnotations[annotation] = value
+	}
+	if err := createNamespace(preLoadNs, nsLabels, nsAnnotations); err != nil {
 		log.Fatal(err)
 	}
 	dsName := "preload"

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -144,6 +144,8 @@ type Job struct {
 	PreLoadNodeLabels map[string]string `yaml:"preLoadNodeLabels" json:"-"`
 	// NamespaceLabels add custom labels to namespaces created by kube-burner
 	NamespaceLabels map[string]string `yaml:"namespaceLabels" json:"-"`
+	// NamespaceAnnotations add custom annotations to namespaces created by kube-burner
+	NamespaceAnnotations map[string]string `yaml:"namespaceAnnotations" json:"-"`
 	// Churn workload
 	Churn bool `yaml:"churn" json:"churn,omitempty"`
 	// Churn percentage


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
With this you can add [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to namespaces that are created by kube-burner. 
Some of the features like ACL logging are enabled by the annotations field, this helps us exposing this field

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
