### PR TITLE
Add flags to specify the kubeconfig path and context

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -151,7 +151,7 @@ func initCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace where the configmap is")
 	cmd.MarkFlagsMutuallyExclusive("config", "configmap")
 	cmd.Flags().StringVar(&userMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
-	cmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the kubeconfig file to use for CLI requests")
+	cmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the kubeconfig file")
 	cmd.Flags().StringVar(&kubeContext, "kube-context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().SortFlags = false
 	return cmd
@@ -173,7 +173,7 @@ func healthCheck() *cobra.Command {
 			util.ClusterHealthCheck(clientSet)
 		},
 	}
-	cmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the kubeconfig file to use for CLI requests")
+	cmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the kubeconfig file")
 	cmd.Flags().StringVar(&kubeContext, "kube-context", "", "The name of the kubeconfig context to use")
 	return cmd
 }
@@ -205,7 +205,7 @@ func destroyCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&uuid, "uuid", "", "UUID")
 	cmd.Flags().DurationVarP(&timeout, "timeout", "", 4*time.Hour, "Deletion timeout")
-	cmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the kubeconfig file to use for CLI requests")
+	cmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the kubeconfig file")
 	cmd.Flags().StringVar(&kubeContext, "kube-context", "", "The name of the kubeconfig context to use")
 	cmd.MarkFlagRequired("uuid")
 	return cmd
@@ -288,7 +288,7 @@ func measureCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&jobName, "job-name", "j", "kube-burner-measure", "Measure job name")
 	cmd.Flags().StringVarP(&rawNamespaces, "namespaces", "n", corev1.NamespaceAll, "comma-separated list of namespaces")
 	cmd.Flags().StringVarP(&selector, "selector", "l", "", "namespace label selector. (e.g. -l key1=value1,key2=value2)")
-	cmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the kubeconfig file to use for CLI requests")
+	cmd.Flags().StringVar(&kubeConfig, "kube-config", "", "Path to the kubeconfig file")
 	cmd.Flags().StringVar(&kubeContext, "kube-context", "", "The name of the kubeconfig context to use")
 	return cmd
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,9 @@ This is the main subcommand; it triggers a new kube-burner benchmark and it supp
 - `password`: Prometheus password for basic authentication.
 - `skip-tls-verify`: Skip TLS verification for Prometheus. The default is `true`.
 - `step`: Prometheus step size. The default is `30s`.
-- `timeout`: Kube-burner benchmark global timeout. When timing out, return code is 2. The default is `4h`.
+- `timeout`: Kube-burner benchmark global timeout. When timing out, return code is 2. The default is `4h`. 
+- `kube-config`: Path to the kubeconfig file.
+- `kube-context`: The name of the kubeconfig context to use.
 - `user-metadata`: YAML file path containing custom user-metadata to be indexed.
 
 !!! Note "Prometheus authentication"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,18 +24,15 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
+	uid "github.com/google/uuid"
 	mtypes "github.com/kube-burner/kube-burner/pkg/measurements/types"
 	"github.com/kube-burner/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
-
-	uid "github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -153,20 +150,56 @@ func Parse(uuid string, f io.Reader) (Spec, error) {
 	return configSpec, nil
 }
 
-// FetchConfigMap Fetchs the specified configmap and looks for config.yml, metrics.yml and alerts.yml files
-func FetchConfigMap(configMap, namespace string) (string, string, error) {
-	log.Infof("Fetching configmap %s", configMap)
-	var kubeconfig, metricProfile, alertProfile string
+type KubeClientProvider struct {
+	restConfig *rest.Config
+}
+
+// func NewKubeClientProvider(config, context string) *KubeClientProvider {
+func NewKubeClientProvider() *KubeClientProvider {
+	var kubeconfig string
 	if os.Getenv("KUBECONFIG") != "" {
 		kubeconfig = os.Getenv("KUBECONFIG")
 	} else if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".kube", "config")); kubeconfig == "" && !os.IsNotExist(err) {
 		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	}
-	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return metricProfile, alertProfile, err
+	var restConfig *rest.Config
+	var err error
+	if kubeconfig == "" {
+		if restConfig, err = rest.InClusterConfig(); err != nil {
+			log.Fatalf("error preparing kubernetes client: %s", err)
+		}
+	} else {
+		if restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig); err != nil {
+			log.Fatalf("error preparing kubernetes client: %s", err)
+		}
 	}
