### PR TITLE
Improve pod waiter

### DIFF
--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -31,7 +31,6 @@ One document, such as the following, is indexed per each pod created by the work
   "namespace": "kubelet-density",
   "podName": "kubelet-density-13",
   "nodeName": "worker-001",
-  "jobConfig": {"config": "params"}
 }
 ```
 
@@ -50,9 +49,6 @@ Pod latency quantile sample:
   "avg": 2876.3,
   "timestamp": "2020-11-15T22:26:51.553221077+01:00",
   "metricName": "podLatencyQuantilesMeasurement",
-  "jobConfig": {
-    "config": "params"
-  }
 },
 {
   "quantileName": "PodScheduled",
@@ -64,9 +60,6 @@ Pod latency quantile sample:
   "avg": 5.38,
   "timestamp": "2020-11-15T22:26:51.553225151+01:00",
   "metricName": "podLatencyQuantilesMeasurement",
-  "jobConfig": {
-    "config": "params"
-  }
 }
 ```
 
@@ -182,9 +175,6 @@ The metrics collected are service latency timeseries (`svcLatencyMeasurement`) a
   "timestamp": "2023-11-19T00:41:51Z",
   "ready": 1631880721,
   "metricName": "svcLatencyMeasurement",
-  "jobConfig": {
-    "config": "params"
-  },
   "uuid": "c4558ba8-1e29-4660-9b31-02b9f01c29bf",
   "namespace": "cluster-density-v2-2",
   "service": "cluster-density-1",
@@ -208,9 +198,6 @@ And the quantiles document has the structure:
   "avg": 1722308938,
   "timestamp": "2023-11-19T00:42:26.663991359Z",
   "metricName": "svcLatencyQuantilesMeasurement",
-  "jobConfig": {
-    "config": "params"
-  }
 },
 {
   "quantileName": "LoadBalancer",
@@ -222,9 +209,6 @@ And the quantiles document has the structure:
   "avg": 1822308938,
   "timestamp": "2023-11-19T00:42:26.663991359Z",
   "metricName": "svcLatencyQuantilesMeasurement",
-  "jobConfig": {
-    "config": "params"
-  }
 }
 ```
 

--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -76,20 +76,10 @@ This document looks like:
     "jobIterationDelay": 0,
     "jobPause": 0,
     "name": "kubelet-density",
-    "objects": [
-      {
-        "objectTemplate": "templates/pod.yml",
-        "replicas": 1,
-        "inputVars": {
-          "containerImage": "registry.k8s.io/pause:3.1"
-        }
-      }
-    ],
     "jobType": "create",
     "qps": 5,
     "burst": 5,
     "namespace": "kubelet-density",
-    "waitFor": null,
     "maxWaitTimeout": 43200000000000,
     "waitForDeletion": true,
     "podWait": false,

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -45,9 +45,6 @@ The collected metrics have the following shape:
     "uuid": "<UUID>",
     "query": "sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0",
     "metricName": "nodeCPU",
-    "jobConfig": {
-      "truncated_job_configuration": "foobar"
-    }
   },
   {
     "timestamp": "2021-06-23T11:50:45+02:00",
@@ -59,14 +56,11 @@ The collected metrics have the following shape:
     "uuid": "<UUID>",
     "query": "sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0",
     "metricName": "nodeCPU",
-    "jobConfig": {
-      "truncated_job_configuration": "foobar"
-    }
   }
 ]
 ```
 
-Notice that kube-burner enriches the query results by adding some extra fields like `uuid`, `query`, `metricName` and `jobConfig`.
+Notice that kube-burner enriches the query results by adding some extra fields like `uuid`, `query` and `metricName`.
 !!! info
     These extra fields are especially useful at the time of identifying and representing the collected metrics.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -30,7 +30,7 @@ In this section is described global job configuration, it holds the following pa
 | `gc`               | Garbage collect created namespaces                                                                       | Boolean        | false      |
 | `gcMetrics`        | Flag to collect metrics during garbage collection                                                        | Boolean        |      false      |
 | `gcTimeout`               | Garbage collection timeout                                                                       | Duration        | 1h   |
