### PR TITLE
Return error on `BeforeCleanup` failure.

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -179,7 +179,10 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				cmd.Stderr = &errb
 				err := cmd.Run()
 				if err != nil {
-					log.Infof("BeforeCleanup failed: %v", err)
+					err = fmt.Errorf("BeforeCleanup failed: %v", err)
+					log.Error(err.Error())
+					errs = append(errs, err)
+					innerRC = 1
 				}
 				log.Infof("BeforeCleanup out: %v, err: %v", outb.String(), errb.String())
 			}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
beofreCleanup script may return an error, which should be reported by kube-burner to enable test running automation.

## Related Tickets & Documents

- Related Issue #
- Closes #
