### PR TITLE
Add cluster metadata information to all documents when using plugin helpers

### DIFF
--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -83,7 +83,7 @@ The `local` indexer can be configured by the parameters below:
 | `createTarball`    | Create metrics tarball                | Boolean | false                   |
 | `tarballName`      | Name of the metrics tarball           | String  | kube-burner-metrics.tgz |
 
-## Job Summary
+## Job Summary and metadata
 
 When an indexer is configured, a document holding the job summary is indexed at the end of the job. This is useful to identify the parameters the job was executed with. It also contains the timestamps of the execution phase (`timestamp` and `endTimestamp`) as well as the cleanup phase (`cleanupTimestamp` and `cleanupEndTimestamp`).
 
@@ -100,29 +100,36 @@ This document looks like:
   "cleanupEndTimestamp": "2023-08-29T00:18:49.014541929Z",
   "metricName": "jobSummary",
   "elapsedTime": 8.768932955,
-  "version": "v1.1.0",
+  "version": "v1.10.0",
   "passed": true,
-  "executionErrors": "",
-  "jobConfig": {
-    "jobIterations": 10,
-    "jobIterationDelay": 0,
-    "jobPause": 0,
-    "name": "kubelet-density",
-    "jobType": "create",
-    "qps": 5,
-    "burst": 5,
-    "namespace": "kubelet-density",
-    "maxWaitTimeout": 43200000000000,
+  "executionErrors": "this is an exmample",
+  "jobConfig": {                          
+    "jobIterations": 1,                                                                                              
+    "name": "cluster-density-v2",                                                                                    
+    "jobType": "create",                                                                                             
+    "qps": 20,                                                                                                       
+    "burst": 20,
+    "namespace": "cluster-density-v2",
+    "maxWaitTimeout": 14400000000000,
     "waitForDeletion": true,
-    "podWait": false,
     "waitWhenFinished": true,
     "cleanup": true,
-    "namespacedIterations": false,
+    "namespacedIterations": true,
+    "iterationsPerNamespace": 1,
     "verifyObjects": true,
-    "errorOnVerify": false
+    "errorOnVerify": true,
+    "preLoadImages": true,
+    "preLoadPeriod": 15000000000,
+    "churnPercent": 10,
+    "churnDuration": 3600000000000,
+    "churnDelay": 120000000000,
+    "churnDeletionStrategy": "default"
   }
 }
 ```
+
+!!! Note
+    It's possible that some of the fields from the document above don't get indexed when it has no value
 
 ## Metric exporting & importing
 

--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -83,7 +83,7 @@ The `local` indexer can be configured by the parameters below:
 | `createTarball`    | Create metrics tarball                | Boolean | false                   |
 | `tarballName`      | Name of the metrics tarball           | String  | kube-burner-metrics.tgz |
 
-## Job Summary and metadata
+## Job Summary
 
 When an indexer is configured, a document holding the job summary is indexed at the end of the job. This is useful to identify the parameters the job was executed with. It also contains the timestamps of the execution phase (`timestamp` and `endTimestamp`) as well as the cleanup phase (`cleanupTimestamp` and `cleanupEndTimestamp`).
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/cloud-bulldozer/go-commons v1.0.15
+	github.com/cloud-bulldozer/go-commons v1.0.16
 	github.com/google/uuid v1.5.0
 	github.com/montanaflynn/stats v0.7.1
 	github.com/prometheus/common v0.52.3

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloud-bulldozer/go-commons v1.0.15 h1:tqd73a18d+ES96x1oX3To+bJjHnXFuvag9QtcLvSGd0=
-github.com/cloud-bulldozer/go-commons v1.0.15/go.mod h1:dUXxFH2mosY5OYY+cFPS3XvCekUTZRtMPuK/ni8Azq8=
+github.com/cloud-bulldozer/go-commons v1.0.16 h1:eVjOyFl7RVH3oQni0ssNT6Zjl7iovG6km11YZM1H8Ww=
+github.com/cloud-bulldozer/go-commons v1.0.16/go.mod h1:GF5G/9qiKJqUYIsqPgW5gFXzeSYjZn0tTScj7E/6ka4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -16,6 +16,7 @@ package workloads
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -55,6 +56,7 @@ func (wh *WorkloadHelper) Run(workload string) {
 	var embedConfig bool
 	var metricsScraper metrics.Scraper
 	var userMetadataContent map[string]interface{}
+	var clusterMetadataMap map[string]interface{}
 	if wh.UserMetadata != "" {
 		userMetadataContent, err = util.ReadUserMetadata(wh.UserMetadata)
 		if err != nil {
@@ -98,6 +100,11 @@ func (wh *WorkloadHelper) Run(workload string) {
 		RawMetadata:     wh.MetricsMetadata,
 		EmbedConfig:     embedConfig,
 	})
+	jsonData, _ := json.Marshal(wh.ClusterMetadata)
+	json.Unmarshal(jsonData, &clusterMetadataMap)
+	for k, v := range clusterMetadataMap {
+		metricsScraper.Metadata[k] = v
+	}
 	rc, err = burner.Run(ConfigSpec, wh.kubeClientProvider, metricsScraper, wh.Timeout)
 	if err != nil {
 		log.Errorf(err.Error())


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

After merging https://github.com/kube-burner/kube-burner/pull/620, the cluster's metadata wasn't being added to the `jobSummary` document, this change helps to add **all** fields from cluster metadata to **all** documents generated (including jobSummary), it simplifies the overall logic by not having to select a subset of fields to add in the metrics.


> Note: The metadata fields are added when using the plugin helpers functions 

## Related Tickets & Documents

- Related Issue #620
- Closes #
