### PR TITLE
Enrich jobSummary

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -439,12 +439,14 @@ func alertCmd() *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			startTime := time.Unix(start, 0)
-			endTime := time.Unix(end, 0)
+			job := prometheus.Job{
+				Start: time.Unix(start, 0),
+				End:   time.Unix(end, 0),
+			}
 			if alertM, err = alerting.NewAlertManager(alertProfile, uuid, p, false, indexer); err != nil {
 				log.Fatalf("Error creating alert manager: %s", err)
 			}
-			err = alertM.Evaluate(startTime, endTime, nil, nil)
+			err = alertM.Evaluate(job)
 			log.Info("👋 Exiting kube-burner ", uuid)
 			if err != nil {
 				os.Exit(1)

--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -100,6 +100,9 @@ This document looks like:
   "cleanupEndTimestamp": "2023-08-29T00:18:49.014541929Z",
   "metricName": "jobSummary",
   "elapsedTime": 8.768932955,
+  "version": "v1.1.0",
+  "passed": true,
+  "executionErrors": "",
   "jobConfig": {
     "jobIterations": 10,
     "jobIterationDelay": 0,

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -258,6 +258,8 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 					Metadata:            metricsScraper.Metadata,
 					Passed:              innerRC == 0,
 					ExecutionErrors:     jobAlerts,
+					Version:             fmt.Sprintf("%v@%v", version.Version, version.GitCommit),
+					MetricName:          jobSummaryMetric,
 				})
 			}
 		}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -88,6 +88,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	var executedJobs []prometheus.Job
 	var jobList []Executor
 	var msWg, gcWg sync.WaitGroup
+	var jobSummaries []jobSummary
 	embedFS = configSpec.EmbedFS
 	embedFSDir = configSpec.EmbedFSDir
 	errs := []error{}
