### PR TITLE
Capturing start is optional in instant metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -27,7 +27,7 @@ In addition to the default range queries, kube-burner has the ability execute [i
 ```
 
 !!! info
-    When using instant queries, the generated documents are resulting from scraping the last timestamp of each job, it's possible to generate an extra document resulting from scraping the first timestamp of the jobs by adding `captureStart: true` to the metric definition, the resulting document's `metricName` are appended the `-start` suffix.
+    When using instant queries, the generated documents are resulting from scraping the last timestamp of each job. It is possible to generate an extra document resulting from scraping the first timestamp of the jobs by adding `captureStart: true` to the metric definition, the resulting document's `metricName` are appended the `-start` suffix.
 
 ## Metric format
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -27,7 +27,7 @@ In addition to the default range queries, kube-burner has the ability execute [i
 ```
 
 !!! info
-    When using instant queries, at least two documents are generated, one resulting from scraping the last timestamp of the job, which would have the configued `metricName` field and an another one resulting from scraping the first timestamp of the job, the `metricName` of document is appended the `-start` suffix.
+    When using instant queries, the generated documents are resulting from scraping the last timestamp of each job, it's possible to generate an extra document resulting from scraping the first timestamp of the jobs by adding `captureStart: true` to the metric definition, the resulting document's `metricName` are appended the `-start` suffix.
 
 ## Metric format
 

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -82,7 +82,9 @@ func (p *Prometheus) ScrapeJobsMetrics(jobList ...Job) error {
 				query := renderedQuery.String()
 				renderedQuery.Reset()
 				if metric.Instant {
-					docsToIndex[metric.MetricName+"-start"] = append(docsToIndex[metric.MetricName+"-start"], p.runInstantQuery(query, metric.MetricName+"-start", jobStart, eachJob)...)
+					if metric.CaptureStart {
+						docsToIndex[metric.MetricName+"-start"] = append(docsToIndex[metric.MetricName+"-start"], p.runInstantQuery(query, metric.MetricName+"-start", jobStart, eachJob)...)
+					}
 					docsToIndex[metric.MetricName] = append(docsToIndex[metric.MetricName], p.runInstantQuery(query, metric.MetricName, jobEnd, eachJob)...)
 				} else {
 					requiresInstant = ((jobEnd.Sub(jobStart).Milliseconds())%(p.Step.Milliseconds()) != 0)

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -58,9 +58,10 @@ type metricProfile struct {
 
 // metricDefinition describes what metrics kube-burner collects
 type metricDefinition struct {
-	Query      string `yaml:"query"`
-	MetricName string `yaml:"metricName"`
-	Instant    bool   `yaml:"instant"`
+	Query        string `yaml:"query"`
+	MetricName   string `yaml:"metricName"`
+	Instant      bool   `yaml:"instant"`
+	CaptureStart bool   `yaml:"captureStart"`
 }
 
 type metric struct {

--- a/test/k8s/metrics-profile.yaml
+++ b/test/k8s/metrics-profile.yaml
@@ -4,6 +4,7 @@
 - query: irate(process_cpu_seconds_total{job="prometheus"}[2m]) and on (job) topk(2,avg_over_time(process_cpu_seconds_total{job="prometheus"}[{{.elapsed}}:]))
   metricName: top2PrometheusCPU
   instant: true
+  captureStart: true
 
 - query: prometheus_build_info
   metricName: prometheusBuildInfo

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -87,7 +87,7 @@ teardown_file() {
 }
 
 @test "kube-burner index: local-indexing=true; tarball=true" {
-  run_cmd kube-burner index --uuid="${UUID}" -u http://localhost:9090 -m "metrics-profile.yaml,metrics-profile.yaml" --tarball-name=metrics.tgz --start=$(date -d "-2 minutes" +%s)
+  run_cmd kube-burner index --uuid="${UUID}" -u http://localhost:9090 -m "metrics-profile.yaml,metrics-profile.yaml" --tarball-name=metrics.tgz --start="$(date -d "-2 minutes" +%s)"
   check_file_list collected-metrics/top2PrometheusCPU.json collected-metrics/top2PrometheusCPU-start.json collected-metrics/prometheusRSS.json
   run_cmd kube-burner import --tarball=metrics.tgz --es-server=${ES_SERVER} --es-index=${ES_INDEX}
 }

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -87,7 +87,7 @@ teardown_file() {
 }
 
 @test "kube-burner index: local-indexing=true; tarball=true" {
-  run_cmd kube-burner index --uuid="${UUID}" -u http://localhost:9090 -m "metrics-profile.yaml,metrics-profile.yaml" --tarball-name=metrics.tgz
+  run_cmd kube-burner index --uuid="${UUID}" -u http://localhost:9090 -m "metrics-profile.yaml,metrics-profile.yaml" --tarball-name=metrics.tgz --start=$(date -d "-2 minutes" +%s)
   check_file_list collected-metrics/top2PrometheusCPU.json collected-metrics/top2PrometheusCPU-start.json collected-metrics/prometheusRSS.json
   run_cmd kube-burner import --tarball=metrics.tgz --es-server=${ES_SERVER} --es-index=${ES_INDEX}
 }

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -72,7 +72,7 @@ teardown_file() {
 @test "kube-burner init: os-indexing=true; local-indexing=true; alerting=true"  {
   export ES_INDEXING=true LOCAL_INDEXING=true ALERTING=true
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
-  check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement alert
+  check_metric_value jobSummary top2PrometheusCPU-start prometheusRSS prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement alert
   check_file_list ${METRICS_FOLDER}/jobSummary-namespaced.json ${METRICS_FOLDER}/podLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/podLatencyQuantilesMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyMeasurement-namespaced.json ${METRICS_FOLDER}/svcLatencyQuantilesMeasurement-namespaced.json
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
@@ -88,7 +88,7 @@ teardown_file() {
 
 @test "kube-burner index: local-indexing=true; tarball=true" {
   run_cmd kube-burner index --uuid="${UUID}" -u http://localhost:9090 -m "metrics-profile.yaml,metrics-profile.yaml" --tarball-name=metrics.tgz
-  check_file_list collected-metrics/top2PrometheusCPU.json collected-metrics/prometheusRSS.json
+  check_file_list collected-metrics/top2PrometheusCPU.json collected-metrics/top2PrometheusCPU-start.json collected-metrics/prometheusRSS.json
   run_cmd kube-burner import --tarball=metrics.tgz --es-server=${ES_SERVER} --es-index=${ES_INDEX}
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

We normally don't need to capture the start of the metric

## Related Tickets & Documents

- Related Issue #
- Closes #603
