### PR TITLE
Link profiles to indexers

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -431,7 +431,7 @@ func alertCmd() *cobra.Command {
 				Token:         token,
 				SkipTLSVerify: skipTLSVerify,
 			}
-			p, err := prometheus.NewPrometheusClient(configSpec, url, auth, prometheusStep, nil, false, *indexer)
+			p, err := prometheus.NewPrometheusClient(configSpec, url, auth, prometheusStep, nil, false, indexer)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -97,7 +97,7 @@ func initCmd() *cobra.Command {
 				log.Fatalf("Config error: %s", err.Error())
 			}
 			metricsScraper := metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
-				ConfigSpec:      configSpec,
+				ConfigSpec:      &configSpec,
 				MetricsEndpoint: metricsEndpoint,
 				UserMetaData:    userMetadata,
 			})
@@ -306,7 +306,7 @@ func indexCmd() *cobra.Command {
 			}
 			configSpec.MetricsEndpoints = append(configSpec.MetricsEndpoints, indexer)
 			metricsScraper := metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
-				ConfigSpec:      configSpec,
+				ConfigSpec:      &configSpec,
 				MetricsEndpoint: metricsEndpoint,
 				UserMetaData:    userMetadata,
 			})

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -187,8 +187,8 @@ func measureCmd() *cobra.Command {
 	var configFile string
 	var jobName string
 	var userMetadata string
-	var indexerList []indexers.Indexer
 	var kubeConfig, kubeContext string
+	indexerList := make(map[string]indexers.Indexer)
 	metadata := make(map[string]interface{})
 	cmd := &cobra.Command{
 		Use:   "measure",
@@ -215,7 +215,7 @@ func measureCmd() *cobra.Command {
 				if err != nil {
 					log.Fatalf("Error creating indexer %d: %v", pos, err.Error())
 				}
-				indexerList = append(indexerList, *idx)
+				indexerList[string(indexer.Alias)] = *idx
 			}
 			if userMetadata != "" {
 				metadata, err = util.ReadUserMetadata(userMetadata)

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -122,6 +122,7 @@ func initCmd() *cobra.Command {
 	cmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to the kubeconfig file")
 	cmd.Flags().StringVar(&kubeContext, "kube-context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().SortFlags = false
+	cmd.MarkFlagRequired("config")
 	return cmd
 }
 

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -70,15 +70,11 @@ To configure your bash shell to load completions for each session execute:
 }
 
 func initCmd() *cobra.Command {
-	var err error
 	var clientSet kubernetes.Interface
 	var kubeConfig, kubeContext string
-	var url, metricsEndpoint, metricsProfile, alertProfile, configFile string
-	var metricsProfiles []string
-	var alertsProfiles []string
-	var username, password, uuid, token, configMap, namespace, userMetadata string
+	var metricsEndpoint, configFile string
+	var uuid, userMetadata string
 	var skipTLSVerify bool
-	var prometheusStep time.Duration
 	var timeout time.Duration
 	var rc int
 	cmd := &cobra.Command{
@@ -92,20 +88,6 @@ func initCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			kubeClientProvider := config.NewKubeClientProvider(kubeConfig, kubeContext)
 			clientSet, _ = kubeClientProvider.DefaultClientSet()
-			if configMap != "" {
-				metricsProfile, alertProfile, err = config.FetchConfigMap(configMap, namespace, clientSet)
-				if err != nil {
-					log.Fatal(err.Error())
-				}
-				// We assume configFile is config.yml
-				configFile = "config.yml"
-			}
-			if metricsProfile != "" {
-				metricsProfiles = append(metricsProfiles, metricsProfile)
-			}
-			if alertProfile != "" {
-				alertsProfiles = append(alertsProfiles, alertProfile)
-			}
 			f, err := util.ReadConfig(configFile)
 			if err != nil {
 				log.Fatalf("Error reading configuration file %s: %s", configFile, err)
@@ -116,15 +98,7 @@ func initCmd() *cobra.Command {
 			}
 			metricsScraper := metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
 				ConfigSpec:      configSpec,
-				Password:        password,
-				PrometheusStep:  prometheusStep,
 				MetricsEndpoint: metricsEndpoint,
-				MetricsProfiles: metricsProfiles,
-				AlertProfiles:   alertsProfiles,
-				SkipTLSVerify:   skipTLSVerify,
-				URL:             url,
-				Token:           token,
-				Username:        username,
 				UserMetaData:    userMetadata,
 			})
 			if configSpec.GlobalConfig.ClusterHealth {
@@ -140,20 +114,10 @@ func initCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&uuid, "uuid", uid.NewString(), "Benchmark UUID")
-	cmd.Flags().StringVarP(&url, "prometheus-url", "u", "", "Prometheus URL")
-	cmd.Flags().StringVarP(&token, "token", "t", "", "Prometheus Bearer token")
-	cmd.Flags().StringVar(&username, "username", "", "Prometheus username for authentication")
-	cmd.Flags().StringVarP(&password, "password", "p", "", "Prometheus password for basic authentication")
-	cmd.Flags().StringVarP(&metricsProfile, "metrics-profile", "m", "", "Metrics profile file or URL")
 	cmd.Flags().StringVarP(&metricsEndpoint, "metrics-endpoint", "e", "", "YAML file with a list of metric endpoints")
-	cmd.Flags().StringVarP(&alertProfile, "alert-profile", "a", "", "Alert profile file or URL")
 	cmd.Flags().BoolVar(&skipTLSVerify, "skip-tls-verify", true, "Verify prometheus TLS certificate")
-	cmd.Flags().DurationVarP(&prometheusStep, "step", "s", 30*time.Second, "Prometheus step size")
 	cmd.Flags().DurationVarP(&timeout, "timeout", "", 4*time.Hour, "Benchmark timeout")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "Config file path or URL")
-	cmd.Flags().StringVarP(&configMap, "configmap", "", "", "Configmap holding all the configuration: config.yml, metrics.yml and alerts.yml. metrics and alerts are optional")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace where the configmap is")
-	cmd.MarkFlagsMutuallyExclusive("config", "configmap")
 	cmd.Flags().StringVar(&userMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
 	cmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to the kubeconfig file")
 	cmd.Flags().StringVar(&kubeContext, "kube-context", "", "The name of the kubeconfig context to use")
@@ -244,7 +208,7 @@ func measureCmd() *cobra.Command {
 			if len(configSpec.Jobs) > 0 {
 				log.Fatal("No jobs are allowed in a measure subcommand config file")
 			}
-			for pos, indexer := range configSpec.Indexers {
+			for pos, indexer := range configSpec.MetricsEndpoints {
 				log.Infof("📁 Creating indexer: %s", indexer.Type)
 				idx, err := indexers.NewIndexer(indexer.IndexerConfig)
 				if err != nil {
@@ -283,9 +247,7 @@ func measureCmd() *cobra.Command {
 			if err = measurements.Stop(); err != nil {
 				log.Error(err.Error())
 			}
-			for _, indexer := range indexerList {
-				measurements.Index(indexer, jobName)
-			}
+			measurements.Index(jobName, indexerList)
 		},
 	}
 	cmd.Flags().StringVar(&uuid, "uuid", "", "UUID")
@@ -308,6 +270,7 @@ func indexCmd() *cobra.Command {
 	var skipTLSVerify bool
 	var prometheusStep time.Duration
 	var tarballName string
+	var indexer config.MetricsEndpoint
 	cmd := &cobra.Command{
 		Use:   "index",
 		Short: "Index kube-burner metrics",
@@ -318,35 +281,32 @@ func indexCmd() *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			configSpec.GlobalConfig.UUID = uuid
-			if esServer != "" && esIndex != "" {
-				configSpec.Indexers = append(configSpec.Indexers,
-					config.Indexer{
-						IndexerConfig: indexers.IndexerConfig{
-							Type:    indexers.ElasticIndexer,
-							Servers: []string{esServer},
-							Index:   esIndex,
-						},
-					})
-			} else {
-				configSpec.Indexers = append(configSpec.Indexers,
-					config.Indexer{
-						IndexerConfig: indexers.IndexerConfig{
-							Type:             indexers.LocalIndexer,
-							MetricsDirectory: metricsDirectory,
-							TarballName:      tarballName,
-						},
-					})
+			indexer = config.MetricsEndpoint{
+				Username:                username,
+				Password:                password,
+				Token:                   token,
+				PrometheusStep:          prometheusStep,
+				PrometheusURL:           url,
+				Metrics:                 []string{metricsProfile},
+				PrometheusSkipTLSVerify: skipTLSVerify,
 			}
+			if esServer != "" && esIndex != "" {
+				indexer.IndexerConfig = indexers.IndexerConfig{
+					Type:    indexers.ElasticIndexer,
+					Servers: []string{esServer},
+					Index:   esIndex,
+				}
+			} else {
+				indexer.IndexerConfig = indexers.IndexerConfig{
+					Type:             indexers.LocalIndexer,
+					MetricsDirectory: metricsDirectory,
+					TarballName:      tarballName,
+				}
+			}
+			configSpec.MetricsEndpoints = append(configSpec.MetricsEndpoints, indexer)
 			metricsScraper := metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
 				ConfigSpec:      configSpec,
-				Password:        password,
-				PrometheusStep:  prometheusStep,
 				MetricsEndpoint: metricsEndpoint,
-				MetricsProfiles: []string{metricsProfile},
-				SkipTLSVerify:   skipTLSVerify,
-				URL:             url,
-				Token:           token,
-				Username:        username,
 				UserMetaData:    userMetadata,
 			})
 			for _, prometheusClient := range metricsScraper.PrometheusClients {
@@ -361,8 +321,8 @@ func indexCmd() *cobra.Command {
 					log.Fatal(err)
 				}
 			}
-			if configSpec.Indexers[0].Type == indexers.LocalIndexer && tarballName != "" {
-				if err := metrics.CreateTarball(configSpec.Indexers[0].IndexerConfig); err != nil {
+			if configSpec.MetricsEndpoints[0].Type == indexers.LocalIndexer && tarballName != "" {
+				if err := metrics.CreateTarball(configSpec.MetricsEndpoints[0].IndexerConfig); err != nil {
 					log.Fatal(err)
 				}
 			}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,7 @@ Use "kube-burner [command] --help" for more information about a command.
 
 This is the main subcommand; it triggers a new kube-burner benchmark and it supports the these flags:
 
-- `uuid`: Benchmark ID. This is essentially an arbitrary string that is used for different purposes along the benchmark. For example, label the objects created by kube-burner as mentioned in the [reference chapter](/kube-burner/configuration/#default-labels). By default, it is auto-generated.
+- `uuid`: Benchmark ID. This is essentially an arbitrary string that is used for different purposes along the benchmark. For example, to label the objects created by kube-burner as mentioned in the [reference chapter](/kube-burner/configuration/#default-labels). By default, it is auto-generated.
 - `config`: Path or URL to a valid configuration file. See details about the configuration schema in the [reference chapter](/kube-burner/configuration/).
 - `configmap`: In case of not providing the `--config` flag, kube-burner is able to fetch its configuration from a given `configMap`. This variable configures its name. kube-burner expects the configMap to hold all the required configuration: config.yml, metrics.yml, and alerts.yml. Where metrics.yml and alerts.yml are optional.
 - `namespace`: Name of the namespace where the configmap is.
@@ -59,13 +59,13 @@ This is the main subcommand; it triggers a new kube-burner benchmark and it supp
 With the above, running a kube-burner benchmark would be as simple as:
 
 ```console
-kube-burner init -c cfg.yml -u https://prometheus-k8s-openshift-monitoring.apps.rsevilla.stress.mycluster.example.com -t ${token} --uuid 67f9ec6d-6a9e-46b6-a3bb-065cde988790`
+kube-burner init -c cfg.yml --uuid 67f9ec6d-6a9e-46b6-a3bb-065cde988790`
 ```
 
 Kube-burner also supports remote configuration files served by a web server. To use it, rather than a path, pass a URL. For example:
 
 ```console
-kube-burner init -c http://web.domain.com:8080/cfg.yml -t ${token} --uuid 67f9ec6d-6a9e-46b6-a3bb-065cde988790`
+kube-burner init -c http://web.domain.com:8080/cfg.yml --uuid 67f9ec6d-6a9e-46b6-a3bb-065cde988790`
 ```
 
 To scrape metrics from multiple endpoints, the  `init` command can be triggered. For example:

--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -4,7 +4,6 @@ Kube-burner allows you to get further metrics using other mechanisms or data sou
 
 Measurements are enabled in the `measurements` object of the configuration file. This object contains a list of measurements with their options.
 
-
 ## Pod and VMI latency
 
 Collects latencies from the different pod/vm/vmi startup phases, these **latency metrics are in ms**. It can be enabled with:
@@ -276,15 +275,17 @@ For example
 metricsEndpoints:
 - indexer:
     type: local
+    alias: local-indexer
 - indexer:
     type: opensearch
     defaultIndex: kube-burner
     esServers: ["https://opensearch.domain:9200"]
+    alias: os-indexer
 global:
   measurements:
   - name: podLatency
-    timeseriesIndexer: 1
-    quantilesIndexer: 2
+    timeseriesIndexer: local-indexer
+    quantilesIndexer: os-indexer
 ```
 
-With the configuration snippet above, the measurement `podLatency` would use the local indexer for timeseries metrics and opensearch for the quantile metrics.
+With the configuration snippet above, the measurement `podLatency` would use the local indexer for timeseries metrics and opensearch for the quantile metrics. The value of these two fields is `all` by default.

--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -264,7 +264,6 @@ An example of how to configure this measurement to collect pprof HEAP and CPU pr
 !!! warning
     As mentioned before, this measurement requires the `curl` command to be available in the target pods.
 
-
 ## Indexing in different places
 
 The pod/vmi and service latency measurements send their metrics by default to all the indexers configured in the `metricsEndpoints` list, but it's possible to configure a different indexer for the quantile and the timeseries metrics by using the fields `quantilesIndexer` and `timeseriesIndexer`.
@@ -288,4 +287,4 @@ global:
     quantilesIndexer: os-indexer
 ```
 
-With the configuration snippet above, the measurement `podLatency` would use the local indexer for timeseries metrics and opensearch for the quantile metrics. The value of these two fields is `all` by default.
+With the configuration snippet above, the measurement `podLatency` would use the local indexer for timeseries metrics and opensearch for the quantile metrics.

--- a/docs/observability/index.md
+++ b/docs/observability/index.md
@@ -1,6 +1,6 @@
 # Overview
 
-Performing a benchmark using kube-burner is relatively simple. However, it is sometimes necessary to analyze and be able to react to some KPIs in order to validate a benchmark. That  is why kube-burner ships  [metric-collection](metrics.md) and [alerting](alerting.md) systems based on Prometheus expressions.
+Performing a benchmark using kube-burner is relatively simple. However, it is sometimes necessary to analyze and be able to react to some KPIs in order to validate a benchmark. That is why kube-burner ships [metric-collection](metrics.md) and [alerting](alerting.md) systems based on Prometheus expressions.
 
 Kube-burner also ships an [indexing](indexing.md) feature that, in combination with the metric-collection and alerting features, can be used to analyze these KPIs in an external tool, such as [Grafana](https://grafana.com/) or similar.
 

--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -17,6 +17,7 @@ The logic to configure metric collection and indexing is established by the `met
 | `metrics` | List of metrics files | `[metrics.yml, more-metrics.yml]` |
 | `alerts` | List of alerts files | `[alerts.yml, more-alerts.yml]` |
 | `indexer` | Indexer configuration | [indexers](#indexers) |
+| `alias`   | Indexer alias, an arbitrary string required to send measurement results to an specific indexer  | `my-indexer` |
 
 !!! Note
     Info about how to configure [metrics-profiles](metrics.md) and [alerts-profiles](alerting.md)
@@ -29,7 +30,6 @@ Depending on the indexer, different configuration parameters need to be specifie
 | Option    | Description     | Supported values   |
 | --------- | --------------- | ------- |
 | `type`    | Type of indexer | `elastic`, `opensearch`, `local`|
-| `alias`   | Indexer alias   | Arbitrary string |
 
 ### Elastic/OpenSearch
 

--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -29,7 +29,7 @@ Depending on the indexer, different configuration parameters need to be specifie
 | Option    | Description     | Supported values   |
 | --------- | --------------- | ------- |
 | `type`    | Type of indexer | `elastic`, `opensearch`, `local`|
-
+| `alias`   | Indexer alias   | Arbitrary string |
 
 ### Elastic/OpenSearch
 

--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -1,39 +1,45 @@
 # Indexing
 
-Kube-burner can index the collected metrics into a given indexer.
+Kube-burner can collect metrics and alerts from prometheus and from measurements and send them to the configured indexers.
+
+## Metrics endpoints
+
+The logic to configure metric collection and indexing is established by the `metricsEndpoints` field of the configuration file, this field is a list of objects with the following structure:
+
+| Field     | Description     | Example   |
+| --------- | --------------- | --------- |
+| `prometheusURL` | Define the prometheus endpoint to scrape | `https://prom.my-domain.com` |
+| `username` | Prometheus username (Basic auth) | `username` |
+| `password` | Prometheus password (Basic auth) | `topSecret` |
+| `token` | Prometheus bearer token (Bearer auth) | `yourTokenDefinition` |
+| `prometheusStep` | Prometheus step size, used when scraping it, by default `30s` | `1m` |
+| `prometheusSkipTLSVerify` | Skip TLS certificate verification, `true` by default | `true` |
+| `metrics` | List of metrics files | `[metrics.yml, more-metrics.yml]` |
+| `alerts` | List of alerts files | `[alerts.yml, more-alerts.yml]` |
+| `indexer` | Indexer configuration | [indexers](#indexers) |
+
+!!! Note
+    Info about how to configure [metrics-profiles](metrics.md) and [alerts-profiles](alerting.md)
 
 ## Indexers
 
-Configured in the `indexers` field, this field defines a list of indexers, making collected metrics to be indexed in them
+Configured by the `indexer` field, it defines an indexer for the Prometheus endpoint, making all collected metrics to be indexed in it.
+Depending on the indexer, different configuration parameters need to be specified. The type of indexer is configured by the field `type`
 
 | Option    | Description     | Supported values   |
 | --------- | --------------- | ------- |
 | `type`    | Type of indexer | `elastic`, `opensearch`, `local`|
 
-Where each indexer supports different options, as in the example below:
-
-```yaml
-global:
-  gc: true
-  measurements:
-    - name: podLatency
- indexers:                                       
-   - type: opensearch                            
-     esServers: ["blablabla:9200"]             
-     defaultIndex: indexName   
-   - type: local                                 
-     metricsDirectory: collected-metrics
-```
 
 ### Elastic/OpenSearch
 
-This indexer send collected documents to Elasticsearch 7 instances or OpenSearch instances.
+Send collected documents to Elasticsearch7 or OpenSearch instances.
 
 The `elastic` or `opensearch` indexer can be configured by the parameters below:
 
 | Option               | Description                                       | Type    | Default |
 | -------------------- | ------------------------------------------------- | ------- | ------- |
-| `esServers`          | List of Elasticsearch or OpenSearch instances     | List    | ""      |
+| `esServers`          | List of Elasticsearch or OpenSearch URLs          | List    | []      |
 | `defaultIndex`       | Default index to send the Prometheus metrics into | String  | ""      |
 | `insecureSkipVerify` | TLS certificate verification                      | Boolean | false   |
 
@@ -56,7 +62,7 @@ The `local` indexer can be configured by the parameters below:
 
 ## Job Summary
 
-When an indexer is configured, a document holding the job summary is indexed at the end of the job. This is useful to identify the parameters the job was executed with. It also contains the timestaps of the execution phase (`timestamp` and `endTimestamp`) as well as the cleanup phase (`cleanupTimestamp` and `cleanupEndTimestamp`).
+When an indexer is configured, a document holding the job summary is indexed at the end of the job. This is useful to identify the parameters the job was executed with. It also contains the timestamps of the execution phase (`timestamp` and `endTimestamp`) as well as the cleanup phase (`cleanupTimestamp` and `cleanupEndTimestamp`).
 
 This document looks like:
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -18,7 +18,7 @@ The `query` field holds the Prometheus expression to evaluate, and `metricName` 
 
 ## Instant queries
 
-In addition to the default range queries, kube-burner has the ability execute [instant queries](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries) against the provided Prometheus API. This can be enaled by enabling the field `instant` to the desired metric.
+In addition to the default range queries, kube-burner has the ability execute [instant queries](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries) against the provided Prometheus API. This can be configured by enabling the field `instant` to the desired metric.
 
 ```yaml
 - query: kube_node_role

--- a/pkg/alerting/alert_manager.go
+++ b/pkg/alerting/alert_manager.go
@@ -66,7 +66,7 @@ type alert struct {
 type AlertManager struct {
 	alertProfile alertProfile
 	prometheus   *prometheus.Prometheus
-	indexers     []indexers.Indexer
+	indexer      indexers.Indexer
 	uuid         string
 }
 
@@ -81,12 +81,12 @@ type descriptionTemplate struct {
 }
 
 // NewAlertManager creates a new alert manager
-func NewAlertManager(alertProfileCfg, uuid string, prometheusClient *prometheus.Prometheus, embedConfig bool, indexers ...indexers.Indexer) (*AlertManager, error) {
+func NewAlertManager(alertProfileCfg, uuid string, prometheusClient *prometheus.Prometheus, embedConfig bool, indexer indexers.Indexer) (*AlertManager, error) {
 	log.Infof("🔔 Initializing alert manager for prometheus: %v", prometheusClient.Endpoint)
 	a := AlertManager{
 		prometheus: prometheusClient,
 		uuid:       uuid,
-		indexers:   indexers,
+		indexer:    indexer,
 	}
 	if err := a.readProfile(alertProfileCfg, embedConfig); err != nil {
 		return &a, err
@@ -144,7 +144,7 @@ func (a *AlertManager) Evaluate(start, end time.Time, churnStart, churnEnd *time
 			alertList = append(alertList, alertSet)
 		}
 	}
-	if len(alertList) > 0 && len(a.indexers) > 0 {
+	if len(alertList) > 0 && a.indexer != nil {
 		a.index(alertList)
 	}
 	return utilerrors.NewAggregate(errs)
@@ -214,12 +214,10 @@ func parseMatrix(value model.Value, description string, severity severityLevel, 
 func (a *AlertManager) index(alertSet []interface{}) {
 	log.Info("Indexing alerts")
 	log.Debugf("Indexing [%d] documents", len(alertSet))
-	for _, indexer := range a.indexers {
-		resp, err := indexer.Index(alertSet, indexers.IndexingOpts{MetricName: alertMetricName})
-		if err != nil {
-			log.Error(err)
-		} else {
-			log.Info(resp)
-		}
+	resp, err := a.indexer.Index(alertSet, indexers.IndexingOpts{MetricName: alertMetricName})
+	if err != nil {
+		log.Error(err)
+	} else {
+		log.Info(resp)
 	}
 }

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -43,9 +43,6 @@ func setupCreateJob(jobConfig config.Job) Executor {
 	var err error
 	var f io.Reader
 	mapper := newRESTMapper()
-	if err != nil {
-		log.Fatalf("Error creating wait clientSet: %s", err.Error())
-	}
 	log.Debugf("Preparing create job: %s", jobConfig.Name)
 	ex := Executor{}
 	for _, o := range jobConfig.Objects {

--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -44,7 +44,7 @@ type jobSummary struct {
 const jobSummaryMetric = "jobSummary"
 
 // indexMetadataInfo Generates and indexes a document with metadata information of the passed job
-func indexjobSummaryInfo(indexer indexers.Indexer, uuid string, jobTimings timings, jobConfig config.Job, metadata map[string]interface{}) {
+func indexJobSummary(indexer indexers.Indexer, uuid string, jobTimings timings, jobConfig config.Job, metadata map[string]interface{}) {
 	metadataInfo := []interface{}{
 		jobSummary{
 			UUID:       uuid,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,9 +125,6 @@ func Parse(uuid string, f io.Reader) (Spec, error) {
 	if err != nil {
 		return configSpec, fmt.Errorf("error rendering configuration template: %s", err)
 	}
-	if err != nil {
-		return configSpec, err
-	}
 	cfgReader := bytes.NewReader(renderedCfg)
 	yamlDec := yaml.NewDecoder(cfgReader)
 	yamlDec.KnownFields(true)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -40,7 +40,7 @@ const (
 // Spec configuration root
 type Spec struct {
 	// List of kube-burner indexers
-	Indexers []Indexer `yaml:"indexers"`
+	MetricsEndpoints []MetricsEndpoint `yaml:"metricsEndpoints"`
 	// GlobalConfig defines global configuration parameters
 	GlobalConfig GlobalConfig `yaml:"global"`
 	// Jobs list of kube-burner jobs
@@ -51,8 +51,18 @@ type Spec struct {
 	EmbedFSDir string
 }
 
-type Indexer struct {
-	indexers.IndexerConfig `yaml:",inline"`
+// metricEndpoint describes prometheus endpoint to scrape
+type MetricsEndpoint struct {
+	indexers.IndexerConfig  `yaml:"indexer"`
+	Metrics                 []string      `yaml:"metrics"`
+	Alerts                  []string      `yaml:"alerts"`
+	PrometheusURL           string        `yaml:"prometheusURL"`
+	PrometheusStep          time.Duration `yaml:"prometheusStep"`
+	PrometheusSkipTLSVerify bool          `yaml:"prometheusSkipTLSVerify"`
+	Token                   string        `yaml:"token"`
+	Username                string        `yaml:"username"`
+	Password                string        `yaml:"password"`
+	EmbedConfig             bool
 }
 
 // GlobalConfig holds the global configuration

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -54,14 +54,15 @@ type Spec struct {
 // metricEndpoint describes prometheus endpoint to scrape
 type MetricsEndpoint struct {
 	indexers.IndexerConfig  `yaml:"indexer"`
-	Metrics                 []string      `yaml:"metrics"`
-	Alerts                  []string      `yaml:"alerts"`
-	PrometheusURL           string        `yaml:"prometheusURL"`
-	PrometheusStep          time.Duration `yaml:"prometheusStep"`
-	PrometheusSkipTLSVerify bool          `yaml:"prometheusSkipTLSVerify"`
-	Token                   string        `yaml:"token"`
-	Username                string        `yaml:"username"`
-	Password                string        `yaml:"password"`
+	Metrics                 []string            `yaml:"metrics"`
+	Alerts                  []string            `yaml:"alerts"`
+	PrometheusURL           string              `yaml:"prometheusURL"`
+	PrometheusStep          time.Duration       `yaml:"prometheusStep"`
+	PrometheusSkipTLSVerify bool                `yaml:"prometheusSkipTLSVerify"`
+	Token                   string              `yaml:"token"`
+	Username                string              `yaml:"username"`
+	Password                string              `yaml:"password"`
+	Alias                   mtypes.IndexerAlias `yaml:"alias"`
 	EmbedConfig             bool
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -54,15 +54,15 @@ type Spec struct {
 // metricEndpoint describes prometheus endpoint to scrape
 type MetricsEndpoint struct {
 	indexers.IndexerConfig  `yaml:"indexer"`
-	Metrics                 []string            `yaml:"metrics"`
-	Alerts                  []string            `yaml:"alerts"`
-	PrometheusURL           string              `yaml:"prometheusURL"`
-	PrometheusStep          time.Duration       `yaml:"prometheusStep"`
-	PrometheusSkipTLSVerify bool                `yaml:"prometheusSkipTLSVerify"`
-	Token                   string              `yaml:"token"`
-	Username                string              `yaml:"username"`
-	Password                string              `yaml:"password"`
-	Alias                   mtypes.IndexerAlias `yaml:"alias"`
+	Metrics                 []string      `yaml:"metrics"`
+	Alerts                  []string      `yaml:"alerts"`
+	PrometheusURL           string        `yaml:"prometheusURL"`
+	PrometheusStep          time.Duration `yaml:"prometheusStep"`
+	PrometheusSkipTLSVerify bool          `yaml:"prometheusSkipTLSVerify"`
+	Token                   string        `yaml:"token"`
+	Username                string        `yaml:"username"`
+	Password                string        `yaml:"password"`
+	Alias                   string        `yaml:"alias"`
 	EmbedConfig             bool
 }
 

--- a/pkg/measurements/common.go
+++ b/pkg/measurements/common.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package measurements
+
+import (
+	"fmt"
+
+	"github.com/cloud-bulldozer/go-commons/indexers"
+	"github.com/kube-burner/kube-burner/pkg/measurements/types"
+	log "github.com/sirupsen/logrus"
+)
+
+func indexLatencyMeasurement(config types.Measurement, jobName string, metricMap map[string][]interface{}, indexerList []indexers.Indexer) {
+	indexDocuments := func(indexer indexers.Indexer, metricName string, data []interface{}) {
+		log.Infof("Indexing metric %s", metricName)
+		indexingOpts := indexers.IndexingOpts{
+			MetricName: fmt.Sprintf("%s-%s", metricName, jobName),
+		}
+		log.Debugf("Indexing [%d] documents: %s", len(data), metricName)
+		resp, err := indexer.Index(data, indexingOpts)
+		if err != nil {
+			log.Error(err.Error())
+		} else {
+			log.Info(resp)
+		}
+	}
+	for metricName, data := range metricMap {
+		// Use the configured TimeseriesIndexer or QuantilesIndexer when specified or else use all indexers
+		if metricName == podLatencyMeasurement && config.TimeseriesIndexer != 0 {
+			indexer := indexerList[config.TimeseriesIndexer-1]
+			indexDocuments(indexer, metricName, data)
+		} else if metricName == podLatencyQuantilesMeasurement && config.QuantilesIndexer != 0 {
+			indexer := indexerList[config.QuantilesIndexer-1]
+			indexDocuments(indexer, metricName, data)
+		} else {
+			for _, indexer := range indexerList {
+				indexDocuments(indexer, metricName, data)
+			}
+		}
+	}
+
+}

--- a/pkg/measurements/common.go
+++ b/pkg/measurements/common.go
@@ -38,14 +38,12 @@ func indexLatencyMeasurement(config types.Measurement, jobName string, metricMap
 	}
 	for metricName, data := range metricMap {
 		// Use the configured TimeseriesIndexer or QuantilesIndexer when specified or else use all indexers
-		if config.TimeseriesIndexer != "" || config.QuantilesIndexer != "" {
-			if metricName == podLatencyMeasurement || metricName == svcLatencyMeasurement {
-				indexer := indexerList[string(config.TimeseriesIndexer)]
-				indexDocuments(indexer, metricName, data)
-			} else if metricName == podLatencyQuantilesMeasurement || metricName == svcLatencyQuantilesMeasurement {
-				indexer := indexerList[string(config.QuantilesIndexer)]
-				indexDocuments(indexer, metricName, data)
-			}
+		if config.TimeseriesIndexer != "" && (metricName == podLatencyMeasurement || metricName == svcLatencyMeasurement) {
+			indexer := indexerList[config.TimeseriesIndexer]
+			indexDocuments(indexer, metricName, data)
+		} else if config.QuantilesIndexer != "" && (metricName == podLatencyQuantilesMeasurement || metricName == svcLatencyQuantilesMeasurement) {
+			indexer := indexerList[config.QuantilesIndexer]
+			indexDocuments(indexer, metricName, data)
 		} else {
 			for _, indexer := range indexerList {
 				indexDocuments(indexer, metricName, data)

--- a/pkg/measurements/common.go
+++ b/pkg/measurements/common.go
@@ -38,7 +38,7 @@ func indexLatencyMeasurement(config types.Measurement, jobName string, metricMap
 	}
 	for metricName, data := range metricMap {
 		// Use the configured TimeseriesIndexer or QuantilesIndexer when specified or else use all indexers
-		if config.TimeseriesIndexer != types.All || config.QuantilesIndexer != types.All {
+		if config.TimeseriesIndexer != "" || config.QuantilesIndexer != "" {
 			if metricName == podLatencyMeasurement || metricName == svcLatencyMeasurement {
 				indexer := indexerList[string(config.TimeseriesIndexer)]
 				indexDocuments(indexer, metricName, data)

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -72,7 +72,6 @@ func NewMeasurementFactory(configSpec config.Spec, metadata map[string]interface
 		if measurement.TimeseriesIndexer != "" {
 			indexerFound = false
 			for _, indexer := range configSpec.MetricsEndpoints {
-				fmt.Println(indexer.Type)
 				if indexer.Alias == measurement.TimeseriesIndexer {
 					indexerFound = true
 					break

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -58,27 +58,15 @@ func NewMeasurementFactory(configSpec config.Spec, metadata map[string]interface
 	}
 	for _, measurement := range globalCfg.Measurements {
 		indexerFound = false
-		if measurement.QuantilesIndexer != "" {
+		if measurement.QuantilesIndexer != "" || measurement.TimeseriesIndexer != "" {
 			for _, indexer := range configSpec.MetricsEndpoints {
-				if indexer.Alias == measurement.QuantilesIndexer {
+				if indexer.Alias == measurement.QuantilesIndexer || indexer.Alias == measurement.TimeseriesIndexer {
 					indexerFound = true
 					break
 				}
 			}
 			if !indexerFound {
-				log.Fatalf("Quantiles indexer not found: %s", measurement.QuantilesIndexer)
-			}
-		}
-		if measurement.TimeseriesIndexer != "" {
-			indexerFound = false
-			for _, indexer := range configSpec.MetricsEndpoints {
-				if indexer.Alias == measurement.TimeseriesIndexer {
-					indexerFound = true
-					break
-				}
-			}
-			if !indexerFound {
-				log.Fatalf("Timeseries indexer not found: %s", measurement.TimeseriesIndexer)
+				log.Fatalf("One of the indexers for measurement %s has not been found", measurement.Name)
 			}
 		}
 		if measurementFunc, exists := measurementMap[measurement.Name]; exists {

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -58,28 +58,29 @@ func NewMeasurementFactory(configSpec config.Spec, metadata map[string]interface
 	}
 	for _, measurement := range globalCfg.Measurements {
 		indexerFound = false
-		if measurement.QuantilesIndexer != types.All {
+		if measurement.QuantilesIndexer != "" {
 			for _, indexer := range configSpec.MetricsEndpoints {
 				if indexer.Alias == measurement.QuantilesIndexer {
 					indexerFound = true
 					break
 				}
 			}
+			if !indexerFound {
+				log.Fatalf("Quantiles indexer not found: %s", measurement.QuantilesIndexer)
+			}
 		}
-		if !indexerFound {
-			log.Fatalf("Quantiles indexer not found: %s", measurement.QuantilesIndexer)
-		}
-		if measurement.TimeseriesIndexer != types.All {
+		if measurement.TimeseriesIndexer != "" {
+			indexerFound = false
 			for _, indexer := range configSpec.MetricsEndpoints {
-				indexerFound = false
+				fmt.Println(indexer.Type)
 				if indexer.Alias == measurement.TimeseriesIndexer {
 					indexerFound = true
 					break
 				}
 			}
-		}
-		if !indexerFound {
-			log.Fatalf("Timeseries indexer not found: %s", measurement.TimeseriesIndexer)
+			if !indexerFound {
+				log.Fatalf("Timeseries indexer not found: %s", measurement.TimeseriesIndexer)
+			}
 		}
 		if measurementFunc, exists := measurementMap[measurement.Name]; exists {
 			if err := factory.register(measurement, measurementFunc); err != nil {

--- a/pkg/measurements/metrics/metrics.go
+++ b/pkg/measurements/metrics/metrics.go
@@ -47,7 +47,7 @@ func CheckThreshold(thresholds []types.LatencyThreshold, quantiles []interface{}
 	for _, phase := range thresholds {
 		for _, pq := range quantiles {
 			if phase.ConditionType == pq.(LatencyQuantiles).QuantileName {
-				// Required to acccess the attribute by name
+				// Required to access the attribute by name
 				r := reflect.ValueOf(pq.(LatencyQuantiles))
 				v := r.FieldByName(phase.Metric).Int()
 				if v > phase.Threshold.Milliseconds() {

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -248,7 +248,7 @@ func (p *podLatency) stop() error {
 }
 
 // index sends metrics to the configured indexer
-func (p *podLatency) index(jobName string, indexerList []indexers.Indexer) {
+func (p *podLatency) index(jobName string, indexerList map[string]indexers.Indexer) {
 	metricMap := map[string][]interface{}{
 		podLatencyMeasurement:          p.normLatencies,
 		podLatencyQuantilesMeasurement: p.latencyQuantiles,

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -146,9 +146,9 @@ func (p *podLatency) validateConfig() error {
 
 // start podLatency measurement
 func (p *podLatency) start(measurementWg *sync.WaitGroup) error {
-	defer measurementWg.Done()
 	// Reset latency slices, required in multi-job benchmarks
 	p.latencyQuantiles, p.normLatencies = nil, nil
+	defer measurementWg.Done()
 	p.metrics = make(map[string]podMetric)
 	log.Infof("Creating Pod latency watcher for %s", factory.jobConfig.Name)
 	p.watcher = metrics.NewWatcher(
@@ -223,9 +223,11 @@ func (p *podLatency) collect(measurementWg *sync.WaitGroup) {
 // Stop stops podLatency measurement
 func (p *podLatency) stop() error {
 	var err error
-	if p.watcher != nil {
-		p.watcher.StopWatcher()
-	}
+	defer func() {
+		if p.watcher != nil {
+			p.watcher.StopWatcher()
+		}
+	}()
 	errorRate := p.normalizeMetrics()
 	if errorRate > 10.00 {
 		log.Error("Latency errors beyond 10%. Hence invalidating the results")
@@ -246,24 +248,12 @@ func (p *podLatency) stop() error {
 }
 
 // index sends metrics to the configured indexer
-func (p *podLatency) index(indexer indexers.Indexer, jobName string) {
-	log.Infof("Indexing pod latency data for job: %s", jobName)
+func (p *podLatency) index(jobName string, indexerList []indexers.Indexer) {
 	metricMap := map[string][]interface{}{
 		podLatencyMeasurement:          p.normLatencies,
 		podLatencyQuantilesMeasurement: p.latencyQuantiles,
 	}
-	for metricName, data := range metricMap {
-		indexingOpts := indexers.IndexingOpts{
-			MetricName: fmt.Sprintf("%s-%s", metricName, jobName),
-		}
-		log.Debugf("Indexing [%d] documents: %s", len(data), metricName)
-		resp, err := indexer.Index(data, indexingOpts)
-		if err != nil {
-			log.Error(err.Error())
-		} else {
-			log.Info(resp)
-		}
-	}
+	indexLatencyMeasurement(p.config, jobName, metricMap, indexerList)
 }
 
 func (p *podLatency) normalizeMetrics() float64 {

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -187,7 +187,7 @@ func (p *pprof) stop() error {
 }
 
 // Fake index function for pprof
-func (p *pprof) index(_ string, _ []indexers.Indexer) {
+func (p *pprof) index(_ string, _ map[string]indexers.Indexer) {
 }
 
 func readCerts(cert, privKey string) (string, string, error) {

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -187,7 +187,7 @@ func (p *pprof) stop() error {
 }
 
 // Fake index function for pprof
-func (p *pprof) index(_ indexers.Indexer, _ string) {
+func (p *pprof) index(_ string, _ []indexers.Indexer) {
 }
 
 func readCerts(cert, privKey string) (string, string, error) {

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -271,7 +271,7 @@ func (s *serviceLatency) normalizeMetrics() {
 	}
 }
 
-func (s *serviceLatency) index(jobName string, indexerList []indexers.Indexer) {
+func (s *serviceLatency) index(jobName string, indexerList map[string]indexers.Indexer) {
 	metricMap := map[string][]interface{}{
 		svcLatencyMeasurement:          s.normLatencies,
 		svcLatencyQuantilesMeasurement: s.latencyQuantiles,

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	svcLatencyMetric               = "svcLatencyMeasurement"
+	svcLatencyMeasurement          = "svcLatencyMeasurement"
 	svcLatencyQuantilesMeasurement = "svcLatencyQuantilesMeasurement"
 )
 
@@ -163,7 +163,7 @@ func (s *serviceLatency) handleCreateSvc(obj interface{}) {
 			Name:              svc.Name,
 			Namespace:         svc.Namespace,
 			Timestamp:         svc.CreationTimestamp.Time.UTC(),
-			MetricName:        svcLatencyMetric,
+			MetricName:        svcLatencyMeasurement,
 			ServiceType:       svc.Spec.Type,
 			ReadyLatency:      svcLatency,
 			UUID:              globalCfg.UUID,
@@ -273,8 +273,8 @@ func (s *serviceLatency) normalizeMetrics() {
 
 func (s *serviceLatency) index(jobName string, indexerList []indexers.Indexer) {
 	metricMap := map[string][]interface{}{
-		podLatencyMeasurement:          s.normLatencies,
-		podLatencyQuantilesMeasurement: s.latencyQuantiles,
+		svcLatencyMeasurement:          s.normLatencies,
+		svcLatencyQuantilesMeasurement: s.latencyQuantiles,
 	}
 	indexLatencyMeasurement(s.config, jobName, metricMap, indexerList)
 }

--- a/pkg/measurements/types/types.go
+++ b/pkg/measurements/types/types.go
@@ -23,6 +23,7 @@ import (
 )
 
 type latencyMetric string
+type MeasurementConfig map[string]any
 
 const (
 	pprofDirectory string = "pprof"
@@ -46,6 +47,8 @@ func (m *Measurement) UnmarshalMeasurement(unmarshal func(interface{}) error) er
 type Measurement struct {
 	// Name is the name the measurement
 	Name string `yaml:"name"`
+	// Measurement configuration
+	Config MeasurementConfig `yaml:"config"`
 	// LatencyThresholds config
 	LatencyThresholds []LatencyThreshold `yaml:"thresholds"`
 	// PPRofTargets targets config
@@ -58,6 +61,10 @@ type Measurement struct {
 	ServiceLatencyMetrics latencyMetric `yaml:"svcLatencyMetrics"`
 	// Service latency endpoint timeout
 	ServiceTimeout time.Duration `yaml:"svcTimeout"`
+	// Defines the indexer for quantile metrics
+	QuantilesIndexer int `yaml:"quantilesIndexer"`
+	// Defines the indexer for timeseries
+	TimeseriesIndexer int `yaml:"timeseriesIndexer"`
 }
 
 // LatencyThreshold holds the thresholds configuration

--- a/pkg/measurements/types/types.go
+++ b/pkg/measurements/types/types.go
@@ -22,21 +22,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-type IndexerAlias string
-
 const (
-	pprofDirectory string       = "pprof"
-	All            IndexerAlias = "all"
+	pprofDirectory string = "pprof"
 )
 
 // UnmarshalYAML implements Unmarshaller to customize object defaults
 func (m *Measurement) UnmarshalMeasurement(unmarshal func(interface{}) error) error {
 	type rawMeasurement Measurement
 	measurement := rawMeasurement{
-		PProfDirectory:    pprofDirectory,
-		ServiceTimeout:    5 * time.Second,
-		TimeseriesIndexer: All,
-		QuantilesIndexer:  All,
+		PProfDirectory: pprofDirectory,
+		ServiceTimeout: 5 * time.Second,
 	}
 	if err := unmarshal(&measurement); err != nil {
 		return err
@@ -60,9 +55,9 @@ type Measurement struct {
 	// Service latency endpoint timeout
 	ServiceTimeout time.Duration `yaml:"svcTimeout"`
 	// Defines the indexer for quantile metrics
-	QuantilesIndexer IndexerAlias `yaml:"quantilesIndexer"`
+	QuantilesIndexer string `yaml:"quantilesIndexer"`
 	// Defines the indexer for timeseries
-	TimeseriesIndexer IndexerAlias `yaml:"timeseriesIndexer"`
+	TimeseriesIndexer string `yaml:"timeseriesIndexer"`
 }
 
 // LatencyThreshold holds the thresholds configuration

--- a/pkg/measurements/types/types.go
+++ b/pkg/measurements/types/types.go
@@ -22,19 +22,21 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-type latencyMetric string
-type MeasurementConfig map[string]any
+type IndexerAlias string
 
 const (
-	pprofDirectory string = "pprof"
+	pprofDirectory string       = "pprof"
+	All            IndexerAlias = "all"
 )
 
 // UnmarshalYAML implements Unmarshaller to customize object defaults
 func (m *Measurement) UnmarshalMeasurement(unmarshal func(interface{}) error) error {
 	type rawMeasurement Measurement
 	measurement := rawMeasurement{
-		PProfDirectory: pprofDirectory,
-		ServiceTimeout: 5 * time.Second,
+		PProfDirectory:    pprofDirectory,
+		ServiceTimeout:    5 * time.Second,
+		TimeseriesIndexer: All,
+		QuantilesIndexer:  All,
 	}
 	if err := unmarshal(&measurement); err != nil {
 		return err
@@ -47,8 +49,6 @@ func (m *Measurement) UnmarshalMeasurement(unmarshal func(interface{}) error) er
 type Measurement struct {
 	// Name is the name the measurement
 	Name string `yaml:"name"`
-	// Measurement configuration
-	Config MeasurementConfig `yaml:"config"`
 	// LatencyThresholds config
 	LatencyThresholds []LatencyThreshold `yaml:"thresholds"`
 	// PPRofTargets targets config
@@ -57,14 +57,12 @@ type Measurement struct {
 	PProfInterval time.Duration `yaml:"pprofInterval"`
 	// PProfDirectory output directory
 	PProfDirectory string `yaml:"pprofDirectory"`
-	// Service latency metrics to index
-	ServiceLatencyMetrics latencyMetric `yaml:"svcLatencyMetrics"`
 	// Service latency endpoint timeout
 	ServiceTimeout time.Duration `yaml:"svcTimeout"`
 	// Defines the indexer for quantile metrics
-	QuantilesIndexer int `yaml:"quantilesIndexer"`
+	QuantilesIndexer IndexerAlias `yaml:"quantilesIndexer"`
 	// Defines the indexer for timeseries
-	TimeseriesIndexer int `yaml:"timeseriesIndexer"`
+	TimeseriesIndexer IndexerAlias `yaml:"timeseriesIndexer"`
 }
 
 // LatencyThreshold holds the thresholds configuration

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -397,7 +397,7 @@ func (p *vmiLatency) stop() error {
 }
 
 // index sends metrics to the configured indexer
-func (p *vmiLatency) index(jobName string, indexerList []indexers.Indexer) {
+func (p *vmiLatency) index(jobName string, indexerList map[string]indexers.Indexer) {
 	metricMap := map[string][]interface{}{
 		podLatencyMeasurement:          p.normLatencies,
 		podLatencyQuantilesMeasurement: p.latencyQuantiles,

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -382,12 +382,14 @@ func (p *vmiLatency) collect(measurementWg *sync.WaitGroup) {
 
 // Stop stops vmiLatency measurement
 func (p *vmiLatency) stop() error {
+	defer func() {
+		p.vmWatcher.StopWatcher()
+		p.vmiWatcher.StopWatcher()
+		p.vmiPodWatcher.StopWatcher()
+	}()
 	if factory.jobConfig.JobType == config.DeletionJob {
 		return nil
 	}
-	p.vmWatcher.StopWatcher()
-	p.vmiWatcher.StopWatcher()
-	p.vmiPodWatcher.StopWatcher()
 	p.normalizeMetrics()
 	p.calcQuantiles()
 	err := metrics.CheckThreshold(p.config.LatencyThresholds, p.latencyQuantiles)
@@ -395,23 +397,12 @@ func (p *vmiLatency) stop() error {
 }
 
 // index sends metrics to the configured indexer
-func (p *vmiLatency) index(indexer indexers.Indexer, jobName string) {
+func (p *vmiLatency) index(jobName string, indexerList []indexers.Indexer) {
 	metricMap := map[string][]interface{}{
 		podLatencyMeasurement:          p.normLatencies,
 		podLatencyQuantilesMeasurement: p.latencyQuantiles,
 	}
-	for metricName, data := range metricMap {
-		indexingOpts := indexers.IndexingOpts{
-			MetricName: fmt.Sprintf("%s-%s", metricName, jobName),
-		}
-		log.Debugf("Indexing [%d] documents", len(data))
-		resp, err := indexer.Index(data, indexingOpts)
-		if err != nil {
-			log.Error(err.Error())
-		} else {
-			log.Info(resp)
-		}
-	}
+	indexLatencyMeasurement(p.config, jobName, metricMap, indexerList)
 }
 
 func (p *vmiLatency) normalizeMetrics() {

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -40,7 +40,7 @@ type Prometheus struct {
 	ConfigSpec     config.Spec
 	metadata       map[string]interface{}
 	embedConfig    bool
-	indexer        indexers.Indexer
+	indexer        *indexers.Indexer
 }
 
 type Job struct {

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -31,16 +31,16 @@ type Auth struct {
 
 // Prometheus describes the prometheus connection
 type Prometheus struct {
-	Client        *prometheus.Prometheus
-	Endpoint      string
-	profileName   string
-	MetricProfile []metricDefinition
-	Step          time.Duration
-	UUID          string
-	ConfigSpec    config.Spec
-	metadata      map[string]interface{}
-	embedConfig   bool
-	indexers      []indexers.Indexer
+	Client         *prometheus.Prometheus
+	Endpoint       string
+	profileName    string
+	MetricProfiles []metricProfile
+	Step           time.Duration
+	UUID           string
+	ConfigSpec     config.Spec
+	metadata       map[string]interface{}
+	embedConfig    bool
+	indexer        indexers.Indexer
 }
 
 type Job struct {
@@ -49,6 +49,11 @@ type Job struct {
 	ChurnStart time.Time
 	ChurnEnd   time.Time
 	JobConfig  config.Job
+}
+
+type metricProfile struct {
+	name    string
+	metrics []metricDefinition
 }
 
 // metricDefinition describes what metrics kube-burner collects

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -49,6 +49,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 		scraperConfig.ConfigSpec.MetricsEndpoints = DecodeMetricsEndpoint(scraperConfig.MetricsEndpoint)
 	}
 	for pos, metricsEndpoint := range scraperConfig.ConfigSpec.MetricsEndpoints {
+		indexer = nil
 		if metricsEndpoint.Type != "" {
 			log.Infof("📁 Creating indexer: %s", metricsEndpoint.Type)
 			indexer, err = indexers.NewIndexer(metricsEndpoint.IndexerConfig)
@@ -64,7 +65,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 				Token:         metricsEndpoint.Token,
 				SkipTLSVerify: metricsEndpoint.PrometheusSkipTLSVerify,
 			}
-			p, err := prometheus.NewPrometheusClient(scraperConfig.ConfigSpec, metricsEndpoint.PrometheusURL, auth, metricsEndpoint.PrometheusStep, metadata, metricsEndpoint.EmbedConfig, *indexer)
+			p, err := prometheus.NewPrometheusClient(scraperConfig.ConfigSpec, metricsEndpoint.PrometheusURL, auth, metricsEndpoint.PrometheusStep, metadata, metricsEndpoint.EmbedConfig, indexer)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -77,13 +77,12 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 			if err != nil {
 				log.Fatal(err)
 			}
+			prometheusClients = append(prometheusClients, p)
 			for _, metricProfile := range metricsEndpoint.Metrics {
 				if err := p.ReadProfile(metricProfile); err != nil {
 					log.Fatal(err.Error())
 				}
-				prometheusClients = append(prometheusClients, p)
 			}
-			prometheusClients = append(prometheusClients, p)
 			for _, alertProfile := range metricsEndpoint.Alerts {
 				if alertM, err = alerting.NewAlertManager(alertProfile, scraperConfig.ConfigSpec.GlobalConfig.UUID, p, metricsEndpoint.EmbedConfig, *indexer); err != nil {
 					log.Fatalf("Error creating alert manager: %s", err)

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -54,15 +54,15 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 	for pos, metricsEndpoint := range scraperConfig.ConfigSpec.MetricsEndpoints {
 		indexer = nil
 		if metricsEndpoint.Type != "" {
-			log.Infof("📁 Creating indexer: %s", metricsEndpoint.Type)
-			indexer, err = indexers.NewIndexer(metricsEndpoint.IndexerConfig)
-			if err != nil {
-				log.Fatalf("Error creating indexer %d: %v", pos, err.Error())
-			}
 			if metricsEndpoint.Alias == "" {
 				indexerAlias = fmt.Sprintf("indexer-%d", pos)
 			} else {
 				indexerAlias = metricsEndpoint.Alias
+			}
+			log.Infof("📁 Creating %s indexer: %s", metricsEndpoint.Type, indexerAlias)
+			indexer, err = indexers.NewIndexer(metricsEndpoint.IndexerConfig)
+			if err != nil {
+				log.Fatalf("Error creating indexer %d: %v", pos, err.Error())
 			}
 			indexerList[indexerAlias] = *indexer
 		}

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -15,6 +15,8 @@
 package metrics
 
 import (
+	"fmt"
+
 	"github.com/cloud-bulldozer/go-commons/indexers"
 	"github.com/kube-burner/kube-burner/pkg/alerting"
 	"github.com/kube-burner/kube-burner/pkg/prometheus"
@@ -29,7 +31,8 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 	}
 	var err error
 	var indexer *indexers.Indexer
-	var indexerList []indexers.Indexer
+	var indexerAlias string
+	indexerList := make(map[string]indexers.Indexer)
 	var prometheusClients []*prometheus.Prometheus
 	var alertM *alerting.AlertManager
 	var alertMs []*alerting.AlertManager
@@ -56,7 +59,12 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 			if err != nil {
 				log.Fatalf("Error creating indexer %d: %v", pos, err.Error())
 			}
-			indexerList = append(indexerList, *indexer)
+			if metricsEndpoint.Alias == "" {
+				indexerAlias = fmt.Sprintf("indexer-%d", pos)
+			} else {
+				indexerAlias = string(metricsEndpoint.Alias)
+			}
+			indexerList[indexerAlias] = *indexer
 		}
 		if metricsEndpoint.PrometheusURL != "" {
 			auth := prometheus.Auth{

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -66,7 +66,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 			}
 			indexerList[indexerAlias] = *indexer
 		}
-		if metricsEndpoint.PrometheusURL != "" {
+		if (len(metricsEndpoint.Metrics) > 0 || len(metricsEndpoint.Alerts) > 0) && metricsEndpoint.PrometheusURL != "" {
 			auth := prometheus.Auth{
 				Username:      metricsEndpoint.Username,
 				Password:      metricsEndpoint.Password,

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -62,7 +62,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 			if metricsEndpoint.Alias == "" {
 				indexerAlias = fmt.Sprintf("indexer-%d", pos)
 			} else {
-				indexerAlias = string(metricsEndpoint.Alias)
+				indexerAlias = metricsEndpoint.Alias
 			}
 			indexerList[indexerAlias] = *indexer
 		}

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -73,7 +73,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 				Token:         metricsEndpoint.Token,
 				SkipTLSVerify: metricsEndpoint.PrometheusSkipTLSVerify,
 			}
-			p, err := prometheus.NewPrometheusClient(scraperConfig.ConfigSpec, metricsEndpoint.PrometheusURL, auth, metricsEndpoint.PrometheusStep, metadata, metricsEndpoint.EmbedConfig, indexer)
+			p, err := prometheus.NewPrometheusClient(*scraperConfig.ConfigSpec, metricsEndpoint.PrometheusURL, auth, metricsEndpoint.PrometheusStep, metadata, metricsEndpoint.EmbedConfig, indexer)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/util/metrics/types.go
+++ b/pkg/util/metrics/types.go
@@ -34,6 +34,6 @@ type ScraperConfig struct {
 type Scraper struct {
 	PrometheusClients []*prometheus.Prometheus
 	AlertMs           []*alerting.AlertManager
-	IndexerList       []indexers.Indexer
+	IndexerList       map[string]indexers.Indexer
 	Metadata          map[string]interface{}
 }

--- a/pkg/util/metrics/types.go
+++ b/pkg/util/metrics/types.go
@@ -15,8 +15,6 @@
 package metrics
 
 import (
-	"time"
-
 	"github.com/cloud-bulldozer/go-commons/indexers"
 	"github.com/kube-burner/kube-burner/pkg/alerting"
 	"github.com/kube-burner/kube-burner/pkg/config"
@@ -26,15 +24,7 @@ import (
 // ScraperConfig holds data related to scraper and target indexer
 type ScraperConfig struct {
 	ConfigSpec      config.Spec
-	Password        string
-	PrometheusStep  time.Duration
 	MetricsEndpoint string
-	MetricsProfiles []string
-	AlertProfiles   []string
-	SkipTLSVerify   bool
-	URL             string
-	Token           string
-	Username        string
 	UserMetaData    string
 	RawMetadata     map[string]interface{}
 	EmbedConfig     bool
@@ -46,15 +36,4 @@ type Scraper struct {
 	AlertMs           []*alerting.AlertManager
 	IndexerList       []indexers.Indexer
 	Metadata          map[string]interface{}
-}
-
-// metricEndpoint describes prometheus endpoint to scrape
-type metricEndpoint struct {
-	Endpoint     string `yaml:"endpoint"`
-	Token        string `yaml:"token"`
-	Profile      string `yaml:"profile"`
-	AlertProfile string `yaml:"alertProfile"`
-	Username     string `yaml:"username"`
-	Password     string `yaml:"password"`
-	EmbedConfig  bool   `yaml:"embedConfig"`
 }

--- a/pkg/util/metrics/types.go
+++ b/pkg/util/metrics/types.go
@@ -23,7 +23,7 @@ import (
 
 // ScraperConfig holds data related to scraper and target indexer
 type ScraperConfig struct {
-	ConfigSpec      config.Spec
+	ConfigSpec      *config.Spec
 	MetricsEndpoint string
 	UserMetaData    string
 	RawMetadata     map[string]interface{}

--- a/pkg/util/metrics/utils.go
+++ b/pkg/util/metrics/utils.go
@@ -18,28 +18,31 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
 // Decodes metrics endpoint yaml file
-func DecodeMetricsEndpoint(metricsEndpoint string, metricsEndpoints *[]metricEndpoint) {
-	f, err := util.ReadConfig(metricsEndpoint)
+func DecodeMetricsEndpoint(metricsEndpointPath string) []config.MetricsEndpoint {
+	var metricsEndpoints []config.MetricsEndpoint
+	f, err := util.ReadConfig(metricsEndpointPath)
 	if err != nil {
-		log.Fatalf("Error reading metricsEndpoint %s: %s", metricsEndpoint, err)
+		log.Fatalf("Error reading metricsEndpoint %s: %s", metricsEndpointPath, err)
 	}
 	cfg, err := io.ReadAll(f)
 	if err != nil {
-		log.Fatalf("Error reading configuration file %s: %s", metricsEndpoint, err)
+		log.Fatalf("Error reading configuration file %s: %s", metricsEndpointPath, err)
 	}
 	renderedME, err := util.RenderTemplate(cfg, util.EnvToMap(), util.MissingKeyError)
 	if err != nil {
-		log.Fatalf("Template error in %s: %s", metricsEndpoint, err)
+		log.Fatalf("Template error in %s: %s", metricsEndpointPath, err)
 	}
 	yamlDec := yaml.NewDecoder(bytes.NewReader(renderedME))
 	yamlDec.KnownFields(true)
 	if err := yamlDec.Decode(&metricsEndpoints); err != nil {
-		log.Fatalf("Error decoding metricsEndpoint %s: %s", metricsEndpoint, err)
+		log.Fatalf("Error decoding metricsEndpoint %s: %s", metricsEndpointPath, err)
 	}
+	return metricsEndpoints
 }

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -50,7 +50,7 @@ func NewWorkloadHelper(config Config, embedConfig embed.FS, kubeClientProvider *
 	return wh
 }
 
-func (wh *WorkloadHelper) Run(workload string, metricsProfiles []string, alertsProfiles []string) {
+func (wh *WorkloadHelper) Run(workload string) {
 	var f io.Reader
 	var rc int
 	var err error
@@ -88,15 +88,14 @@ func (wh *WorkloadHelper) Run(workload string, metricsProfiles []string, alertsP
 		ConfigSpec.EmbedFS = wh.embedConfig
 		ConfigSpec.EmbedFSDir = path.Join(wh.ConfigDir, workload)
 	}
+	// Overwrite credentials
+	for pos, _ := range ConfigSpec.MetricsEndpoints {
+		ConfigSpec.MetricsEndpoints[pos].PrometheusURL = wh.PrometheusURL
+		ConfigSpec.MetricsEndpoints[pos].PrometheusURL = wh.PrometheusToken
+	}
 	metricsScraper = metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
 		ConfigSpec:      ConfigSpec,
-		PrometheusStep:  stepSize,
 		MetricsEndpoint: wh.MetricsEndpoint,
-		MetricsProfiles: metricsProfiles,
-		AlertProfiles:   alertsProfiles,
-		SkipTLSVerify:   true,
-		URL:             wh.PrometheusURL,
-		Token:           wh.PrometheusToken,
 		RawMetadata:     wh.MetricsMetadata,
 		EmbedConfig:     embedConfig,
 	})

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -94,7 +94,7 @@ func (wh *WorkloadHelper) Run(workload string) {
 		ConfigSpec.MetricsEndpoints[pos].PrometheusURL = wh.PrometheusToken
 	}
 	metricsScraper = metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
-		ConfigSpec:      ConfigSpec,
+		ConfigSpec:      &ConfigSpec,
 		MetricsEndpoint: wh.MetricsEndpoint,
 		RawMetadata:     wh.MetricsMetadata,
 		EmbedConfig:     embedConfig,

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -89,6 +89,17 @@ check_file_list() {
   return 0
 }
 
+check_files_dont_exist() {
+  for f in "${@}"; do
+    if [[ -f ${f} ]]; then
+      echo "File ${f} found"
+      return 1
+    fi
+  done
+  return 0
+}
+
+
 print_events() {
   kubectl get events --sort-by='.lastTimestamp' -A
 }

--- a/test/k8s/kube-burner-delete.yml
+++ b/test/k8s/kube-burner-delete.yml
@@ -4,15 +4,21 @@ global:
   measurements:
   - name: podLatency
 
-indexers:
+metricsEndpoints:
 {{ if .ES_INDEXING }}
-  - type: opensearch
-    esServers: ["{{ .ES_SERVER }}"]
-    defaultIndex: {{ .ES_INDEX }}
+  - prometheusURL: http://localhost:9090
+    indexer: 
+      type: opensearch
+      esServers: ["{{ .ES_SERVER }}"]
+      defaultIndex: {{ .ES_INDEX }}
+    metrics: [metrics-profile.yaml]
 {{ end }}
 {{ if .LOCAL_INDEXING }}
-  - type: local
-    metricsDirectory: {{ .METRICS_FOLDER }}
+  - prometheusURL: http://localhost:9090
+    indexer: 
+      type: local
+      metricsDirectory: {{ .METRICS_FOLDER }}
+    metrics: [metrics-profile.yaml]
 {{ end }}
 
 jobs:

--- a/test/k8s/kube-burner-read.yml
+++ b/test/k8s/kube-burner-read.yml
@@ -1,13 +1,19 @@
 ---
-indexers:
+metricsEndpoints:
 {{ if .ES_INDEXING }}
-  - type: opensearch
-    esServers: ["{{ .ES_SERVER }}"]
-    defaultIndex: {{ .ES_INDEX }}
+  - prometheusURL: http://localhost:9090
+    indexer: 
+      type: opensearch
+      esServers: ["{{ .ES_SERVER }}"]
+      defaultIndex: {{ .ES_INDEX }}
+    metrics: [metrics-profile.yaml]
 {{ end }}
 {{ if .LOCAL_INDEXING }}
-  - type: local
-    metricsDirectory: {{ .METRICS_FOLDER }}
+  - prometheusURL: http://localhost:9090
+    indexer: 
+      type: local
+      metricsDirectory: {{ .METRICS_FOLDER }}
+    metrics: [metrics-profile.yaml]
 {{ end }}
 
 jobs:

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -6,15 +6,27 @@ global:
   - name: podLatency
   - name: serviceLatency
     svcTimeout: 5s
-indexers:
+metricsEndpoints:
 {{ if .ES_INDEXING }}
-  - type: opensearch
-    esServers: ["{{ .ES_SERVER }}"]
-    defaultIndex: {{ .ES_INDEX }}
+  - prometheusURL: http://localhost:9090
+    indexer: 
+      type: opensearch
+      esServers: ["{{ .ES_SERVER }}"]
+      defaultIndex: {{ .ES_INDEX }}
+    metrics: [metrics-profile.yaml]
+{{ if .ALERTING }}
+    alerts: [alert-profile.yaml]
+{{ end }}
 {{ end }}
 {{ if .LOCAL_INDEXING }}
-  - type: local
-    metricsDirectory: {{ .METRICS_FOLDER }}
+  - prometheusURL: http://localhost:9090
+    indexer: 
+      type: local
+      metricsDirectory: {{ .METRICS_FOLDER }}
+    metrics: [metrics-profile.yaml]
+{{ if .ALERTING }}
+    alerts: [alert-profile.yaml]
+{{ end }}
 {{ end }}
 
 jobs:

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -12,7 +12,6 @@ global:
 metricsEndpoints:
 {{ if .ES_INDEXING }}
   - prometheusURL: http://localhost:9090
-    alias: my-opensearch
     indexer:
       type: opensearch
       esServers: ["{{ .ES_SERVER }}"]

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -12,8 +12,8 @@ global:
 metricsEndpoints:
 {{ if .ES_INDEXING }}
   - prometheusURL: http://localhost:9090
+    alias: my-opensearch
     indexer:
-      alias: my-opensearch
       type: opensearch
       esServers: ["{{ .ES_SERVER }}"]
       defaultIndex: {{ .ES_INDEX }}

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -4,12 +4,16 @@ global:
   gc: {{env "GC"}}
   measurements:
   - name: podLatency
+{{ if .TIMESERIES_INDEXER }}
+    timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
+{{ end }}
   - name: serviceLatency
     svcTimeout: 5s
 metricsEndpoints:
 {{ if .ES_INDEXING }}
   - prometheusURL: http://localhost:9090
-    indexer: 
+    indexer:
+      alias: my-opensearch
       type: opensearch
       esServers: ["{{ .ES_SERVER }}"]
       defaultIndex: {{ .ES_INDEX }}

--- a/test/k8s/metrics-endpoints.yaml
+++ b/test/k8s/metrics-endpoints.yaml
@@ -1,4 +1,5 @@
 - prometheusURL: http://localhost:9090
+  alias: os-indexing
   indexer:
     type: opensearch
     esServers: ["{{ .ES_SERVER }}"]
@@ -8,7 +9,6 @@
   alerts:
   - alert-profile.yaml
 - prometheusURL: http://localhost:9090
-  alias: local-indexing
   indexer:
     type: local
     metricsDirectory: {{ .METRICS_FOLDER }}

--- a/test/k8s/metrics-endpoints.yaml
+++ b/test/k8s/metrics-endpoints.yaml
@@ -8,6 +8,7 @@
   alerts:
   - alert-profile.yaml
 - prometheusURL: http://localhost:9090
+  alias: local-indexing
   indexer:
     type: local
     metricsDirectory: {{ .METRICS_FOLDER }}

--- a/test/k8s/metrics-endpoints.yaml
+++ b/test/k8s/metrics-endpoints.yaml
@@ -1,5 +1,15 @@
-- endpoint: http://localhost:9090
-  profile: metrics-profile.yaml
-  alertProfile: alert-profile.yaml
-- endpoint: http://localhost:9090
-  profile: metrics-profile.yaml
+- prometheusURL: http://localhost:9090
+  indexer:
+    type: opensearch
+    esServers: ["{{ .ES_SERVER }}"]
+    defaultIndex: {{ .ES_INDEX }}
+  metrics:
+  - metrics-profile.yaml
+  alerts:
+  - alert-profile.yaml
+- prometheusURL: http://localhost:9090
+  indexer:
+    type: local
+    metricsDirectory: {{ .METRICS_FOLDER }}
+  metrics:
+  - metrics-profile.yaml

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -79,7 +79,7 @@ teardown_file() {
 }
 
 @test "kube-burner init: os-indexing=true; local-indexing=true; metrics-endpoint=true" {
-  export ES_INDEXING=true LOCAL_INDEXING=true TIMESERIES_INDEXER=my-opensearch
+  export ES_INDEXING=true LOCAL_INDEXING=true TIMESERIES_INDEXER=local-indexing
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug -e metrics-endpoints.yaml
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement alerts
   check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -79,7 +79,7 @@ teardown_file() {
 }
 
 @test "kube-burner init: os-indexing=true; local-indexing=true; metrics-endpoint=true" {
-  export ES_INDEXING=true LOCAL_INDEXING=true TIMESERIES_INDEXER=local-indexing
+  export ES_INDEXING=true LOCAL_INDEXING=true TIMESERIES_INDEXER=os-indexing
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug -e metrics-endpoints.yaml
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement alerts
   check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -28,6 +28,7 @@ setup() {
   export ES_INDEXING=""
   export LOCAL_INDEXING=""
   export ALERTING=""
+  export TIMESERIES_INDEXER=""
 }
 
 teardown() {
@@ -78,10 +79,11 @@ teardown_file() {
 }
 
 @test "kube-burner init: os-indexing=true; local-indexing=true; metrics-endpoint=true" {
-  export ES_INDEXING=true LOCAL_INDEXING=true
+  export ES_INDEXING=true LOCAL_INDEXING=true TIMESERIES_INDEXER=my-opensearch
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug -e metrics-endpoints.yaml
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement alerts
-  check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
+  check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
+  check_files_dont_exist ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -27,6 +27,7 @@ setup() {
   export METRICS_FOLDER="metrics-${UUID}"
   export ES_INDEXING=""
   export LOCAL_INDEXING=""
+  export ALERTING=""
 }
 
 teardown() {
@@ -67,10 +68,11 @@ teardown_file() {
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }
 
-@test "kube-burner init: os-indexing=true; alerting=true"  {
-  export ES_INDEXING=true
-  run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug -u http://localhost:9090 -m metrics-profile.yaml -a alert-profile.yaml
+@test "kube-burner init: os-indexing=true; local-indexing=true; alerting=true"  {
+  export ES_INDEXING=true LOCAL_INDEXING=true ALERTING=true
+  run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement alert
+  check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }
@@ -78,7 +80,7 @@ teardown_file() {
 @test "kube-burner init: os-indexing=true; local-indexing=true; metrics-endpoint=true" {
   export ES_INDEXING=true LOCAL_INDEXING=true
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug -e metrics-endpoints.yaml
-  check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement
+  check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement alerts
   check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
@@ -92,7 +94,8 @@ teardown_file() {
 
 @test "kube-burner index: metrics-endpoint=true; os-indexing=true" {
   run_cmd kube-burner index --uuid="${UUID}" -e metrics-endpoints.yaml --es-server=${ES_SERVER} --es-index=${ES_INDEX}
-  check_metric_value top2PrometheusCPU prometheusRSS
+  check_metric_value top2PrometheusCPU prometheusRSS jobSummary alerts
+  check_file_list collected-metrics/top2PrometheusCPU.json collected-metrics/prometheusRSS.json collected-metrics/prometheusRSS.json
 }
 
 @test "kube-burner init: crd" {
@@ -104,7 +107,7 @@ teardown_file() {
 
 @test "kube-burner init: delete=true; os-indexing=true; local-indexing=true" {
   export ES_INDEXING=true LOCAL_INDEXING=true
-  run_cmd kube-burner init -c kube-burner-delete.yml --uuid "${UUID}" --log-level=debug -u http://localhost:9090 -m metrics-profile.yaml
+  run_cmd kube-burner init -c kube-burner-delete.yml --uuid "${UUID}" --log-level=debug
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement
   check_file_list ${METRICS_FOLDER}/jobSummary-delete-job.json ${METRICS_FOLDER}/podLatencyMeasurement-delete-job.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-delete-job.json ${METRICS_FOLDER}/prometheusBuildInfo.json
@@ -112,7 +115,7 @@ teardown_file() {
 
 @test "kube-burner init: read; os-indexing=true; local-indexing=true" {
   export ES_INDEXING=true LOCAL_INDEXING=true
-  run_cmd kube-burner init -c kube-burner-read.yml --uuid "${UUID}" --log-level=debug -u http://localhost:9090 -m metrics-profile.yaml
+  run_cmd kube-burner init -c kube-burner-read.yml --uuid "${UUID}" --log-level=debug
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement
   check_file_list ${METRICS_FOLDER}/jobSummary-read-job.json ${METRICS_FOLDER}/prometheusBuildInfo.json
 }


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [x] Documentation Update

## Description

Multiple changes with the goal to adopt the updated version the `metricsEndpoints` API in the configuration file and link metrics, alerts (supporting multiple files now) and measurements to indexers:

With this change the configuration file now looks like:

```yaml
metricsEndpoints:
- prometheusURL: http://localhost:9090
  token: blablabla
  indexer: 
    type: opensearch
    esServers: ["https://es-instance.com:9200"]
    defaultIndex: kube-burner
  metrics: [metrics-profile.yaml]
  alerts: [alert-profile.yaml]
- prometheusURL: http://localhost:9090
  token: blablabla
  indexer: 
    type: local
  metrics: [metrics-profile.yaml]
  alerts: [alert-profile.yaml]
```

Another important feature is that now It's possible to "split" the measurement metrics and send them to different indexers thanks to the new fields _timeseriesIndexer_ and _quantilesIndexer_. i.e:

```yaml
metricsEndpoints:
- indexer:
    type: local
    alias: local-indexer
- indexer:
    type: opensearch
    defaultIndex: kube-burner
    esServers: ["https://opensearch.domain:9200"]
    alias: opensearch-indexer
global:
  measurements:
  - name: podLatency
    timeseriesIndexer: local-indexer
    quantilesIndexer: opensearch-indexer
```

With the snippet above, the measurement `podLatency` would use the local indexer for timeseries metrics and opensearch for the quantile metrics. cc: @afcollins 

## Related Tickets & Documents

- Related Issue #
- Closes #