-| `waitWhenFinished` | Wait for all pods to be running when all jobs are completed                                             | Boolean        | false      |
+| `waitWhenFinished` | Wait for all pods/jobs (including probes) to be running/completed when all jobs are completed           | Boolean  | false   |
 | `clusterHealth` | Checks if all the nodes are in "Ready" state                                             | Boolean        | false      |
 
 !!! note
@@ -55,8 +55,8 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | `namespacedIterations`   | Whether to create a namespace per job iteration                                                                                   | Boolean  | true    |
 | `iterationsPerNamespace` | The maximum number of `jobIterations` to create in a single namespace. Important for node-density workloads that create Services. | Integer  | 1       |
 | `cleanup`                | Cleanup clean up old namespaces                                                                                                   | Boolean  | true    |
-| `podWait`                | Wait for all pods to be running before moving forward to the next job iteration                                                   | Boolean  | false   |
-| `waitWhenFinished`       | Wait for all pods to be running when all iterations are completed                                                                 | Boolean  | true    |
+| `podWait`                | Wait for all pods/jobs (including probes) to be running/completed before moving forward to the next job iteration                 | Boolean  | false   |
+| `waitWhenFinished`       | Wait for all pods/jobs (including probes) to be running/completed when all job iterations are completed                           | Boolean  | true    |
 | `maxWaitTimeout`         | Maximum wait timeout per namespace                                                                                                | Duration | 4h      |
 | `jobIterationDelay`      | How long to wait between each job iteration. This is also the wait interval between each delete operation                         | Duration | 0s      |
 | `jobPause`               | How long to pause after finishing the job                                                                                         | Duration | 0s      |

--- a/examples/workloads/kubelet-density-heavy/kubelet-density-heavy.yml
+++ b/examples/workloads/kubelet-density-heavy/kubelet-density-heavy.yml
@@ -1,17 +1,18 @@
 ---
 global:
-    type: elastic
+  gc: true
   measurements:
     - name: podLatency
 
 jobs:
   - name: kubelet-density-heavy
-    jobIterations: 280
-    qps: 25
-    burst: 25
+    jobIterations: 10
+    qps: 10
+    burst: 10
     namespacedIterations: false
     namespace: kubelet-density-heavy
     waitWhenFinished: true
+    preLoadImages: false
     podWait: false
     objects:
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -65,7 +65,7 @@ check_running_pods() {
 }
 
 check_running_pods_in_ns() {
-    running_pods=$(kubectl get pod -n "${1}" -l kube-burner-job=namespaced | grep -c Running)
+    running_pods=$(kubectl get pod -n "${1}" -l kube-burner-job=namespaced --field-selector=status.phase==Running --no-headers | wc -l)
     if [[ "${running_pods}" != "${2}" ]]; then
       echo "Running pods in namespace $1 different from expected. Expected=${2}, observed=${running_pods}"
       return 1


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [x] Documentation Update

## Description

The `waitForPod` implementation was incorrect and follows a different logic compared to the `waitForDeployments` function.

In the original implementation, this logic waits for all pods in the specified namespace to have status.phase as Running. Which according to the docs means
>- `"Running"` means the pod has been bound to a node and all of the containers have been started. At least one container is still running or is in the process of being restarted.

Meaning that the status phase of the pod can be `Running`, w/o passing any probe.

This behaviour is different in Pods handled by a controller such as Deployment or DaemonSet, in which kube-burner uses the ReadyReplicas/NumberReady status fields, and these fields depend on the Ready condition of the child pods, this condition is marked as true when all containers of the pod are also Ready (incuding probes)

This fix shouldn't affect any the result of any `kube-burner-ocp` workload, the only one potentially affected can be node-density, which uses bare pods w/o any probes.  

