### PR TITLE
validate job.Namespace when it's non empty.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -199,7 +199,7 @@ func validateDNS1123() error {
 		if errs := validation.IsDNS1123Subdomain(job.Name); len(errs) > 0 {
 			return fmt.Errorf("Job %s name validation error: %s", job.Name, fmt.Sprint(errs))
 		}
-		if job.JobType == CreationJob {
+		if job.JobType == CreationJob && len(job.Namespace) > 0 {
 			if errs := validation.IsDNS1123Subdomain(job.Namespace); job.JobType == CreationJob && len(errs) > 0 {
 				return fmt.Errorf("Namespace %s name validation error: %s", job.Namespace, errs)
 			}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Skip `validation.IsDNS1123Subdomain` when job.Namespace  is empty.

## Related Tickets & Documents

- Related Issue #
- Closes #628
