### PR TITLE
Fixing check-alerts command and add test case

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -418,7 +418,7 @@ func alertCmd() *cobra.Command {
 					MetricsDirectory: metricsDirectory,
 				}
 			}
-			if indexer != nil {
+			if indexerConfig.Type != "" {
 				log.Infof("📁 Creating indexer: %s", indexerConfig.Type)
 				indexer, err = indexers.NewIndexer(indexerConfig)
 				if err != nil {
@@ -437,7 +437,7 @@ func alertCmd() *cobra.Command {
 			}
 			startTime := time.Unix(start, 0)
 			endTime := time.Unix(end, 0)
-			if alertM, err = alerting.NewAlertManager(alertProfile, uuid, p, false, *indexer); err != nil {
+			if alertM, err = alerting.NewAlertManager(alertProfile, uuid, p, false, indexer); err != nil {
 				log.Fatalf("Error creating alert manager: %s", err)
 			}
 			err = alertM.Evaluate(startTime, endTime, nil, nil)

--- a/pkg/alerting/alert_manager.go
+++ b/pkg/alerting/alert_manager.go
@@ -66,7 +66,7 @@ type alert struct {
 type AlertManager struct {
 	alertProfile alertProfile
 	prometheus   *prometheus.Prometheus
-	indexer      indexers.Indexer
+	indexer      *indexers.Indexer
 	uuid         string
 }
 
@@ -81,7 +81,7 @@ type descriptionTemplate struct {
 }
 
 // NewAlertManager creates a new alert manager
-func NewAlertManager(alertProfileCfg, uuid string, prometheusClient *prometheus.Prometheus, embedConfig bool, indexer indexers.Indexer) (*AlertManager, error) {
+func NewAlertManager(alertProfileCfg, uuid string, prometheusClient *prometheus.Prometheus, embedConfig bool, indexer *indexers.Indexer) (*AlertManager, error) {
 	log.Infof("🔔 Initializing alert manager for prometheus: %v", prometheusClient.Endpoint)
 	a := AlertManager{
 		prometheus: prometheusClient,
@@ -214,7 +214,7 @@ func parseMatrix(value model.Value, description string, severity severityLevel, 
 func (a *AlertManager) index(alertSet []interface{}) {
 	log.Info("Indexing alerts")
 	log.Debugf("Indexing [%d] documents", len(alertSet))
-	resp, err := a.indexer.Index(alertSet, indexers.IndexingOpts{MetricName: alertMetricName})
+	resp, err := (*a.indexer).Index(alertSet, indexers.IndexingOpts{MetricName: alertMetricName})
 	if err != nil {
 		log.Error(err)
 	} else {

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -84,7 +84,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 				}
 			}
 			for _, alertProfile := range metricsEndpoint.Alerts {
-				if alertM, err = alerting.NewAlertManager(alertProfile, scraperConfig.ConfigSpec.GlobalConfig.UUID, p, metricsEndpoint.EmbedConfig, *indexer); err != nil {
+				if alertM, err = alerting.NewAlertManager(alertProfile, scraperConfig.ConfigSpec.GlobalConfig.UUID, p, metricsEndpoint.EmbedConfig, indexer); err != nil {
 					log.Fatalf("Error creating alert manager: %s", err)
 				}
 				alertMs = append(alertMs, alertM)

--- a/test/k8s/alerts.yml
+++ b/test/k8s/alerts.yml
@@ -1,0 +1,3 @@
+- expr: up == 1
+  description: Prometheus {{$labels.instance}} is up & running
+  severity: warning

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -138,3 +138,8 @@ teardown_file() {
 @test "kube-burner cluster health check" {
   run_cmd kube-burner health-check
 }
+
+@test "kube-burner check-alerts" {
+  run_cmd kube-burner check-alerts -a alerts.yml -u http://localhost:9090 --metrics-directory=alerts
+  check_file_list alerts/alert.json
+}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

check-alerts was broken due to a nil pointer in indexer

```shell
$ ~/labs/kube-burner/bin/amd64/kube-burner check-alerts -a up.yml -u http://localhost:9090                                                         16:18:54 [118/1437]
time="2024-04-22 16:16:04" level=info msg="👽 Initializing prometheus client with URL: http://localhost:9090" file="prometheus.go:47"
panic: runtime error: invalid memory address or nil pointer dereference                                                
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b4d890]                                                                                                                                                                       
                                                                                                                                                                                                                                              
goroutine 1 [running]:                                                                                                                                                                                                                        
main.alertCmd.func1(0xc00050d000?, {0xc00051f5c0?, 0x4?, 0x208f102?})                                                                                                                                                                         
        /home/rsevilla/labs/kube-burner/cmd/kube-burner/kube-burner.go:481 +0x7f0                                                                                                                                                             
github.com/spf13/cobra.(*Command).execute(0xc0003d6c00, {0xc00051f580, 0x4, 0x4})                                                                                                                                                             
        /home/rsevilla/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x863                                                                                                                                                         
github.com/spf13/cobra.(*Command).ExecuteC(0x3550fe0)                                                                  
        /home/rsevilla/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3a5                                                                                                                                                        
github.com/spf13/cobra.(*Command).Execute(...)                                                                                                                                                                                                
        /home/rsevilla/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968                                         
main.main()                                                                                                            
        /home/rsevilla/labs/kube-burner/cmd/kube-burner/kube-burner.go:523 +0xfa     
```

## Related Tickets & Documents

- Related Issue #
- Closes #
