### PR TITLE
Query fix to avoid prometheus timeouts

### DIFF
--- a/cmd/kube-burner/ocp-config/metrics-aggregated.yml
+++ b/cmd/kube-burner/ocp-config/metrics-aggregated.yml
@@ -25,7 +25,7 @@
 - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|sdn|ovn-kubernetes|network-node-identity|multus|.*apiserver|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)|cilium"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
   metricName: containerCPU-Masters
 
-- query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|multus|ingress)|cilium"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, pod, container)) > 0
+- query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|multus|ingress)|cilium"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, container)) > 0
   metricName: containerCPU-AggregatedWorkers
 
 - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(monitoring|sdn|ovn-kubernetes|multus|ingress)"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
@@ -34,7 +34,7 @@
 - query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|network-node-identity|sdn|multus|ingress|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)|cilium"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
   metricName: containerMemory-Masters
 
-- query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|multus|ingress)|cilium"} and on (node) kube_node_role{role="worker"}) by (pod, container, namespace)
+- query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|multus|ingress)|cilium"} and on (node) kube_node_role{role="worker"}) by (container, namespace)
   metricName: containerMemory-AggregatedWorkers
 
 - query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|multus|ingress|monitoring|image-registry)|cilium"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Some prow jobs are failing due to timeouts related to long Prometheus indexing tasks. The two worse offenders are `containerCPU-AggregatedWorkers` and `containerMemory-AggregatedWorkers`:
```
time="2024-01-15 04:35:37" level=info msg="Indexing metric containerCPU-AggregatedWorkers" file="prometheus.go:101"
time="2024-01-15 05:05:49" level=info msg="Indexing finished in 30m12.317s: created=464966 updated=30144" file="prometheus.go:107"
```

## Related Tickets & Documents

- Related Issue: https://redhat-internal.slack.com/archives/C020CKMP6CT/p1705306161906339