### PR TITLE
Make measurement indexing not a blocking operation

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -232,18 +232,18 @@ func measureCmd() *cobra.Command {
 				namespaceLabels[req.Key()] = req.Values().List()[0]
 			}
 			log.Infof("%v", namespaceLabels)
-			measurements.NewMeasurementFactory(configSpec, metadata)
-			measurements.SetJobConfig(&config.Job{
+			mf := measurements.NewMeasurementFactory(configSpec, metadata)
+			mf.SetJobConfig(&config.Job{
 				Name:                 jobName,
 				Namespace:            rawNamespaces,
 				NamespaceLabels:      namespaceLabels,
 				NamespaceAnnotations: namespaceAnnotations,
 			})
-			measurements.Collect()
-			if err = measurements.Stop(); err != nil {
+			mf.Collect()
+			if err = mf.Stop(); err != nil {
 				log.Error(err.Error())
 			}
-			measurements.Index(indexer)
+			mf.Index(indexer, jobName)
 		},
 	}
 	cmd.Flags().StringVar(&uuid, "uuid", "", "UUID")

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -232,18 +232,18 @@ func measureCmd() *cobra.Command {
 				namespaceLabels[req.Key()] = req.Values().List()[0]
 			}
 			log.Infof("%v", namespaceLabels)
-			mf := measurements.NewMeasurementFactory(configSpec, metadata)
-			mf.SetJobConfig(&config.Job{
+			measurements.NewMeasurementFactory(configSpec, metadata)
+			measurements.SetJobConfig(&config.Job{
 				Name:                 jobName,
 				Namespace:            rawNamespaces,
 				NamespaceLabels:      namespaceLabels,
 				NamespaceAnnotations: namespaceAnnotations,
 			})
-			mf.Collect()
-			if err = mf.Stop(); err != nil {
+			measurements.Collect()
+			if err = measurements.Stop(); err != nil {
 				log.Error(err.Error())
 			}
-			mf.Index(indexer, jobName)
+			measurements.Index(indexer, jobName)
 		},
 	}
 	cmd.Flags().StringVar(&uuid, "uuid", "", "UUID")

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -232,7 +232,7 @@ func measureCmd() *cobra.Command {
 				namespaceLabels[req.Key()] = req.Values().List()[0]
 			}
 			log.Infof("%v", namespaceLabels)
-			measurements.NewMeasurementFactory(configSpec, indexer, metadata)
+			measurements.NewMeasurementFactory(configSpec, metadata)
 			measurements.SetJobConfig(&config.Job{
 				Name:                 jobName,
 				Namespace:            rawNamespaces,
@@ -243,6 +243,7 @@ func measureCmd() *cobra.Command {
 			if err = measurements.Stop(); err != nil {
 				log.Error(err.Error())
 			}
+			measurements.Index(indexer)
 		},
 	}
 	cmd.Flags().StringVar(&uuid, "uuid", "", "UUID")

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -306,8 +306,7 @@ func indexCmd() *cobra.Command {
 						Name: jobName,
 					},
 				}
-				prometheusClient.JobList = append(prometheusClient.JobList, prometheusJob)
-				if err := prometheusClient.ScrapeJobsMetrics(); err != nil {
+				if err := prometheusClient.ScrapeJobsMetrics(prometheusJob); err != nil {
 					log.Fatal(err)
 				}
 			}

--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -15,7 +15,7 @@ Collects latencies from the different pod startup phases, these **latency metric
 
 ### Metrics
 
-The metrics collected are pod latency timeeries (`podLatencyMeasurement`) and four documents holding a summary with different pod latency quantiles of each pod condition (`podLatencyQuantilesMeasurement`). It's possible to skip indexing the `podLatencyMeasurement` metric by configuring the field `podLatencyMetrics` of this measurement to `quantiles`.
+The metrics collected are pod latency timeeries (`podLatencyMeasurement`) and four documents holding a summary with different pod latency quantiles of each pod condition (`podLatencyQuantilesMeasurement`).
 
 One document, such as the following, is indexed per each pod created by the workload that enters in `Running` condition during the workload:
 

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -109,7 +109,6 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 	var wg sync.WaitGroup
 	var ns string
 	var err error
-	log.Infof("Running job %s", ex.Name)
 	for label, value := range ex.NamespaceLabels {
 		nsLabels[label] = value
 	}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -85,7 +85,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 	var rc int
 	var executedJobs []prometheus.Job
 	var jobList []Executor
-	var gcWg sync.WaitGroup
+	var msWg, gcWg sync.WaitGroup
 	embedFS = configSpec.EmbedFS
 	embedFSDir = configSpec.EmbedFSDir
 	errs := []error{}
@@ -97,8 +97,15 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 	log.Infof("🔥 Starting kube-burner (%s@%s) with UUID %s", version.Version, version.GitCommit, uuid)
 	go func() {
 		var innerRC int
-		measurements.NewMeasurementFactory(configSpec, indexer, metadata)
+		measurements.NewMeasurementFactory(configSpec, metadata)
 		jobList = newExecutorList(configSpec, uuid, timeout)
+		for _, job := range jobList {
+			if job.PreLoadImages && job.JobType == config.CreationJob {
+				if err = preLoadImages(job); err != nil {
+					log.Fatal(err.Error())
+				}
+			}
+		}
 		// Iterate job list
 		for jobPosition, job := range jobList {
 			var waitListNamespaces []string
@@ -116,11 +123,6 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 			}
 			discoveryClient = discovery.NewDiscoveryClientForConfigOrDie(restConfig)
 			DynamicClient = dynamic.NewForConfigOrDie(restConfig)
-			if job.PreLoadImages && job.JobType == config.CreationJob {
-				if err = preLoadImages(job); err != nil {
-					log.Fatal(err.Error())
-				}
-			}
 			currentJob := prometheus.Job{
 				Start:     time.Now().UTC(),
 				JobConfig: job.Job,
@@ -186,20 +188,22 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 			if !globalConfig.WaitWhenFinished {
 				elapsedTime := currentJob.End.Sub(currentJob.Start).Round(time.Second)
 				log.Infof("Job %s took %v", job.Name, elapsedTime)
-				if err = measurements.Stop(); err != nil {
-					errs = append(errs, err)
-					log.Error(err.Error())
-					innerRC = 1
-				}
 			}
-		}
-		if globalConfig.WaitWhenFinished {
-			runWaitList(globalWaitMap, executorMap)
 			if err = measurements.Stop(); err != nil {
 				errs = append(errs, err)
 				log.Error(err.Error())
 				innerRC = 1
 			}
+			if indexer != nil && !job.SkipIndexing {
+				msWg.Add(1)
+				go func() {
+					defer msWg.Done()
+					measurements.Index(indexer)
+				}()
+			}
+		}
+		if globalConfig.WaitWhenFinished {
+			runWaitList(globalWaitMap, executorMap)
 		}
 		// We initialize garbage collection as soon as the benchmark finishes
 		if globalConfig.GC {
@@ -224,6 +228,8 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				})
 			}
 		}
