### PR TITLE
[WIP] Implement read jobType to simulate load with GET requests

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 
 Kube-burner is a Kubernetes performance and scale test orchestration toolset. It provides multi-faceted functionality, the most important of which are summarized below.
 
-- Create, delete, and patch Kubernetes resources at scale.
+- Create, delete, read, and patch Kubernetes resources at scale.
 - Prometheus metric collection and indexing.
 - Measurements.
 - Alerting.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -153,6 +153,35 @@ This type of job supports the following parameters. Some of them  are already de
 - `jobPause`
 - `jobIterationDelay`
 
+### Read
+
+This type of job reads objects described in the objects list. Using read as job type the objects list would have the following structure:
+
+```yaml
+objects:
+- kind: Deployment
+  labelSelector: {kube-burner-job: cluster-density}
+  apiVersion: apps/v1
+
+- kind: Secret
+  labelSelector: {kube-burner-job: cluster-density}
+```
+
+Where:
+
+- `kind`: Object kind of the k8s object to read.
+- `labelSelector`: Reads the objects with the given labels.
+- `apiVersion`: API version from the k8s object.
+
+This type of job supports the following parameters. Some of them  are already described in the [create job type section](#create):
+
+- `name`
+- `qps`
+- `burst`
+- `jobPause`
+- `jobIterationDelay`
+- `jobIterations`
+
 ### Patch
 
 This type of job can be used to patch objects with the template described in the object list. This object list has the following structure:

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -160,6 +160,8 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				job.RunDeleteJob()
 			case config.PatchJob:
 				job.RunPatchJob()
+			case config.ReadJob:
+				job.RunReadJob(0, job.JobIterations)
 			}
 			if job.BeforeCleanup != "" {
 				log.Infof("Waiting for beforeCleanup command %s to finish", job.BeforeCleanup)
@@ -290,6 +292,8 @@ func newExecutorList(configSpec config.Spec, uuid string, timeout time.Duration)
 			ex = setupDeleteJob(job)
 		case config.PatchJob:
 			ex = setupPatchJob(job)
+		case config.ReadJob:
+			ex = setupReadJob(job)
 		default:
 			log.Fatalf("Unknown jobType: %s", job.JobType)
 		}

