### PR TITLE
Remove incompatibility check

### DIFF
--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -279,13 +279,6 @@ func (p *vmiLatency) start(measurementWg *sync.WaitGroup) error {
 	defer measurementWg.Done()
 	// Reset latency slices, required in multi-job benchmarks
 	p.latencyQuantiles, p.normLatencies = nil, nil
-	if factory.jobConfig.JobType == config.DeletionJob {
-		log.Info("VMI latency measurement not compatible with delete jobs, skipping")
-		return nil
-	}
-	if err := p.validateConfig(); err != nil {
-		return err
-	}
 	p.metrics = make(map[string]*vmiMetric)
 	log.Infof("Creating VM latency watcher for %s", factory.jobConfig.Name)
 	restClient := newRESTClientWithRegisteredKubevirtResource()


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Removing unnecessary incompatibility check for the VMI latency measurement in delete jobs. The measurement can be running while a VM/VMI is deleted w/o issues, as it just handles the latency of new created VM/VMIs

This check was leading into issues, the logic wasn't 100% correct as it was trying to stop it even when it hasn't been previously started.

## Related Tickets & Documents

- Related Issue #
- Closes #658