+		// Make sure that measurements have indexed their stuff before we index metrics
+		msWg.Wait()
 		for _, job := range executedJobs {
 			// elapsedTime is recalculated for every job of the list
 			if indexer != nil && !job.JobConfig.SkipIndexing {
@@ -241,10 +247,8 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				innerRC = 1
 			}
 		}
-		for _, prometheusClient := range prometheusClients {
-			prometheusClient.JobList = executedJobs
-			// If prometheus is enabled query metrics from the start of the first job to the end of the last one
-			if indexer != nil {
+		if indexer != nil {
+			for _, prometheusClient := range prometheusClients {
 				prometheusClient.ScrapeJobsMetrics()
 			}
 		}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -97,7 +97,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 	log.Infof("🔥 Starting kube-burner (%s@%s) with UUID %s", version.Version, version.GitCommit, uuid)
 	go func() {
 		var innerRC int
-		mf := measurements.NewMeasurementFactory(configSpec, metadata)
+		measurements.NewMeasurementFactory(configSpec, metadata)
 		jobList = newExecutorList(configSpec, uuid, timeout)
 		ClientSet, restConfig, err = config.GetClientSet(10, 20)
 		if err != nil {
@@ -131,9 +131,9 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				Start:     time.Now().UTC(),
 				JobConfig: job.Job,
 			}
-			mf.SetJobConfig(&job.Job)
+			measurements.SetJobConfig(&job.Job)
 			log.Infof("Triggering job: %s", job.Name)
-			mf.Start()
+			measurements.Start()
 			switch job.JobType {
 			case config.CreationJob:
 				if job.Cleanup {
@@ -193,7 +193,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				elapsedTime := currentJob.End.Sub(currentJob.Start).Round(time.Second)
 				log.Infof("Job %s took %v", job.Name, elapsedTime)
 			}
-			if err = mf.Stop(); err != nil {
+			if err = measurements.Stop(); err != nil {
 				errs = append(errs, err)
 				log.Error(err.Error())
 				innerRC = 1
@@ -202,7 +202,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				msWg.Add(1)
 				go func(jobName string) {
 					defer msWg.Done()
-					mf.Index(indexer, jobName)
+					measurements.Index(indexer, jobName)
 				}(job.Name)
 			}
 		}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -99,7 +99,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 		var innerRC int
 		measurements.NewMeasurementFactory(configSpec, metadata)
 		jobList = newExecutorList(configSpec, uuid, timeout)
-		ClientSet, restConfig, err = config.GetClientSet(10, 20)
+		ClientSet, restConfig, err = config.GetClientSet(rest.DefaultQPS, rest.DefaultBurst)
 		if err != nil {
 			log.Fatalf("Error creating clientSet: %s", err)
 		}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -99,6 +99,10 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 		var innerRC int
 		measurements.NewMeasurementFactory(configSpec, metadata)
 		jobList = newExecutorList(configSpec, uuid, timeout)
+		ClientSet, restConfig, err = config.GetClientSet(10, 20)
+		if err != nil {
+			log.Fatalf("Error creating clientSet: %s", err)
+		}
 		for _, job := range jobList {
 			if job.PreLoadImages && job.JobType == config.CreationJob {
 				if err = preLoadImages(job); err != nil {

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -249,7 +249,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 		}
 		if indexer != nil {
 			for _, prometheusClient := range prometheusClients {
-				prometheusClient.ScrapeJobsMetrics()
+				prometheusClient.ScrapeJobsMetrics(executedJobs...)
 			}
 		}
 		if indexer != nil {

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -33,7 +33,6 @@ type measurementFactory struct {
 	clientSet   *kubernetes.Clientset
 	restConfig  *rest.Config
 	createFuncs map[string]measurement
-	indexer     *indexers.Indexer
 	metadata    map[string]interface{}
 }
 
@@ -43,6 +42,7 @@ type measurement interface {
 	collect(*sync.WaitGroup)
 	setConfig(types.Measurement)
 	validateConfig() error
+	index(indexers.Indexer)
 }
 
 var factory measurementFactory
@@ -50,11 +50,10 @@ var measurementMap = make(map[string]measurement)
 var globalCfg config.GlobalConfig
 
 // NewMeasurementFactory initializes the measurement facture
-func NewMeasurementFactory(configSpec config.Spec, indexer *indexers.Indexer, metadata map[string]interface{}) {
+func NewMeasurementFactory(configSpec config.Spec, metadata map[string]interface{}) {
 	globalCfg = configSpec.GlobalConfig
 	factory = measurementFactory{
 		createFuncs: make(map[string]measurement),
-		indexer:     indexer,
 		metadata:    metadata,
 	}
 	for _, measurement := range globalCfg.Measurements {
@@ -120,4 +119,11 @@ func Stop() error {
 		errs = append(errs, measurement.stop())
 	}
 	return utilerrors.NewAggregate(errs)
+}
+
+func Index(indexer *indexers.Indexer) {
+	for name, measurement := range factory.createFuncs {
+		log.Infof("Indexing collected data from measurement: %s", name)
+		measurement.index(*indexer)
+	}
 }

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -248,8 +248,6 @@ func (p *podLatency) stop() error {
 	if errorRate > 0 {
 		log.Infof("Pod latencies error rate was: %.2f", errorRate)
 	}
-	// Reset latency slices, required in multi-job benchmarks
-	p.latencyQuantiles, p.normLatencies = nil, nil
 	return err
 }
 
@@ -260,9 +258,8 @@ func (p *podLatency) index(indexer indexers.Indexer) {
 		podLatencyMeasurement:          p.normLatencies,
 		podLatencyQuantilesMeasurement: p.latencyQuantiles,
 	}
-	if p.config.PodLatencyMetrics == types.Quantiles {
-		delete(metricMap, podLatencyMeasurement)
-	}
+	// Reset latency slices, required in multi-job benchmarks
+	p.latencyQuantiles, p.normLatencies = nil, nil
 	for metricName, data := range metricMap {
 		indexingOpts := indexers.IndexingOpts{
 			MetricName: fmt.Sprintf("%s-%s", metricName, factory.jobConfig.Name),

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -83,8 +83,8 @@ func (p *podLatency) handleCreatePod(obj interface{}) {
 			Name:       pod.Name,
 			MetricName: podLatencyMeasurement,
 			UUID:       globalCfg.UUID,
-			JobConfig:  *Factory.jobConfig,
-			Metadata:   Factory.metadata,
+			JobConfig:  *factory.jobConfig,
+			Metadata:   factory.metadata,
 		}
 	}
 }
@@ -151,9 +151,9 @@ func (p *podLatency) validateConfig() error {
 func (p *podLatency) start(measurementWg *sync.WaitGroup) error {
 	defer measurementWg.Done()
 	p.metrics = make(map[string]podMetric)
-	log.Infof("Creating Pod latency watcher for %s", Factory.jobConfig.Name)
+	log.Infof("Creating Pod latency watcher for %s", factory.jobConfig.Name)
 	p.watcher = metrics.NewWatcher(
-		Factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
+		factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
 		"podWatcher",
 		"pods",
 		corev1.NamespaceAll,
@@ -178,13 +178,13 @@ func (p *podLatency) start(measurementWg *sync.WaitGroup) error {
 func (p *podLatency) collect(measurementWg *sync.WaitGroup) {
 	defer measurementWg.Done()
 	var pods []corev1.Pod
-	labelSelector := labels.SelectorFromSet(Factory.jobConfig.NamespaceLabels)
+	labelSelector := labels.SelectorFromSet(factory.jobConfig.NamespaceLabels)
 	options := metav1.ListOptions{
 		LabelSelector: labelSelector.String(),
 	}
-	namespaces := strings.Split(Factory.jobConfig.Namespace, ",")
+	namespaces := strings.Split(factory.jobConfig.Namespace, ",")
 	for _, namespace := range namespaces {
-		podList, err := Factory.clientSet.CoreV1().Pods(namespace).List(context.TODO(), options)
+		podList, err := factory.clientSet.CoreV1().Pods(namespace).List(context.TODO(), options)
 		if err != nil {
 			log.Errorf("error listing pods in namespace %s: %v", namespace, err)
 		}
@@ -212,8 +212,8 @@ func (p *podLatency) collect(measurementWg *sync.WaitGroup) {
 			MetricName:      podLatencyMeasurement,
 			NodeName:        pod.Spec.NodeName,
 			UUID:            globalCfg.UUID,
-			JobConfig:       *Factory.jobConfig,
-			Metadata:        Factory.metadata,
+			JobConfig:       *factory.jobConfig,
+			Metadata:        factory.metadata,
 			scheduled:       scheduled,
 			initialized:     initialized,
 			containersReady: containersReady,
@@ -239,7 +239,7 @@ func (p *podLatency) stop() error {
 	}
 	for _, q := range p.latencyQuantiles {
 		pq := q.(metrics.LatencyQuantiles)
-		log.Infof("%s: %s 50th: %v 99th: %v max: %v avg: %v", Factory.jobConfig.Name, pq.QuantileName, pq.P50, pq.P99, pq.Max, pq.Avg)
+		log.Infof("%s: %s 50th: %v 99th: %v max: %v avg: %v", factory.jobConfig.Name, pq.QuantileName, pq.P50, pq.P99, pq.Max, pq.Avg)
 	}
 	if errorRate > 0 {
 		log.Infof("Pod latencies error rate was: %.2f", errorRate)
@@ -335,8 +335,8 @@ func (p *podLatency) calcQuantiles() {
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
 		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
 		latencySummary.UUID = globalCfg.UUID
-		latencySummary.JobConfig = *Factory.jobConfig
-		latencySummary.Metadata = Factory.metadata
+		latencySummary.JobConfig = *factory.jobConfig
+		latencySummary.Metadata = factory.metadata
 		latencySummary.MetricName = podLatencyQuantilesMeasurement
 		return latencySummary
 	}

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -150,10 +150,6 @@ func (p *podLatency) validateConfig() error {
 // start podLatency measurement
 func (p *podLatency) start(measurementWg *sync.WaitGroup) error {
 	defer measurementWg.Done()
-	if Factory.jobConfig.JobType == config.DeletionJob {
-		log.Info("Pod latency measurement not compatible with delete jobs, skipping")
-		return nil
-	}
 	p.metrics = make(map[string]podMetric)
 	log.Infof("Creating Pod latency watcher for %s", Factory.jobConfig.Name)
 	p.watcher = metrics.NewWatcher(

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -81,7 +81,7 @@ func (p *pprof) start(measurementWg *sync.WaitGroup) error {
 
 func getPods(target types.PProftarget) []corev1.Pod {
 	labelSelector := labels.Set(target.LabelSelector).String()
-	podList, err := factory.clientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+	podList, err := Factory.clientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		log.Errorf("Error found listing pods labeled with %s: %s", labelSelector, err)
 	}
@@ -142,7 +142,7 @@ func (p *pprof) getPProf(wg *sync.WaitGroup, first bool) {
 				} else {
 					command = []string{"curl", "-sSLk", target.URL}
 				}
-				req := factory.clientSet.CoreV1().
+				req := Factory.clientSet.CoreV1().
 					RESTClient().
 					Post().
 					Resource("pods").
@@ -158,7 +158,7 @@ func (p *pprof) getPProf(wg *sync.WaitGroup, first bool) {
 					Stdout:    true,
 				}, scheme.ParameterCodec)
 				log.Debugf("Executing %s in pod %s", command, pod.Name)
-				exec, err := remotecommand.NewSPDYExecutor(factory.restConfig, "POST", req.URL())
+				exec, err := remotecommand.NewSPDYExecutor(Factory.restConfig, "POST", req.URL())
 				if err != nil {
 					log.Errorf("Failed to execute pprof command on %s: %s", target.Name, err)
 				}
@@ -187,7 +187,7 @@ func (p *pprof) stop() error {
 }
 
 // Fake index function for pprof
-func (p *pprof) index(_ indexers.Indexer) {
+func (p *pprof) index(_ indexers.Indexer, _ string) {
 }
 
 func readCerts(cert, privKey string) (string, string, error) {
@@ -220,7 +220,7 @@ func copyCertsToPod(pod corev1.Pod, cert, privKey io.Reader) error {
 		"/tmp/pprof.key": privKey,
 	}
 	for dest, f := range fMap {
-		req := factory.clientSet.CoreV1().
+		req := Factory.clientSet.CoreV1().
 			RESTClient().
 			Post().
 			Resource("pods").
@@ -234,7 +234,7 @@ func copyCertsToPod(pod corev1.Pod, cert, privKey io.Reader) error {
 			Stderr:    true,
 			Stdout:    false,
 		}, scheme.ParameterCodec)
-		exec, err := remotecommand.NewSPDYExecutor(factory.restConfig, "POST", req.URL())
+		exec, err := remotecommand.NewSPDYExecutor(Factory.restConfig, "POST", req.URL())
 		if err != nil {
 			return fmt.Errorf("Failed to establish SPDYExecutor on %s: %s", pod.Name, err)
 		}

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloud-bulldozer/go-commons/indexers"
 	"github.com/kube-burner/kube-burner/pkg/measurements/types"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -183,6 +184,10 @@ func (p *pprof) collect(measurementWg *sync.WaitGroup) {
 func (p *pprof) stop() error {
 	p.stopChannel <- true
 	return nil
+}
+
+// Fake index function for pprof
+func (p *pprof) index(_ indexers.Indexer) {
 }
 
 func readCerts(cert, privKey string) (string, string, error) {

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -81,7 +81,7 @@ func (p *pprof) start(measurementWg *sync.WaitGroup) error {
 
 func getPods(target types.PProftarget) []corev1.Pod {
 	labelSelector := labels.Set(target.LabelSelector).String()
-	podList, err := Factory.clientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+	podList, err := factory.clientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		log.Errorf("Error found listing pods labeled with %s: %s", labelSelector, err)
 	}
@@ -142,7 +142,7 @@ func (p *pprof) getPProf(wg *sync.WaitGroup, first bool) {
 				} else {
 					command = []string{"curl", "-sSLk", target.URL}
 				}
-				req := Factory.clientSet.CoreV1().
+				req := factory.clientSet.CoreV1().
 					RESTClient().
 					Post().
 					Resource("pods").
@@ -158,7 +158,7 @@ func (p *pprof) getPProf(wg *sync.WaitGroup, first bool) {
 					Stdout:    true,
 				}, scheme.ParameterCodec)
 				log.Debugf("Executing %s in pod %s", command, pod.Name)
-				exec, err := remotecommand.NewSPDYExecutor(Factory.restConfig, "POST", req.URL())
+				exec, err := remotecommand.NewSPDYExecutor(factory.restConfig, "POST", req.URL())
 				if err != nil {
 					log.Errorf("Failed to execute pprof command on %s: %s", target.Name, err)
 				}
@@ -220,7 +220,7 @@ func copyCertsToPod(pod corev1.Pod, cert, privKey io.Reader) error {
 		"/tmp/pprof.key": privKey,
 	}
 	for dest, f := range fMap {
-		req := Factory.clientSet.CoreV1().
+		req := factory.clientSet.CoreV1().
 			RESTClient().
 			Post().
 			Resource("pods").
@@ -234,7 +234,7 @@ func copyCertsToPod(pod corev1.Pod, cert, privKey io.Reader) error {
 			Stderr:    true,
 			Stdout:    false,
 		}, scheme.ParameterCodec)
-		exec, err := remotecommand.NewSPDYExecutor(Factory.restConfig, "POST", req.URL())
+		exec, err := remotecommand.NewSPDYExecutor(factory.restConfig, "POST", req.URL())
 		if err != nil {
 			return fmt.Errorf("Failed to establish SPDYExecutor on %s: %s", pod.Name, err)
 		}

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -284,9 +284,8 @@ func (s *serviceLatency) index(indexer indexers.Indexer) {
 		svcLatencyMetric:               s.normLatencies,
 		svcLatencyQuantilesMeasurement: s.latencyQuantiles,
 	}
-	if s.config.ServiceLatencyMetrics == types.Quantiles {
-		delete(metricMap, svcLatencyMetric)
-	}
+	// Reset latency slices, required in multi-job benchmarks
+	s.latencyQuantiles, s.normLatencies = nil, nil
 	for metricName, documents := range metricMap {
 		indexingOpts := indexers.IndexingOpts{
 			MetricName: fmt.Sprintf("%s-%s", metricName, factory.jobConfig.Name),

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -81,10 +81,10 @@ func init() {
 
 func deployAssets() error {
 	var err error
-	if err = kutil.CreateNamespace(factory.clientSet, types.SvcLatencyNs, nil, nil); err != nil {
+	if err = kutil.CreateNamespace(Factory.clientSet, types.SvcLatencyNs, nil, nil); err != nil {
 		return err
 	}
-	if _, err = factory.clientSet.CoreV1().Pods(types.SvcLatencyNs).Create(context.TODO(), types.SvcLatencyCheckerPod, metav1.CreateOptions{}); err != nil {
+	if _, err = Factory.clientSet.CoreV1().Pods(types.SvcLatencyNs).Create(context.TODO(), types.SvcLatencyCheckerPod, metav1.CreateOptions{}); err != nil {
 		if errors.IsAlreadyExists(err) {
 			log.Warn(err)
 		} else {
@@ -92,7 +92,7 @@ func deployAssets() error {
 		}
 	}
 	err = wait.PollUntilContextCancel(context.TODO(), 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
-		pod, err := factory.clientSet.CoreV1().Pods(types.SvcLatencyNs).Get(context.TODO(), types.SvcLatencyCheckerPod.Name, metav1.GetOptions{})
+		pod, err := Factory.clientSet.CoreV1().Pods(types.SvcLatencyNs).Get(context.TODO(), types.SvcLatencyCheckerPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -130,7 +130,7 @@ func (s *serviceLatency) handleCreateSvc(obj interface{}) {
 		}
 		endpointsReadyTs := time.Now().UTC()
 		log.Debugf("Endpoints %v/%v ready", svc.Namespace, svc.Name)
-		svcLatencyChecker, err := util.NewSvcLatencyChecker(*factory.clientSet, *factory.restConfig)
+		svcLatencyChecker, err := util.NewSvcLatencyChecker(*Factory.clientSet, *Factory.restConfig)
 		if err != nil {
 			log.Error(err)
 		}
@@ -175,9 +175,9 @@ func (s *serviceLatency) handleCreateSvc(obj interface{}) {
 			MetricName:        svcLatencyMetric,
 			ServiceType:       svc.Spec.Type,
 			ReadyLatency:      svcLatency,
-			JobConfig:         *factory.jobConfig,
+			JobConfig:         *Factory.jobConfig,
 			UUID:              globalCfg.UUID,
-			Metadata:          factory.metadata,
+			Metadata:          Factory.metadata,
 			IPAssignedLatency: ipAssignedLatency,
 		}
 		s.metricLock.Unlock()
@@ -202,9 +202,9 @@ func (s *serviceLatency) start(measurementWg *sync.WaitGroup) error {
 		log.Fatal(err)
 		return err
 	}
-	log.Infof("Creating service latency watcher for %s", factory.jobConfig.Name)
+	log.Infof("Creating service latency watcher for %s", Factory.jobConfig.Name)
 	s.svcWatcher = metrics.NewWatcher(
-		factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
+		Factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
 		"svcWatcher",
 		"services",
 		corev1.NamespaceAll,
@@ -217,7 +217,7 @@ func (s *serviceLatency) start(measurementWg *sync.WaitGroup) error {
 		AddFunc: s.handleCreateSvc,
 	})
 	s.epWatcher = metrics.NewWatcher(
-		factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
+		Factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
 		"epWatcher",
 		"endpoints",
 		corev1.NamespaceAll,
@@ -242,12 +242,12 @@ func (s *serviceLatency) stop() error {
 	// 5 minutes should be more than enough to cleanup this namespace
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	kutil.CleanupNamespaces(ctx, factory.clientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", types.SvcLatencyNs))
+	kutil.CleanupNamespaces(ctx, Factory.clientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", types.SvcLatencyNs))
 	s.normalizeMetrics()
 	for _, q := range s.latencyQuantiles {
 		pq := q.(metrics.LatencyQuantiles)
 		// Divide nanoseconds by 1e6 to get milliseconds
-		log.Infof("%s: %s 50th: %dms 99th: %dms max: %dms avg: %dms", factory.jobConfig.Name, pq.QuantileName, pq.P50/1e6, pq.P99/1e6, pq.Max/1e6, pq.Avg/1e6)
+		log.Infof("%s: %s 50th: %dms 99th: %dms max: %dms avg: %dms", Factory.jobConfig.Name, pq.QuantileName, pq.P50/1e6, pq.P99/1e6, pq.Max/1e6, pq.Avg/1e6)
 	}
 	return nil
 }
@@ -265,9 +265,9 @@ func (s *serviceLatency) normalizeMetrics() {
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
 		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
 		latencySummary.UUID = globalCfg.UUID
-		latencySummary.JobConfig = *factory.jobConfig
+		latencySummary.JobConfig = *Factory.jobConfig
 		latencySummary.Timestamp = time.Now().UTC()
-		latencySummary.Metadata = factory.metadata
+		latencySummary.Metadata = Factory.metadata
 		latencySummary.MetricName = svcLatencyQuantilesMeasurement
 		return latencySummary
 	}
@@ -279,7 +279,7 @@ func (s *serviceLatency) normalizeMetrics() {
 	}
 }
 
-func (s *serviceLatency) index(indexer indexers.Indexer) {
+func (s *serviceLatency) index(indexer indexers.Indexer, jobName string) {
 	metricMap := map[string][]interface{}{
 		svcLatencyMetric:               s.normLatencies,
 		svcLatencyQuantilesMeasurement: s.latencyQuantiles,
@@ -288,7 +288,7 @@ func (s *serviceLatency) index(indexer indexers.Indexer) {
 	s.latencyQuantiles, s.normLatencies = nil, nil
 	for metricName, documents := range metricMap {
 		indexingOpts := indexers.IndexingOpts{
-			MetricName: fmt.Sprintf("%s-%s", metricName, factory.jobConfig.Name),
+			MetricName: fmt.Sprintf("%s-%s", metricName, jobName),
 		}
 		log.Debugf("Indexing [%d] documents: %s", len(documents), metricName)
 		resp, err := indexer.Index(documents, indexingOpts)

--- a/pkg/measurements/types/types.go
+++ b/pkg/measurements/types/types.go
@@ -35,9 +35,8 @@ const (
 func (m *Measurement) UnmarshalMeasurement(unmarshal func(interface{}) error) error {
 	type rawMeasurement Measurement
 	measurement := rawMeasurement{
-		PProfDirectory:    pprofDirectory,
-		PodLatencyMetrics: All,
-		ServiceTimeout:    5 * time.Second,
+		PProfDirectory: pprofDirectory,
+		ServiceTimeout: 5 * time.Second,
 	}
 	if err := unmarshal(&measurement); err != nil {
 		return err
@@ -58,8 +57,6 @@ type Measurement struct {
 	PProfInterval time.Duration `yaml:"pprofInterval"`
 	// PProfDirectory output directory
 	PProfDirectory string `yaml:"pprofDirectory"`
-	// Pod latency metrics to index
-	PodLatencyMetrics latencyMetric `yaml:"podLatencyMetrics"`
 	// Service latency metrics to index
 	ServiceLatencyMetrics latencyMetric `yaml:"svcLatencyMetrics"`
 	// Service latency endpoint timeout

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -100,15 +100,15 @@ func (p *vmiLatency) handleCreateVM(obj interface{}) {
 	vmID := vm.Labels["kubevirt-vm"]
 	p.mu.Lock()
 	if _, exists := p.metrics[vmID]; !exists {
-		if strings.Contains(vm.Namespace, Factory.jobConfig.Namespace) {
+		if strings.Contains(vm.Namespace, factory.jobConfig.Namespace) {
 			p.metrics[vmID] = &vmiMetric{
 				Timestamp:  time.Now().UTC(),
 				Namespace:  vm.Namespace,
 				Name:       vm.Name,
 				MetricName: vmiLatencyMeasurement,
 				UUID:       globalCfg.UUID,
-				JobConfig:  *Factory.jobConfig,
-				Metadata:   Factory.metadata,
+				JobConfig:  *factory.jobConfig,
+				Metadata:   factory.metadata,
 			}
 		}
 	}
@@ -144,7 +144,7 @@ func (p *vmiLatency) handleCreateVMI(obj interface{}) {
 	}
 	p.mu.Lock()
 	if _, exists := p.metrics[vmID]; !exists {
-		if strings.Contains(vmi.Namespace, Factory.jobConfig.Namespace) {
+		if strings.Contains(vmi.Namespace, factory.jobConfig.Namespace) {
 			p.metrics[vmID] = &vmiMetric{
 				Timestamp:  time.Now().UTC(),
 				Namespace:  vmi.Namespace,
@@ -278,7 +278,7 @@ func (p *vmiLatency) setConfig(cfg types.Measurement) {
 
 // Start starts vmiLatency measurement
 func (p *vmiLatency) start(measurementWg *sync.WaitGroup) error {
-	if Factory.jobConfig.JobType == config.DeletionJob {
+	if factory.jobConfig.JobType == config.DeletionJob {
 		log.Info("VMI latency measurement not compatible with delete jobs, skipping")
 		return nil
 	}
@@ -287,7 +287,7 @@ func (p *vmiLatency) start(measurementWg *sync.WaitGroup) error {
 		return err
 	}
 	p.metrics = make(map[string]*vmiMetric)
-	log.Infof("Creating VM latency watcher for %s", Factory.jobConfig.Name)
+	log.Infof("Creating VM latency watcher for %s", factory.jobConfig.Name)
 	restClient := newRESTClientWithRegisteredKubevirtResource()
 	p.vmWatcher = metrics.NewWatcher(
 		restClient,
@@ -309,7 +309,7 @@ func (p *vmiLatency) start(measurementWg *sync.WaitGroup) error {
 		return fmt.Errorf("VMI Latency measurement error: %s", err)
 	}
 
-	log.Infof("Creating VMI latency watcher for %s", Factory.jobConfig.Name)
+	log.Infof("Creating VMI latency watcher for %s", factory.jobConfig.Name)
 	p.vmiWatcher = metrics.NewWatcher(
 		restClient,
 		"vmiWatcher",
@@ -330,9 +330,9 @@ func (p *vmiLatency) start(measurementWg *sync.WaitGroup) error {
 		return fmt.Errorf("VMI Latency measurement error: %s", err)
 	}
 
-	log.Infof("Creating VMI Pod latency watcher for %s", Factory.jobConfig.Name)
+	log.Infof("Creating VMI Pod latency watcher for %s", factory.jobConfig.Name)
 	p.vmiPodWatcher = metrics.NewWatcher(
-		Factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
+		factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
 		"podWatcher",
 		"pods",
 		corev1.NamespaceAll,
@@ -354,7 +354,7 @@ func (p *vmiLatency) start(measurementWg *sync.WaitGroup) error {
 }
 
 func newRESTClientWithRegisteredKubevirtResource() *rest.RESTClient {
-	shallowCopy := Factory.restConfig
+	shallowCopy := factory.restConfig
 	setConfigDefaults(shallowCopy)
 	restClient, err := rest.RESTClientFor(shallowCopy)
 	if err != nil {
@@ -382,7 +382,7 @@ func (p *vmiLatency) collect(measurementWg *sync.WaitGroup) {
 
 // Stop stops vmiLatency measurement
 func (p *vmiLatency) stop() error {
-	if Factory.jobConfig.JobType == config.DeletionJob {
+	if factory.jobConfig.JobType == config.DeletionJob {
 		return nil
 	}
 	p.vmWatcher.StopWatcher()
@@ -463,8 +463,8 @@ func (p *vmiLatency) calcQuantiles() {
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
 		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
 		latencySummary.UUID = globalCfg.UUID
-		latencySummary.JobConfig = *Factory.jobConfig
-		latencySummary.Metadata = Factory.metadata
+		latencySummary.JobConfig = *factory.jobConfig
+		latencySummary.Metadata = factory.metadata
 		latencySummary.MetricName = podLatencyQuantilesMeasurement
 		return latencySummary
 	}

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -391,8 +391,6 @@ func (p *vmiLatency) stop() error {
 	p.normalizeMetrics()
 	p.calcQuantiles()
 	err := metrics.CheckThreshold(p.config.LatencyThresholds, p.latencyQuantiles)
-	// Reset latency slices, required in multi-job benchmarks
-	p.latencyQuantiles, p.normLatencies = nil, nil
 	return err
 }
 
@@ -402,9 +400,8 @@ func (p *vmiLatency) index(indexer indexers.Indexer) {
 		podLatencyMeasurement:          p.normLatencies,
 		podLatencyQuantilesMeasurement: p.latencyQuantiles,
 	}
-	if p.config.PodLatencyMetrics == types.Quantiles {
-		delete(metricMap, podLatencyMeasurement)
-	}
+	// Reset latency slices, required in multi-job benchmarks
+	p.latencyQuantiles, p.normLatencies = nil, nil
 	for metricName, data := range metricMap {
 		indexingOpts := indexers.IndexingOpts{
 			MetricName: fmt.Sprintf("%s-%s", metricName, factory.jobConfig.Name),

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -53,10 +53,10 @@ func NewPrometheusClient(configSpec config.Spec, url string, auth Auth, step tim
 }
 
 // ScrapeJobsMetrics gets all prometheus metrics required and handles them
-func (p *Prometheus) ScrapeJobsMetrics() error {
+func (p *Prometheus) ScrapeJobsMetrics(jobList ...Job) error {
 	docsToIndex := make(map[string][]interface{})
-	start := p.JobList[0].Start
-	end := p.JobList[len(p.JobList)-1].End
+	start := jobList[0].Start
+	end := jobList[len(jobList)-1].End
 	log.Infof("🔍 Scraping %v Profile: %v Start: %v End: %v",
 		p.Endpoint,
 		p.profileName,
@@ -66,7 +66,7 @@ func (p *Prometheus) ScrapeJobsMetrics() error {
 	var renderedQuery bytes.Buffer
 	vars := util.EnvToMap()
 	vars["elapsed"] = fmt.Sprintf("%ds", elapsed)
-	for _, eachJob := range p.JobList {
+	for _, eachJob := range jobList {
 		if eachJob.JobConfig.SkipIndexing {
 			log.Infof("Skipping indexing in job: %v", eachJob.JobConfig.Name)
 			continue

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -38,7 +38,6 @@ type Prometheus struct {
 	Step          time.Duration
 	UUID          string
 	ConfigSpec    config.Spec
-	JobList       []Job
 	metadata      map[string]interface{}
 	embedConfig   bool
 	indexer       *indexers.Indexer

--- a/pkg/util/namespaces.go
+++ b/pkg/util/namespaces.go
@@ -78,7 +78,6 @@ func CleanupNamespaces(ctx context.Context, clientSet *kubernetes.Clientset, lab
 }
 
 func waitForDeleteNamespaces(ctx context.Context, clientSet *kubernetes.Clientset, labelSelector string) {
-	log.Info("Waiting for namespaces to be definitely deleted")
 	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		ns, err := clientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Indexing measurement metrics is not a blocking operation anymore, subsequent jobs don't have to wait for the metrics to be indexed, some changes were required to prevent race conditions when we restart measurements and the metrics hasn't been indexed yet.

## Related Tickets & Documents

- Related Issue #
- Closes #589 