--- a/pkg/burner/read.go
+++ b/pkg/burner/read.go
@@ -1,0 +1,110 @@
+// Copyright 2020 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"context"
+	"time"
+
+	"github.com/kube-burner/kube-burner/pkg/config"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func setupReadJob(jobConfig config.Job) Executor {
+	var ex Executor
+	log.Debugf("Preparing read job: %s", jobConfig.Name)
+	mapper := newRESTMapper()
+	for _, o := range jobConfig.Objects {
+		if o.APIVersion == "" {
+			o.APIVersion = "v1"
+		}
+		gvk := schema.FromAPIVersionAndKind(o.APIVersion, o.Kind)
+		mapping, err := mapper.RESTMapping(gvk.GroupKind())
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(o.LabelSelector) == 0 {
+			log.Fatalf("Empty labelSelectors not allowed with: %s", o.Kind)
+		}
+		obj := object{
+			gvr:           mapping.Resource,
+			labelSelector: o.LabelSelector,
+		}
+		obj.Namespaced = mapping.Scope.Name() == meta.RESTScopeNameNamespace
+		log.Debugf("Job %s: Read %s with selector %s", jobConfig.Name, gvk.Kind, labels.Set(obj.labelSelector))
+		ex.objects = append(ex.objects, obj)
+	}
+	log.Infof("Job %s: %d iterations", jobConfig.Name, jobConfig.JobIterations)
+	return ex
+}
+
+// RunReadJob executes a reading job
+func (ex *Executor) RunReadJob(iterationStart, iterationEnd int) {
+	var itemList *unstructured.UnstructuredList
+
+	// We have to sum 1 since the iterations start from 1
+	iterationProgress := (iterationEnd - iterationStart) / 10
+	percent := 1
+	for i := iterationStart; i < iterationEnd; i++ {
+		if i == iterationStart+iterationProgress*percent {
+			log.Infof("%v/%v iterations completed", i-iterationStart, iterationEnd-iterationStart)
+			percent++
+		}
+		log.Debugf("Reading object from iteration %d", i)
+		for _, obj := range ex.objects {
+			labelSelector := labels.Set(obj.labelSelector).String()
+			listOptions := metav1.ListOptions{
+				LabelSelector: labelSelector,
+			}
+			err := RetryWithExponentialBackOff(func() (done bool, err error) {
+				itemList, err = DynamicClient.Resource(obj.gvr).List(context.TODO(), listOptions)
+				if err != nil {
+					log.Errorf("Error found listing %s labeled with %s: %s", obj.gvr.Resource, labelSelector, err)
+					return false, nil
+				}
+				return true, nil
+			}, 1*time.Second, 3, 0, ex.MaxWaitTimeout)
+			if err != nil {
+				continue
+			}
+			log.Infof("Found %d %s with selector %s, reading them", len(itemList.Items), obj.gvr.Resource, labelSelector)
+			for _, item := range itemList.Items {
+				go func(item unstructured.Unstructured) {
+					ex.limiter.Wait(context.TODO())
+					var err error
+					if obj.Namespaced {
+						log.Debugf("Reading %s/%s from namespace %s", item.GetKind(), item.GetName(), item.GetNamespace())
+						_, err = DynamicClient.Resource(obj.gvr).Namespace(item.GetNamespace()).Get(context.TODO(), item.GetName(), metav1.GetOptions{})
+					} else {
+						log.Debugf("Reading %s/%s", item.GetKind(), item.GetName())
+						_, err = DynamicClient.Resource(obj.gvr).Get(context.TODO(), item.GetName(), metav1.GetOptions{})
+					}
+					if err != nil {
+						log.Errorf("Error found reading %s/%s: %s", item.GetKind(), item.GetName(), err)
+					}
+				}(item)
+				if ex.JobIterationDelay > 0 {
+					log.Infof("Sleeping for %v", ex.JobIterationDelay)
+					time.Sleep(ex.JobIterationDelay)
+				}
+			}
+		}
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,7 +138,7 @@ func Parse(uuid string, f io.Reader) (Spec, error) {
 		if !job.NamespacedIterations && job.Churn {
 			log.Fatal("Cannot have Churn enabled without Namespaced Iterations also enabled")
 		}
-		if job.JobIterations < 1 && job.JobType == CreationJob {
+		if job.JobIterations < 1 && (job.JobType == CreationJob || job.JobType == ReadJob) {
 			log.Fatalf("Job %s has < 1 iterations", job.Name)
 		}
 		if job.JobType == DeletionJob {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -32,6 +32,8 @@ const (
 	DeletionJob JobType = "delete"
 	// PatchJob used to patch objects
 	PatchJob JobType = "patch"
+	// ReadJob used to read objects
+	ReadJob JobType = "read"
 )
 
 // Spec configuration root

--- a/test/k8s/kube-burner-read.yml
+++ b/test/k8s/kube-burner-read.yml
@@ -1,0 +1,18 @@
+---
+global:
+  indexerConfig:
+    type: {{ .INDEXING_TYPE }}
+    metricsDirectory: {{ .METRICS_FOLDER }}
+    esServers: ["{{ .ES_SERVER }}"]
+    defaultIndex: {{ .ES_INDEX }}
+
+jobs:
+  - name: read-job
+    jobType: read
+    jobIterations: 20
+    qps: 5
+    burst: 10
+    jobPause: 5s
+    objects:
+    - kind: Namespace
+      labelSelector: {kubernetes.io/metadata.name: default}

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -96,3 +96,8 @@ teardown_file() {
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement
 }
+
+@test "kube-burner init: read; os-indexing=true" {
+  export INDEXING_TYPE=opensearch
+  run_cmd kube-burner init -c kube-burner-read.yml --uuid "${UUID}" --log-level=debug -u http://localhost:9090 -m metrics-profile.yaml
+}


### PR DESCRIPTION
## Type of change

Attempt to address https://github.com/kube-burner/kube-burner/issues/575

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds new `jobType: read` which can be used to simulate load of GET requests 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
