### PR TITLE
Add fileName when Error decoding YAML

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -71,7 +71,7 @@ func setupCreateJob(jobConfig config.Job) Executor {
 		if err != nil {
 			log.Fatalf("Error preparing template %s: %s", o.ObjectTemplate, err)
 		}
-		_, gvk := yamlToUnstructured(cleanTemplate, uns)
+		_, gvk := yamlToUnstructured(o.ObjectTemplate, cleanTemplate, uns)
 		mapping, err := mapper.RESTMapping(gvk.GroupKind())
 		if err != nil {
 			log.Fatal(err)
@@ -239,7 +239,7 @@ func (ex *Executor) replicaHandler(labels map[string]string, obj object, ns stri
 				log.Fatalf("Template error in %s: %s", obj.ObjectTemplate, err)
 			}
 			// Re-decode rendered object
-			yamlToUnstructured(renderedObj, newObject)
+			yamlToUnstructured(obj.ObjectTemplate, renderedObj, newObject)
 
 			for k, v := range newObject.GetLabels() {
 				copiedLabels[k] = v

--- a/pkg/burner/patch.go
+++ b/pkg/burner/patch.go
@@ -151,7 +151,7 @@ func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructu
 			patchOptions.FieldManager = "kube-controller-manager"
 		} else {
 			newObject := &unstructured.Unstructured{}
-			yamlToUnstructured(renderedObj, newObject)
+			yamlToUnstructured(obj.ObjectTemplate, renderedObj, newObject)
 			data, err = newObject.MarshalJSON()
 			if err != nil {
 				log.Errorf("Error converting patch to JSON")

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -72,7 +72,7 @@ func getJobImages(job Executor) ([]string, error) {
 		if err != nil {
 			return imageList, err
 		}
-		yamlToUnstructured(renderedObj, &unstructuredObject)
+		yamlToUnstructured(object.ObjectTemplate, renderedObj, &unstructuredObject)
 		switch unstructuredObject.GetKind() {
 		case "Deployment", "DaemonSet", "ReplicaSet", "Job":
 			var pod NestedPod

--- a/pkg/burner/utils.go
+++ b/pkg/burner/utils.go
@@ -69,10 +69,10 @@ func setMetadataLabels(obj *unstructured.Unstructured, labels map[string]string)
 	unstructured.SetNestedMap(obj.Object, metadata, templatePath...)
 }
 
-func yamlToUnstructured(y []byte, uns *unstructured.Unstructured) (runtime.Object, *schema.GroupVersionKind) {
+func yamlToUnstructured(fileName string, y []byte, uns *unstructured.Unstructured) (runtime.Object, *schema.GroupVersionKind) {
 	o, gvk, err := scheme.Codecs.UniversalDeserializer().Decode(y, nil, uns)
 	if err != nil {
-		log.Fatalf("Error decoding YAML: %s", err)
+		log.Fatalf("Error decoding YAML (%s): %s", fileName, err)
 	}
 	return o, gvk
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->
error log when  error decoding YAML,finding error is difficult.
`"Error decoding YAML: yaml: line 11: could not find expected ':'" file="utils.go:75"`

adding a file name makes it easy
`"Error decoding YAML file (templates/xxx.yaml): yaml: line 11: could not find expected ':'" file="utils.go:75"`

## Related Tickets & Documents

- Related Issue #
- Closes #