-	clientSet := kubernetes.NewForConfigOrDie(restConfig)
+	return &KubeClientProvider{restConfig: restConfig}
+}
+
+func (p *KubeClientProvider) DefaultRestConfig() *rest.Config {
+	restConfig := *p.restConfig
+	return &restConfig
+}
+
+func (p *KubeClientProvider) DefaultClientSet() kubernetes.Interface {
+	return kubernetes.NewForConfigOrDie(p.DefaultRestConfig())
+}
+
+func (p *KubeClientProvider) RestConfig(QPS float32, burst int) *rest.Config {
+	restConfig := *p.restConfig
+	restConfig.QPS, restConfig.Burst = QPS, burst
+	restConfig.Timeout = configSpec.GlobalConfig.RequestTimeout
+	return &restConfig
+}
+
+func (p *KubeClientProvider) ClientSet(QPS float32, burst int) kubernetes.Interface {
+	return kubernetes.NewForConfigOrDie(p.RestConfig(QPS, burst))
+}
+
+// FetchConfigMap Fetchs the specified configmap and looks for config.yml, metrics.yml and alerts.yml files
+func FetchConfigMap(configMap, namespace string, clientSet kubernetes.Interface) (string, string, error) {
+	log.Infof("Fetching configmap %s", configMap)
+	var metricProfile, alertProfile string
 	configMapData, err := clientSet.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMap, v1.GetOptions{})
 	if err != nil {
 		return metricProfile, alertProfile, err
@@ -199,37 +232,6 @@ func validateDNS1123() error {
 		}
 	}
 	return nil
