### PR TITLE
Remove indexer from workload config

### DIFF
--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -105,8 +105,8 @@ func (wh *WorkloadHelper) Run(workload string, metricsProfiles []string, alertsP
 		ConfigSpec.EmbedFS = wh.embedConfig
 		ConfigSpec.EmbedFSDir = path.Join(wh.ConfigDir, workload)
 	}
-	if wh.Config.Indexer != "" {
-		indexerConfig := ConfigSpec.GlobalConfig.IndexerConfig
+	indexerConfig := ConfigSpec.GlobalConfig.IndexerConfig
+	if indexerConfig.Type != "" {
 		log.Infof("📁 Creating indexer: %s", indexerConfig.Type)
 		indexer, err = indexers.NewIndexer(indexerConfig)
 		if err != nil {
@@ -183,7 +183,7 @@ func (wh *WorkloadHelper) Run(workload string, metricsProfiles []string, alertsP
 		log.Error(err)
 	}
 	wh.Metadata.Passed = rc == 0
-	if wh.Indexer != "" {
+	if indexer != nil {
 		IndexMetadata(indexer, wh.Metadata)
 	}
 	log.Info("👋 Exiting kube-burner ", wh.UUID)

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -18,14 +18,12 @@ import (
 	"embed"
 	"time"
 
-	"github.com/cloud-bulldozer/go-commons/indexers"
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/ocp-metadata"
 	"k8s.io/client-go/rest"
 )
 
 type Config struct {
 	UUID            string
-	Indexer         indexers.IndexerType
 	Timeout         time.Duration
 	MetricsEndpoint string
 	UserMetadata    string


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

The Indexer field from the workloads.Config  struct, this field is not necessary, we should use the value of the configuration file rather than relying on a field set on this structure.

This PR is part of a bug fix that happens when using a configuration file in the ocp-wrapper with an indexer in the configuration file and a workload is executed w/o passing es-server/es-index/local-indexing




## Related Tickets & Documents

- Related Issue https://github.com/kube-burner/kube-burner-ocp/issues/7
