### PR TITLE
Don't override maxWaitTimeout in job spec

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -318,7 +318,12 @@ func newExecutorList(configSpec config.Spec, kubeClientProvider *config.KubeClie
 				log.Fatalf("Job names must be unique: %s", job.Name)
 			}
 		}
-		job.MaxWaitTimeout = timeout
+		if job.MaxWaitTimeout == 0 {
+			log.Debugf("job.MaxWaitTimeout is zero in %s, override by timeout: %s", job.Name, timeout)
+			job.MaxWaitTimeout = timeout
+		} else {
+			log.Debugf("job.MaxWaitTimeout is non zero in %s: %s", job.Name, job.MaxWaitTimeout)
+		}
 		// Limits the number of workers to QPS and Burst
 		ex.limiter = rate.NewLimiter(rate.Limit(job.QPS), job.Burst)
 		ex.Job = job

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,7 +91,6 @@ func (j *Job) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		ErrorOnVerify:          true,
 		JobType:                CreationJob,
 		WaitForDeletion:        true,
-		MaxWaitTimeout:         4 * time.Hour,
 		PreLoadImages:          true,
 		PreLoadPeriod:          1 * time.Minute,
 		Churn:                  false,


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

+ Do not set default `job.MaxWaitTimeout` in `UnmarshalYAML`
+ Override `job.MaxWaitTimeout` only if it is empty

## Related Tickets & Documents

- Related Issue #
- Closes #618