@@ -99,8 +100,6 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	log.Infof("🔥 Starting kube-burner (%s@%s) with UUID %s", version.Version, version.GitCommit, uuid)
 	go func() {
 		var innerRC int
-		var churnStart *time.Time
-		var churnEnd *time.Time
 		measurements.NewMeasurementFactory(configSpec, metricsScraper.Metadata)
 		jobList = newExecutorList(configSpec, kubeClientProvider, uuid, timeout)
 		ClientSet, restConfig = kubeClientProvider.DefaultClientSet()
@@ -239,30 +238,27 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 		// Make sure that measurements have indexed their stuff before we index metrics
 		msWg.Wait()
 		for _, job := range executedJobs {
-			// elapsedTime is recalculated for every job of the list
-			jobTimings := Timings{
-				Timestamp:    job.Start,
-				EndTimestamp: job.End,
-				ElapsedTime:  job.End.Sub(job.Start).Round(time.Second).Seconds(),
-			}
-			if !job.JobConfig.SkipIndexing {
-				for _, indexer := range metricsScraper.IndexerList {
-					if job.JobConfig.Churn {
-						jobTimings.ChurnStartTimestamp = &job.ChurnStart
-						jobTimings.ChurnEndTimestamp = &job.ChurnEnd
-						if churnStart == nil {
-							churnStart = &job.ChurnStart
-						}
-						churnEnd = &job.ChurnEnd
-					}
-					IndexJobSummary(indexer, uuid, jobTimings, job.JobConfig, metricsScraper.Metadata)
+			var jobAlerts string
+			for _, alertM := range metricsScraper.AlertMs {
+				if err := alertM.Evaluate(job); err != nil {
+					jobAlerts = err.Error()
+					errs = append(errs, err)
+					innerRC = 1
 				}
 			}
-		}
-		for _, alertM := range metricsScraper.AlertMs {
-			if err := alertM.Evaluate(executedJobs[0].Start, executedJobs[len(jobList)-1].End, churnStart, churnEnd); err != nil {
-				errs = append(errs, err)
-				innerRC = 1
+			if !job.JobConfig.SkipIndexing {
+				jobSummaries = append(jobSummaries, jobSummary{
+					UUID:                uuid,
+					Timestamp:           job.Start,
+					EndTimestamp:        job.End,
+					ElapsedTime:         job.End.Sub(job.Start).Round(time.Second).Seconds(),
+					ChurnStartTimestamp: &job.ChurnStart,
+					ChurnEndTimestamp:   &job.ChurnEnd,
+					JobConfig:           job.JobConfig,
+					Metadata:            metricsScraper.Metadata,
+					Passed:              innerRC == 0,
+					ExecutionErrors:     jobAlerts,
+				})
 			}
 		}
 		for _, prometheusClient := range metricsScraper.PrometheusClients {

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -88,7 +88,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	var executedJobs []prometheus.Job
 	var jobList []Executor
 	var msWg, gcWg sync.WaitGroup
-	var jobSummaries []jobSummary
+	var jobSummaries []JobSummary
 	embedFS = configSpec.EmbedFS
 	embedFSDir = configSpec.EmbedFSDir
 	errs := []error{}
@@ -252,7 +252,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				executionErrors = utilerrors.NewAggregate(jobAlerts).Error()
 			}
 			if !job.JobConfig.SkipIndexing {
-				jobSummaries = append(jobSummaries, jobSummary{
+				jobSummaries = append(jobSummaries, JobSummary{
 					UUID:                uuid,
 					Timestamp:           job.Start,
 					EndTimestamp:        job.End,

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -263,6 +263,9 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				})
 			}
 		}
+		for _, indexer := range metricsScraper.IndexerList {
+			indexJobSummary(jobSummaries, indexer)
+		}
 		for _, prometheusClient := range metricsScraper.PrometheusClients {
 			prometheusClient.ScrapeJobsMetrics(executedJobs...)
 		}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -269,7 +269,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 			}
 		}
 		for _, indexer := range metricsScraper.IndexerList {
-			indexJobSummary(jobSummaries, indexer)
+			IndexJobSummary(jobSummaries, indexer)
 		}
 		for _, prometheusClient := range metricsScraper.PrometheusClients {
 			prometheusClient.ScrapeJobsMetrics(executedJobs...)

--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -46,7 +46,7 @@ func IndexJobSummary(jobSummaries []jobSummary, indexer indexers.Indexer) {
 	for _, summary := range jobSummaries {
 		summary.Version = fmt.Sprintf("%v@%v", version.Version, version.GitCommit)
 		summary.MetricName = jobSummaryMetric
-		log.Infof("Indexing job summary for job: %s", summary.JobConfig.Name)
+		log.Infof("Indexing summary for job: %s", summary.JobConfig.Name)
 		indexingOpts := indexers.IndexingOpts{
 			MetricName: fmt.Sprintf("%s-%s", jobSummaryMetric, summary.JobConfig.Name),
 		}

--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -22,7 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type jobSummary struct {
+type JobSummary struct {
 	Timestamp           time.Time              `json:"timestamp"`
 	EndTimestamp        time.Time              `json:"endTimestamp"`
 	ChurnStartTimestamp *time.Time             `json:"churnStartTimestamp,omitempty"`
@@ -40,7 +40,7 @@ type jobSummary struct {
 const jobSummaryMetric = "jobSummary"
 
 // indexMetadataInfo Generates and indexes a document with metadata information of the passed job
-func IndexJobSummary(jobSummaries []jobSummary, indexer indexers.Indexer) {
+func IndexJobSummary(jobSummaries []JobSummary, indexer indexers.Indexer) {
 	log.Info("Indexing job summaries")
 	var jobSummariesInt []interface{}
 	indexingOpts := indexers.IndexingOpts{

--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -36,7 +36,7 @@ type jobSummary struct {
 	Metadata            map[string]interface{} `json:"metadata,omitempty"`
 	Version             string                 `json:"version"`
 	Passed              bool                   `json:"passed"`
-	ExecutionErrors     string                 `json:"executionErrors",omitempty"`
+	ExecutionErrors     string                 `json:"executionErrors,omitempty"`
 }
 
 const jobSummaryMetric = "jobSummary"

--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -15,11 +15,9 @@
 package burner
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
-	"github.com/cloud-bulldozer/go-commons/version"
 	"github.com/kube-burner/kube-burner/pkg/config"
 	log "github.com/sirupsen/logrus"
 )
@@ -43,18 +41,18 @@ const jobSummaryMetric = "jobSummary"
 
 // indexMetadataInfo Generates and indexes a document with metadata information of the passed job
 func IndexJobSummary(jobSummaries []jobSummary, indexer indexers.Indexer) {
+	log.Info("Indexing job summaries")
+	var jobSummariesInt []interface{}
+	indexingOpts := indexers.IndexingOpts{
+		MetricName: jobSummaryMetric,
+	}
 	for _, summary := range jobSummaries {
-		summary.Version = fmt.Sprintf("%v@%v", version.Version, version.GitCommit)
-		summary.MetricName = jobSummaryMetric
-		log.Infof("Indexing summary for job: %s", summary.JobConfig.Name)
-		indexingOpts := indexers.IndexingOpts{
-			MetricName: fmt.Sprintf("%s-%s", jobSummaryMetric, summary.JobConfig.Name),
-		}
-		resp, err := indexer.Index([]interface{}{summary}, indexingOpts)
-		if err != nil {
-			log.Error(err)
-		} else {
-			log.Info(resp)
-		}
+		jobSummariesInt = append(jobSummariesInt, summary)
+	}
+	resp, err := indexer.Index(jobSummariesInt, indexingOpts)
+	if err != nil {
+		log.Error(err)
+	} else {
+		log.Info(resp)
 	}
 }

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -22,7 +22,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/cloud-bulldozer/go-commons/indexers"
 	"github.com/kube-burner/kube-burner/pkg/burner"
 	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/util"
@@ -31,8 +30,7 @@ import (
 )
 
 const (
-	stepSize              = 30 * time.Second
-	clusterMetadataMetric = "clusterMetadata"
+	stepSize = 30 * time.Second
 )
 
 var ConfigSpec config.Spec
@@ -101,12 +99,7 @@ func (wh *WorkloadHelper) Run(workload string) {
 	})
 	rc, err = burner.Run(ConfigSpec, wh.kubeClientProvider, metricsScraper, wh.Timeout)
 	if err != nil {
-		wh.Metadata.ExecutionErrors = err.Error()
-		log.Error(err)
-	}
-	wh.Metadata.Passed = rc == 0
-	for _, indexer := range metricsScraper.IndexerList {
-		IndexMetadata(indexer, wh.Metadata)
+		log.Errorf(err.Error())
 	}
 	log.Info("👋 Exiting kube-burner ", wh.UUID)
 	os.Exit(rc)
@@ -136,18 +129,4 @@ func ExtractWorkload(embedConfig embed.FS, configDir string, workload string, ro
 		}
 	}
 	return nil
-}
-
-// IndexMetadata indexes metadata using given indexer.
-func IndexMetadata(indexer indexers.Indexer, metadata BenchmarkMetadata) {
-	log.Info("Indexing cluster metadata document")
-	metadata.EndDate = time.Now().UTC()
-	msg, err := (indexer).Index([]interface{}{metadata}, indexers.IndexingOpts{
-		MetricName: metadata.MetricName,
-	})
-	if err != nil {
-		log.Error(err.Error())
-	} else {
-		log.Info(msg)
-	}
 }

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -54,13 +54,14 @@ func (wh *WorkloadHelper) Run(workload string) {
 	var err error
 	var embedConfig bool
 	var metricsScraper metrics.Scraper
+	var userMetadataContent map[string]interface{}
 	if wh.UserMetadata != "" {
-		wh.Metadata.UserMetadata, err = util.ReadUserMetadata(wh.UserMetadata)
+		userMetadataContent, err = util.ReadUserMetadata(wh.UserMetadata)
 		if err != nil {
 			log.Fatalf("Error reading provided user metadata: %v", err)
 		}
 		// Combine provided userMetadata with the regular OCP metadata
-		for k, v := range wh.Metadata.UserMetadata {
+		for k, v := range userMetadataContent {
 			wh.MetricsMetadata[k] = v
 		}
 	}

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -32,20 +32,9 @@ type Config struct {
 	PrometheusToken string
 }
 
-type BenchmarkMetadata struct {
-	ocpmetadata.ClusterMetadata
-	UUID            string                 `json:"uuid"`
-	Benchmark       string                 `json:"benchmark"`
-	Timestamp       time.Time              `json:"timestamp"`
-	EndDate         time.Time              `json:"endDate"`
-	Passed          bool                   `json:"passed"`
-	ExecutionErrors string                 `json:"executionErrors"`
-	UserMetadata    map[string]interface{} `json:"metadata,omitempty"`
-}
-
 type WorkloadHelper struct {
 	Config
-	Metadata           BenchmarkMetadata
+	ClusterMetadata    ocpmetadata.ClusterMetadata
 	embedConfig        embed.FS
 	kubeClientProvider *config.KubeClientProvider
 	MetadataAgent      ocpmetadata.Metadata

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -81,9 +81,7 @@ teardown_file() {
 @test "kube-burner init: os-indexing=true; local-indexing=true; metrics-endpoint=true" {
   export ES_INDEXING=true LOCAL_INDEXING=true TIMESERIES_INDEXER=local-indexing
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug -e metrics-endpoints.yaml
-  check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement alerts
   check_file_list ${METRICS_FOLDER}/jobSummary.json  ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
-  check_files_dont_exist ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -64,7 +64,7 @@ teardown_file() {
 @test "kube-burner init: local-indexing=true; pod-latency-metrics-indexing=true" {
   export LOCAL_INDEXING=true
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
-  check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
+  check_file_list ${METRICS_FOLDER}/jobSummary.json ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }
@@ -72,8 +72,8 @@ teardown_file() {
 @test "kube-burner init: os-indexing=true; local-indexing=true; alerting=true"  {
   export ES_INDEXING=true LOCAL_INDEXING=true ALERTING=true
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
-  check_metric_value jobSummary top2PrometheusCPU-start prometheusRSS prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement alert
-  check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
+  check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement alert
+  check_file_list ${METRICS_FOLDER}/jobSummary.json  ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }
@@ -81,7 +81,9 @@ teardown_file() {
 @test "kube-burner init: os-indexing=true; local-indexing=true; metrics-endpoint=true" {
   export ES_INDEXING=true LOCAL_INDEXING=true TIMESERIES_INDEXER=local-indexing
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug -e metrics-endpoints.yaml
-  check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json
+  check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement svcLatencyMeasurement svcLatencyQuantilesMeasurement alerts
+  check_file_list ${METRICS_FOLDER}/jobSummary.json  ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
+  check_files_dont_exist ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }
@@ -109,14 +111,14 @@ teardown_file() {
   run_cmd kube-burner init -c kube-burner-delete.yml --uuid "${UUID}" --log-level=debug
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement
-  check_file_list ${METRICS_FOLDER}/jobSummary-delete-job.json ${METRICS_FOLDER}/podLatencyMeasurement-delete-job.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-delete-job.json ${METRICS_FOLDER}/prometheusBuildInfo.json
+  check_file_list ${METRICS_FOLDER}/jobSummary.json ${METRICS_FOLDER}/podLatencyMeasurement-delete-job.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-delete-job.json ${METRICS_FOLDER}/prometheusBuildInfo.json
 }
 
 @test "kube-burner init: read; os-indexing=true; local-indexing=true" {
   export ES_INDEXING=true LOCAL_INDEXING=true
   run_cmd kube-burner init -c kube-burner-read.yml --uuid "${UUID}" --log-level=debug
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement
-  check_file_list ${METRICS_FOLDER}/jobSummary-read-job.json ${METRICS_FOLDER}/prometheusBuildInfo.json
+  check_file_list ${METRICS_FOLDER}/jobSummary.json ${METRICS_FOLDER}/prometheusBuildInfo.json
 }
 
 @test "kube-burner init: kubeconfig" {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [x] Documentation Update

## Description

Update the format of the `jobSummary` document, to include the fields:

- passed: This field indicates if the job passed of not. To fail means that any of these conditions were true:
  - An alert of error severity was fired
  - Pod latency thresholds not met
  - Object verification failed
- executionErrors: Details the error reason

One of the goals of this new approach is to get rid of the document `benchmarkMetadata` generated by `kube-burner-ocp` and consolidate into a single one.


## Related Tickets & Documents

- Related Issue #
- Closes #
