### PR TITLE
fallback logic while reading metric profiles

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -131,8 +131,13 @@ func (p *Prometheus) ReadProfile(location string) error {
 	var f io.Reader
 	var err error
 	if p.embedConfig {
-		location = path.Join(path.Dir(p.ConfigSpec.EmbedFSDir), location)
-		f, err = util.ReadEmbedConfig(p.ConfigSpec.EmbedFS, location)
+		embededLocation := path.Join(path.Dir(p.ConfigSpec.EmbedFSDir), location)
+		f, err = util.ReadEmbedConfig(p.ConfigSpec.EmbedFS, embededLocation)
+		if err != nil {
+			log.Info("Embedded config doesn't contain metrics profile. Falling back to original path")
+			f, err = util.ReadConfig(location)
+		}
+		location = embededLocation
 	} else {
 		f, err = util.ReadConfig(location)
 	}

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -89,7 +89,7 @@ func (wh *WorkloadHelper) Run(workload string) {
 		ConfigSpec.EmbedFSDir = path.Join(wh.ConfigDir, workload)
 	}
 	// Overwrite credentials
-	for pos, _ := range ConfigSpec.MetricsEndpoints {
+	for pos := range ConfigSpec.MetricsEndpoints {
 		ConfigSpec.MetricsEndpoints[pos].Endpoint = wh.PrometheusURL
 		ConfigSpec.MetricsEndpoints[pos].Token = wh.PrometheusToken
 	}


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adding fallback logic to ready metric profiles properly when specified from a metrics-endpoint file. Previous logic used to append prefix "config" which was leading to errors.

## Testing
Tested and verified in local integrating with ocp wrapper.
```
[vchalla@vchalla-thinkpadp1gen2 kube-burner-ocp]$ kube-burner-ocp cluster-density-v2 --log-level=info --qps=20 --burst=20 --gc=true --uuid 78cf9e75-1d7a-407f-98cc-a389e0ed4852 --gc-metrics=true --profile-type=reporting --gc-metrics=true --profile-type=reporting --iterations=1 --churn=true --es-server='https://ocp-qe:Perfscale24!@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com' --es-index=ripsaw-kube-burner --metrics-endpoint=metrics-endpoint.yml --log-level=debug
time="2024-05-10 16:00:44" level=info msg=metrics-endpoint.yml file="helpers.go:96"
time="2024-05-10 16:00:44" level=info msg="📁 Creating opensearch indexer: indexer-0" file="metrics.go:62"
time="2024-05-10 16:00:44" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="prometheus.go:47"
time="2024-05-10 16:00:45" level=info msg=../../e2e-benchmarking/workloads/kube-burner-ocp-wrapper/metrics-profiles/hosted-cluster-metrics.yml file="metrics.go:85"
time="2024-05-10 16:00:45" level=info msg="Embeded config doesn't contain metrics profile. Falling back to original path" file="prometheus.go:137"
time="2024-05-10 16:00:45" level=info msg="🔔 Initializing alert manager for prometheus: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="alert_manager.go:85"
time="2024-05-10 16:00:45" level=info msg="📁 Creating opensearch indexer: indexer-1" file="metrics.go:62"
time="2024-05-10 16:00:45" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="prometheus.go:47"
time="2024-05-10 16:00:45" level=info msg=metrics.yml file="metrics.go:85"
time="2024-05-10 16:00:45" level=info msg="📁 Creating opensearch indexer: indexer-2" file="metrics.go:62"
time="2024-05-10 16:00:46" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="prometheus.go:47"
time="2024-05-10 16:00:46" level=info msg=metrics.yml file="metrics.go:85"
time="2024-05-10 16:00:46" level=info msg="🔔 Initializing alert manager for prometheus: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="alert_manager.go:85"
time="2024-05-10 16:00:46" level=info msg="🔥 Starting kube-burner (main@3f46dbfafc10ddc24d16ce840996c67ee989d4fa) with UUID 78cf9e75-1d7a-407f-98cc-a389e0ed4852" file="job.go:99"
time="2024-05-10 16:00:46" level=info msg="📈 Registered measurement: podLatency" file="factory.go:91"
```