-}
-
-// GetRestConfig returns restConfig with the given QPS and burst
-func GetClientSet(QPS float32, burst int) (*kubernetes.Clientset, *rest.Config, error) {
-	var err error
-	var restConfig *rest.Config
-	var kubeconfig string
-	if os.Getenv("KUBECONFIG") != "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	} else if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".kube", "config")); kubeconfig == "" && !os.IsNotExist(err) {
-		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	}
-	restConfig, err = buildConfig(kubeconfig)
-	if err != nil {
-		return &kubernetes.Clientset{}, restConfig, err
-	}
-	restConfig.QPS, restConfig.Burst = QPS, burst
-	restConfig.Timeout = configSpec.GlobalConfig.RequestTimeout
-	return kubernetes.NewForConfigOrDie(restConfig), restConfig, nil
-}
-
-func buildConfig(kubeconfigPath string) (*rest.Config, error) {
-	if kubeconfigPath == "" {
-		kubeconfig, err := rest.InClusterConfig()
-		if err == nil {
-			return kubeconfig, nil
-		}
-	}
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
-		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}}).ClientConfig()
 }
 
 func jobIsDuped() error {

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -130,7 +130,7 @@ func (s *serviceLatency) handleCreateSvc(obj interface{}) {
 		}
 		endpointsReadyTs := time.Now().UTC()
 		log.Debugf("Endpoints %v/%v ready", svc.Namespace, svc.Name)
-		svcLatencyChecker, err := util.NewSvcLatencyChecker(*factory.clientSet, *factory.restConfig)
+		svcLatencyChecker, err := util.NewSvcLatencyChecker(factory.clientSet, *factory.restConfig)
 		if err != nil {
 			log.Error(err)
 		}

--- a/pkg/measurements/util/svc_checker.go
+++ b/pkg/measurements/util/svc_checker.go
@@ -18,11 +18,11 @@ import (
 
 type SvcLatencyChecker struct {
 	Pod        *corev1.Pod
-	clientSet  kubernetes.Clientset
+	clientSet  kubernetes.Interface
 	restConfig rest.Config
 }
 
-func NewSvcLatencyChecker(clientSet kubernetes.Clientset, restConfig rest.Config) (SvcLatencyChecker, error) {
+func NewSvcLatencyChecker(clientSet kubernetes.Interface, restConfig rest.Config) (SvcLatencyChecker, error) {
 	pod, err := clientSet.CoreV1().Pods(types.SvcLatencyNs).Get(context.TODO(), types.SvcLatencyCheckerName, metav1.GetOptions{})
 	if err != nil {
 		return SvcLatencyChecker{}, err

--- a/pkg/util/cluster_health.go
+++ b/pkg/util/cluster_health.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func ClusterHealthCheck(clientSet *kubernetes.Clientset) {
+func ClusterHealthCheck(clientSet kubernetes.Interface) {
 	log.Infof("🏥 Checking for Cluster Health")
 	if ClusterHealthyVanillaK8s(clientSet) {
 		log.Infof("Cluster is healthy.")
@@ -18,7 +18,7 @@ func ClusterHealthCheck(clientSet *kubernetes.Clientset) {
 	}
 }
 
-func ClusterHealthyVanillaK8s(clientset *kubernetes.Clientset) bool {
+func ClusterHealthyVanillaK8s(clientset kubernetes.Interface) bool {
 	var isHealthy = true
 	nodes, err := clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {

--- a/pkg/util/namespaces.go
+++ b/pkg/util/namespaces.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func CreateNamespace(clientSet *kubernetes.Clientset, name string, nsLabels map[string]string, nsAnnotations map[string]string) error {
+func CreateNamespace(clientSet kubernetes.Interface, name string, nsLabels map[string]string, nsAnnotations map[string]string) error {
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: nsLabels, Annotations: nsAnnotations},
 	}
@@ -57,7 +57,7 @@ func CreateNamespace(clientSet *kubernetes.Clientset, name string, nsLabels map[
 }
 
 // CleanupNamespaces deletes namespaces with the given selector
-func CleanupNamespaces(ctx context.Context, clientSet *kubernetes.Clientset, labelSelector string) {
+func CleanupNamespaces(ctx context.Context, clientSet kubernetes.Interface, labelSelector string) {
 	ns, err := clientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		log.Errorf("Error listing namespaces: %v", err.Error())
@@ -77,7 +77,7 @@ func CleanupNamespaces(ctx context.Context, clientSet *kubernetes.Clientset, lab
 	}
 }
 
-func waitForDeleteNamespaces(ctx context.Context, clientSet *kubernetes.Clientset, labelSelector string) {
+func waitForDeleteNamespaces(ctx context.Context, clientSet kubernetes.Interface, labelSelector string) {
 	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		ns, err := clientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
@@ -98,7 +98,7 @@ func waitForDeleteNamespaces(ctx context.Context, clientSet *kubernetes.Clientse
 }
 
 // Cleanup non-namespaced resources with the given selector
-func CleanupNonNamespacedResources(ctx context.Context, clientSet *kubernetes.Clientset, dynamicClient dynamic.Interface, labelSelector string) {
+func CleanupNonNamespacedResources(ctx context.Context, clientSet kubernetes.Interface, dynamicClient dynamic.Interface, labelSelector string) {
 	serverResources, _ := clientSet.Discovery().ServerPreferredResources()
 	log.Infof("Deleting non-namespace resources with label: %s", labelSelector)
 	for _, resourceList := range serverResources {

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
@@ -31,7 +30,6 @@ import (
 	"github.com/kube-burner/kube-burner/pkg/util"
 	"github.com/kube-burner/kube-burner/pkg/util/metrics"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -43,24 +41,14 @@ var ConfigSpec config.Spec
 var indexer *indexers.Indexer
 
 // NewWorkloadHelper initializes workloadHelper
-func NewWorkloadHelper(config Config, embedConfig embed.FS) WorkloadHelper {
-	var kubeconfig string
-	if os.Getenv("KUBECONFIG") != "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	} else if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".kube", "config")); kubeconfig == "" && !os.IsNotExist(err) {
-		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
-	}
-	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		log.Fatal(err)
-	}
+func NewWorkloadHelper(config Config, embedConfig embed.FS, kubeClientProvider *config.KubeClientProvider) WorkloadHelper {
 	if config.ConfigDir == "" {
 		log.Fatal("Config dir cannot be empty")
 	}
 	wh := WorkloadHelper{
-		Config:      config,
-		embedConfig: embedConfig,
-		RestConfig:  restConfig,
+		Config:             config,
+		embedConfig:        embedConfig,
+		kubeClientProvider: kubeClientProvider,
 	}
 	return wh
 }
@@ -177,7 +165,7 @@ func (wh *WorkloadHelper) Run(workload string, metricsProfiles []string, alertsP
 			}
 		}
 	}
-	rc, err = burner.Run(ConfigSpec, prometheusClients, alertMs, indexer, wh.Timeout, wh.MetricsMetadata)
+	rc, err = burner.Run(ConfigSpec, wh.kubeClientProvider, prometheusClients, alertMs, indexer, wh.Timeout, wh.MetricsMetadata)
 	if err != nil {
 		wh.Metadata.ExecutionErrors = err.Error()
 		log.Error(err)

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/ocp-metadata"
-	"k8s.io/client-go/rest"
+	"github.com/kube-burner/kube-burner/pkg/config"
 )
 
 type Config struct {
@@ -45,9 +45,9 @@ type BenchmarkMetadata struct {
 
 type WorkloadHelper struct {
 	Config
-	Metadata        BenchmarkMetadata
-	embedConfig     embed.FS
-	MetadataAgent   ocpmetadata.Metadata
-	RestConfig      *rest.Config
-	MetricsMetadata map[string]interface{}
+	Metadata           BenchmarkMetadata
+	embedConfig        embed.FS
+	kubeClientProvider *config.KubeClientProvider
+	MetadataAgent      ocpmetadata.Metadata
+	MetricsMetadata    map[string]interface{}
 }


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [x] Documentation Update

## Description
This PR adds flags to specify the kubeconfig path and context. The target subcommands are as follows:
- init
- health-check
- destroy
- measure

Additionally, this PR includes some small refactorings below:
- Commonize the initialization logic of client config wrote in multiple locations, by adding a new struct KubeClientProvider. This struct provides kubernetes client objects based on single initialization logic.
- Replace `*kubernetes.clientSet` with `kubernetes.Interface` adhere to the concept of utilizing objects through an interface.

## Related Tickets & Documents

- Related Issue #535 
- Closes #535
