### PR TITLE
Replace deprecated bats-action

### DIFF
--- a/.github/workflows/test-k8s.yml
+++ b/.github/workflows/test-k8s.yml
@@ -34,9 +34,13 @@ jobs:
         path: /tmp/
 
     - name: Install bats
-      uses: mig4/setup-bats@v1
+      uses: bats-core/bats-action@1.5.4
       with:
-        bats-version: 1.9.0
+        bats-version: 1.10.0
+        support-install: false
+        assert-install: false
+        detik-install: false
+        file-install: false
 
     - name: Execute Tests
       run: |


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current bats install action is deprecated, replacing it by the official one. 

## Related Tickets & Documents

- Related Issue #
- Closes #
