### PR TITLE
Only append prometheus client to slice when it has a metrics profile

### DIFF
--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -96,6 +96,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 				if err != nil {
 					log.Fatal(err)
 				}
+				prometheusClients = append(prometheusClients, p)
 			}
 			if metricsEndpoint.AlertProfile != "" {
 				if alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, scraperConfig.ConfigSpec.GlobalConfig.UUID, p, metricsEndpoint.EmbedConfig, indexerList...); err != nil {
@@ -103,7 +104,6 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 				}
 				alertMs = append(alertMs, alertM)
 			}
-			prometheusClients = append(prometheusClients, p)
 		}
 	}
 	return Scraper{


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We were appending a PrometheusClient to the clients slice in all cases even when that prometheus client was going to be used to scrape alerts, this clients in this slice are used to scrape metrics and no other client there should be added.

## Related Tickets & Documents

- Related Issue #
- Closes #616
