### PR TITLE
Removing jobConfig from the metrics

### DIFF
--- a/pkg/measurements/metrics/metrics.go
+++ b/pkg/measurements/metrics/metrics.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/measurements/types"
 	"github.com/montanaflynn/stats"
 	log "github.com/sirupsen/logrus"
@@ -37,7 +36,6 @@ type LatencyQuantiles struct {
 	Avg          int         `json:"avg"`
 	Timestamp    time.Time   `json:"timestamp"`
 	MetricName   string      `json:"metricName"`
-	JobConfig    config.Job  `json:"jobConfig"`
 	Metadata     interface{} `json:"metadata,omitempty"`
 }
 

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
-	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/measurements/metrics"
 	"github.com/kube-burner/kube-burner/pkg/measurements/types"
 	log "github.com/sirupsen/logrus"
@@ -49,7 +48,6 @@ type podMetric struct {
 	podReady               time.Time
 	PodReadyLatency        int         `json:"podReadyLatency"`
 	MetricName             string      `json:"metricName"`
-	JobConfig              config.Job  `json:"jobConfig"`
 	UUID                   string      `json:"uuid"`
 	Namespace              string      `json:"namespace"`
 	Name                   string      `json:"podName"`
@@ -83,7 +81,6 @@ func (p *podLatency) handleCreatePod(obj interface{}) {
 			Name:       pod.Name,
 			MetricName: podLatencyMeasurement,
 			UUID:       globalCfg.UUID,
-			JobConfig:  *factory.jobConfig,
 			Metadata:   factory.metadata,
 		}
 	}
