### PR TITLE
Directly delete non-namespaced resource

### DIFF
--- a/pkg/util/namespaces.go
+++ b/pkg/util/namespaces.go
@@ -127,12 +127,11 @@ func CleanupNonNamespacedResources(ctx context.Context, clientSet kubernetes.Int
 func DeleteNonNamespacedResources(ctx context.Context, resources *unstructured.UnstructuredList, resourceInterface dynamic.NamespaceableResourceInterface) {
 	if len(resources.Items) > 0 {
 		for _, item := range resources.Items {
-			go func(item unstructured.Unstructured) {
-				err := resourceInterface.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-				if err != nil {
-					log.Errorf("Error deleting %v/%v: %v", item.GetKind(), item.GetName(), err)
-				}
-			}(item)
+			log.Debugf("Deleting non-namespaced resource: %s", item.GetName())
+			err := resourceInterface.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
+			if err != nil {
+				log.Errorf("Error deleting %v/%v: %v", item.GetKind(), item.GetName(), err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
+ `resourceInterface.Delete` is a non-blocked function.
+ If run `resourceInterface.Delete` in a goroutine, the `resourceInterface.Delete` haven't had a chance to run before `kube-burner` exit.

## Related Tickets & Documents

- Related Issue #
- Closes #630
