### PR TITLE
Bug fix for OCP clustermetadata indexing

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -54,6 +54,10 @@ func NewPrometheusClient(configSpec config.Spec, url string, auth Auth, step tim
 
 // ScrapeJobsMetrics gets all prometheus metrics required and handles them
 func (p *Prometheus) ScrapeJobsMetrics(jobList ...Job) error {
+	if len(p.indexers) == 0 {
+		log.Debug("Indexing not required for this run")
+		return nil
+	}
 	docsToIndex := make(map[string][]interface{})
 	start := jobList[0].Start
 	end := jobList[len(jobList)-1].End

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -35,12 +35,14 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 	}
 	metadata := make(map[string]interface{})
 	for pos, indexer := range scraperConfig.ConfigSpec.Indexers {
-		log.Infof("📁 Creating indexer: %s", indexer.Type)
-		idx, err := indexers.NewIndexer(indexer.IndexerConfig)
-		if err != nil {
-			log.Fatalf("Error creating indexer %d: %v", pos, err.Error())
+		if indexer.Type != "" {
+			log.Infof("📁 Creating indexer: %s", indexer.Type)
+			idx, err := indexers.NewIndexer(indexer.IndexerConfig)
+			if err != nil {
+				log.Fatalf("Error creating indexer %d: %v", pos, err.Error())
+			}
+			indexerList = append(indexerList, *idx)
 		}
-		indexerList = append(indexerList, *idx)
 	}
 	if scraperConfig.UserMetaData != "" {
 		metadata, err = util.ReadUserMetadata(scraperConfig.UserMetaData)

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -36,7 +36,6 @@ const (
 )
 
 var ConfigSpec config.Spec
-var indexer *indexers.Indexer
 
 // NewWorkloadHelper initializes workloadHelper
 func NewWorkloadHelper(config Config, embedConfig embed.FS, kubeClientProvider *config.KubeClientProvider) WorkloadHelper {
@@ -107,7 +106,7 @@ func (wh *WorkloadHelper) Run(workload string, metricsProfiles []string, alertsP
 		log.Error(err)
 	}
 	wh.Metadata.Passed = rc == 0
-	if indexer != nil {
+	for _, indexer := range metricsScraper.IndexerList {
 		IndexMetadata(indexer, wh.Metadata)
 	}
 	log.Info("👋 Exiting kube-burner ", wh.UUID)
@@ -141,10 +140,10 @@ func ExtractWorkload(embedConfig embed.FS, configDir string, workload string, ro
 }
 
 // IndexMetadata indexes metadata using given indexer.
-func IndexMetadata(indexer *indexers.Indexer, metadata BenchmarkMetadata) {
+func IndexMetadata(indexer indexers.Indexer, metadata BenchmarkMetadata) {
 	log.Info("Indexing cluster metadata document")
 	metadata.EndDate = time.Now().UTC()
-	msg, err := (*indexer).Index([]interface{}{metadata}, indexers.IndexingOpts{
+	msg, err := (indexer).Index([]interface{}{metadata}, indexers.IndexingOpts{
 		MetricName: metadata.MetricName,
 	})
 	if err != nil {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixing leftover bug through:https://github.com/kube-burner/kube-burner/pull/602, which was not publishing clusterMetadata due to nil value being populated in indexer variable.

## Testing
Tested integrating with OCP wrapper. My own release verified in this PR: https://github.com/kube-burner/kube-burner-ocp/pull/33/files 
