### PR TITLE
optimize iterations output

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -120,7 +120,7 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 		*waitListNamespaces = append(*waitListNamespaces, ns)
 	}
 	// We have to sum 1 since the iterations start from 1
-	iterationProgress := (iterationEnd - iterationStart) / 10
+	iterationProgress := (iterationEnd - iterationStart + 9) / 10
 	percent := 1
 	var namespacesCreated = make(map[string]bool)
 	var namespacesWaited = make(map[string]bool)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Use `examples/workloads/kubelet-density`，and change `jobIterations` to 5.

### currently 
When `jobIterations` is 5, the `iterationProgress` is 0 and `iterations completed` has been printed only 1 time.
```
time="2024-05-08 06:32:37" level=info msg="0/5 iterations completed" file="create.go:129"
```

### After change
When `jobIterations` is 5, the `iterationProgress` is 1 and `iterations completed` has been printed 4 times.
```
time="2024-05-09 04:51:43" level=info msg="1/5 iterations completed" file="create.go:129"
time="2024-05-09 04:51:44" level=info msg="2/5 iterations completed" file="create.go:129"
time="2024-05-09 04:51:44" level=info msg="3/5 iterations completed" file="create.go:129"
time="2024-05-09 04:51:45" level=info msg="4/5 iterations completed" file="create.go:129"
```

## Related Tickets & Documents

- Related Issue #
- Closes #