@@ -214,7 +211,6 @@ func (p *podLatency) collect(measurementWg *sync.WaitGroup) {
 			MetricName:      podLatencyMeasurement,
 			NodeName:        pod.Spec.NodeName,
 			UUID:            globalCfg.UUID,
-			JobConfig:       *factory.jobConfig,
 			Metadata:        factory.metadata,
 			scheduled:       scheduled,
 			initialized:     initialized,
@@ -335,7 +331,6 @@ func (p *podLatency) calcQuantiles() {
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
 		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
 		latencySummary.UUID = globalCfg.UUID
-		latencySummary.JobConfig = *factory.jobConfig
 		latencySummary.Metadata = factory.metadata
 		latencySummary.MetricName = podLatencyQuantilesMeasurement
 		return latencySummary

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
-	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/measurements/metrics"
 	"github.com/kube-burner/kube-burner/pkg/measurements/types"
 	"github.com/kube-burner/kube-burner/pkg/measurements/util"
@@ -58,7 +57,6 @@ type svcMetric struct {
 	IPAssignedLatency time.Duration      `json:"ipAssigned,omitempty"`
 	ReadyLatency      time.Duration      `json:"ready"`
 	MetricName        string             `json:"metricName"`
-	JobConfig         config.Job         `json:"jobConfig"`
 	UUID              string             `json:"uuid"`
 	Namespace         string             `json:"namespace"`
 	Name              string             `json:"service"`
@@ -168,7 +166,6 @@ func (s *serviceLatency) handleCreateSvc(obj interface{}) {
 			MetricName:        svcLatencyMetric,
 			ServiceType:       svc.Spec.Type,
 			ReadyLatency:      svcLatency,
-			JobConfig:         *factory.jobConfig,
 			UUID:              globalCfg.UUID,
 			Metadata:          factory.metadata,
 			IPAssignedLatency: ipAssignedLatency,
@@ -259,7 +256,6 @@ func (s *serviceLatency) normalizeMetrics() {
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
 		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
 		latencySummary.UUID = globalCfg.UUID
-		latencySummary.JobConfig = *factory.jobConfig
 		latencySummary.Timestamp = time.Now().UTC()
 		latencySummary.Metadata = factory.metadata
 		latencySummary.MetricName = svcLatencyQuantilesMeasurement

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -72,7 +72,6 @@ type vmiMetric struct {
 	VMReadyLatency int `json:"vmReadyLatency"`
 
 	MetricName string      `json:"metricName"`
-	JobConfig  config.Job  `json:"jobConfig"`
 	Metadata   interface{} `json:"metadata,omitempty"`
 	UUID       string      `json:"uuid"`
 	Namespace  string      `json:"namespace"`
@@ -107,7 +106,6 @@ func (p *vmiLatency) handleCreateVM(obj interface{}) {
 				Name:       vm.Name,
 				MetricName: vmiLatencyMeasurement,
 				UUID:       globalCfg.UUID,
-				JobConfig:  *factory.jobConfig,
 				Metadata:   factory.metadata,
 			}
 		}
@@ -463,7 +461,6 @@ func (p *vmiLatency) calcQuantiles() {
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
 		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
 		latencySummary.UUID = globalCfg.UUID
-		latencySummary.JobConfig = *factory.jobConfig
 		latencySummary.Metadata = factory.metadata
 		latencySummary.MetricName = podLatencyQuantilesMeasurement
 		return latencySummary

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -168,7 +168,6 @@ func (p *Prometheus) createMetric(query, metricName string, job Job, labels mode
 		UUID:       p.UUID,
 		Query:      query,
 		MetricName: metricName,
-		JobConfig:  job.JobConfig,
 		Timestamp:  timestamp,
 		Metadata:   p.metadata,
 	}

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -66,6 +66,5 @@ type metric struct {
 	Query       string            `json:"query"`
 	ChurnMetric bool              `json:"churnMetric,omitempty"`
 	MetricName  string            `json:"metricName,omitempty"`
-	JobConfig   config.Job        `json:"jobConfig,omitempty"`
 	Metadata    interface{}       `json:"metadata,omitempty"`
 }


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Keeping `jobConfig` only in the `jobSummary` document and removing from rest of the metrics. This field is redundant and is not used anywhere including our grafana dashboards.

Verified that there wouldn't be any impact in all our grafana dashboards as the existing queries can get required UUIDs from the `jobConfig` and `metadata` fields present in the `jobSummary` document which should be sufficient enough.

Analysis proving the above statement: https://gist.github.com/vishnuchalla/33ec9ef9861c458cc3378d3d92eaca50

Also one more advantage of doing this is, its going to reduce around `40%` of space occupied by kube-burner elastic search indices. Example

#### **Size of current list of docs with `jobConfig` field included**
```
[vchalla@vchalla-thinkpadp1gen2 collected-metrics-vchalla-testmar30regular]$ du -sh
9.0M	
```
#### **Size of same list of docs without `jobConfig` field**
```
[vchalla@vchalla-thinkpadp1gen2 collected-metrics-vchalla-testmar30woconfigregular]$ du -sh
3.8M
```

## Related Tickets & Documents

- Related Issue: https://github.com/kube-burner/kube-burner/issues/606

## Testing
Tested in local dev environment using a self managed AWS cluster.
```
kube-burner-ocp cluster-density-v2 --iterations=5 --profile-type=regular --user-metadata=user-metadata.yml --uuid=vchalla-testmar30woconfigregular --local-indexing --alerting=true --qps=20 ooburst=20 --churn-cycles=1
```
#### Before this change
```
[vchalla@vchalla-thinkpadp1gen2 collected-metrics-vchalla-testmar30regular]$ cat * | jq 'try .[].jobConfig catch null' | grep -i '{' | wc -l
7701
```
We had this field redundantly in 7701 docs. Also attaching grafana snapshot: https://snapshots.raintank.io/dashboard/snapshot/zfxz7YowxwJjc5tmqArzxUj27DP0PYNh

#### After this change
```
[vchalla@vchalla-thinkpadp1gen2 collected-metrics-vchalla-testmar30woconfigregular]$ cat * | jq 'try .[].jobConfig catch null' | grep -i '{' | wc -l
1
```
Now we only have a single document that has `jobConfig` which is the summary. Also attaching grafana snapshot: https://snapshots.raintank.io/dashboard/snapshot/A8gVFQvtfUWWnV3JeT4Z4icwNH948uNc
```
[vchalla@vchalla-thinkpadp1gen2 collected-metrics-vchalla-testmar30woconfigregular]$ cat jobSummary-cluster-density-v2.json | jq
[
  {
    "timestamp": "2024-03-30T19:13:49.031276772Z",
    "endTimestamp": "2024-03-30T19:17:08.117754135Z",
    "churnStartTimestamp": "2024-03-30T19:14:08.835201353Z",
    "churnEndTimestamp": "2024-03-30T19:17:08.1177425Z",
    "elapsedTime": 199,
    "uuid": "vchalla-testmar30woconfigregular",
    "metricName": "jobSummary",
    "jobConfig": {
      "jobIterations": 5,
      "name": "cluster-density-v2",
      "jobType": "create",
      "qps": 20,
      "burst": 20,
      "namespace": "cluster-density-v2",
      "maxWaitTimeout": 14400000000000,
      "waitForDeletion": true,
      "waitWhenFinished": true,
      "cleanup": true,
      "namespacedIterations": true,
      "iterationsPerNamespace": 1,
      "verifyObjects": true,
      "errorOnVerify": true,
      "preLoadImages": true,
      "preLoadPeriod": 15000000000,
      "churn": true,
      "churnCycles": 1,
      "churnPercent": 10,
      "churnDuration": 3600000000000,
      "churnDelay": 120000000000,
      "churnDeletionStrategy": "default"
    },
    "metadata": {
      "cloud-bulldozer": true,
      "k8sVersion": "v1.28.6+6216ea1",
      "ocpMajorVersion": "4.15",
      "ocpVersion": "4.15.0",
      "platform": "AWS",
      "sdnType": "OVNKubernetes",
      "totalNodes": 6
    },
    "version": "main@e53cdd828cd7356244803c06ca38fcc42f5e3d21"
  }
]
```