### PR TITLE
Cluster health check

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,7 @@ Available Commands:
   check-alerts Evaluate alerts for the given time range
   completion   Generates completion scripts for bash shell
   destroy      Destroy old namespaces labeled with the given UUID.
+  health-check Check for Health Status of the cluster
   help         Help about any command
   import       Import metrics tarball
   index        Index kube-burner metrics
@@ -111,6 +112,10 @@ This subcommand can be used to evaluate alerts configured in the given alert pro
 ## Destroy
 
 This subcommand requires the `uuid` flag to destroy all namespaces labeled with `kube-burner-uuid=<UUID>`.
+
+## Health Check
+
+The `health-check` subcommand assesses the status of nodes within the cluster. It provides information on the overall health of the cluster, indicating whether it is in a healthy state. In the event of an unhealthy cluster, the subcommand returns a list of nodes that are not in a "Ready" state, helping users identify and address specific issues affecting cluster stability.
 
 ## Completion
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -25,6 +25,7 @@ In this section is described global job configuration, it holds the following pa
 | `gcMetrics`        | Flag to collect metrics during garbage collection                                                        | Boolean        |      false      |
 | `gcTimeout`               | Garbage collection timeout                                                                       | Duration        | 1h   |
 | `waitWhenFinished` | Wait for all pods to be running when all jobs are completed                                             | Boolean        | false      |
+| `clusterHealth` | Checks if all the nodes are in "Ready" state                                             | Boolean        | false      |
 
 !!! note
     The precedence order to wait on resources is Global.waitWhenFinished > Job.waitWhenFinished > Job.podWait

--- a/examples/workloads/cluster-density/cluster-density.yml
+++ b/examples/workloads/cluster-density/cluster-density.yml
@@ -7,6 +7,7 @@ global:
     type: elastic
   measurements:
     - name: podLatency
+  clusterHealth: true
 
 jobs:
   - name: cluster-density

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -69,6 +69,8 @@ type GlobalConfig struct {
 	GCTimeout time.Duration `yaml:"gcTimeout"`
 	// Boolean flag to collect metrics during garbage collection
 	GCMetrics bool `yaml:"gcMetrics"`
+	// Boolean flag to check for cluster-health
+	ClusterHealth bool `yaml:"clusterHealth"`
 }
 
 // Object defines an object that kube-burner will create

--- a/pkg/util/cluster_health.go
+++ b/pkg/util/cluster_health.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func ClusterHealthCheck(clientSet *kubernetes.Clientset) {
+	log.Infof("🏥 Checking for Cluster Health")
+	if ClusterHealthyVanillaK8s(clientSet) {
+		log.Infof("Cluster is healthy.")
+	} else {
+		log.Fatalf("Cluster is not healthy.")
+	}
+}
+
+func ClusterHealthyVanillaK8s(clientset *kubernetes.Clientset) bool {
+	var isHealthy = true
+	nodes, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("Error getting nodes: %v\n", err)
+		return false
+	}
+
+	for _, node := range nodes.Items {
+		// Check condition for node health check status as Ready, MemoryPressure, DiskPressure, PIDPressure
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == "Ready" && condition.Status != "True" {
+				isHealthy = false
+				log.Errorf("Node %s is not Ready", node.Name)
+			}
+			if condition.Type != "Ready" && condition.Status != "False" { //nolint:goconst
+				isHealthy = false
+				log.Errorf("Node %s is experiencing %s", node.Name, condition.Type)
+			}
+
+		}
+	}
+	return isHealthy
+}

--- a/pkg/util/cluster_health.go
+++ b/pkg/util/cluster_health.go
@@ -22,7 +22,7 @@ func ClusterHealthyVanillaK8s(clientset *kubernetes.Clientset) bool {
 	var isHealthy = true
 	nodes, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		log.Errorf("Error getting nodes: %v\n", err)
+		log.Errorf("Error getting nodes: %v", err)
 		return false
 	}
 

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -33,6 +33,7 @@ teardown_file() {
   $OCI_BIN rm -f prometheus
 }
 
+
 @test "kube-burner init: churn=true" {
   export CHURN=true
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
@@ -104,4 +105,8 @@ teardown_file() {
 @test "kube-burner init: read; os-indexing=true" {
   export INDEXING_TYPE=opensearch
   run_cmd kube-burner init -c kube-burner-read.yml --uuid "${UUID}" --log-level=debug -u http://localhost:9090 -m metrics-profile.yaml
+}
+
+@test "kube-burner cluster health check" {
+  run_cmd kube-burner health-check
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The health check is designed to assess the condition of nodes and cluster operators within a Kubernetes cluster. In vanilla Kubernetes, the evaluation is focused on the node status. However, for OpenShift (OCP), the health check encompasses both node status and the status of cluster operators.

Initiating the health check can be achieved by either configuring the global settings with ```clusterHealth: true``` during workload execution or by directly invoking the command ```kube-burner health-check```.

output 1

```
sboyapal cluster-density (healthcheck) >> kube-burner health-check
time="2024-01-31 17:02:37" level=info msg="Checking for Cluster Health" file="kube-burner.go:182"
time="2024-01-31 17:02:39" level=info msg="Cluster is healthy." file="kube-burner.go:187"
time="2024-01-31 17:02:39" level=info msg="👋 Exiting kube-burner " file="kube-burner.go:173"
```

output2 
```
sboyapal cluster-density (healthcheck) >> kube-burner health-check 
time="2024-01-31 16:38:29" level=info msg="📁 Creating indexer: elastic" file="metrics.go:36"
time="2024-01-31 16:38:29" level=info msg="Checking for Cluster Health" file="kube-burner.go:126"
time="2024-01-31 16:38:30" level=error msg="Node ip-10-0-12-58.us-west-2.compute.internal is Unschedulable" file="clusterHealth.go:75"
time="2024-01-31 16:38:30" level=error msg="Node ip-10-0-42-19.us-west-2.compute.internal is Unschedulable" file="clusterHealth.go:75"
time="2024-01-31 16:38:30" level=fatal msg="Cluster is not healthy." file="kube-burner.go:134"
```



<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #568 
- Closes #
