### PR TITLE
Handling empty metadata cases to be handled in metrics.

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -175,7 +175,9 @@ func (p *Prometheus) createMetric(query, metricName string, job Job, labels mode
 		Query:      query,
 		MetricName: metricName,
 		Timestamp:  timestamp,
-		Metadata:   p.metadata,
+	}
+	if len(p.metadata) != 0 {
+		m.Metadata = p.metadata 
 	}
 	for k, v := range labels {
 		if k != "__name__" {

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -26,8 +26,11 @@ import (
 
 // Processes common config and executes according to the caller
 func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
+	metadata := make(map[string]interface{})
 	if len(scraperConfig.ConfigSpec.MetricsEndpoints) == 0 && scraperConfig.MetricsEndpoint == "" {
-		return Scraper{}
+		return Scraper{
+			Metadata: metadata,
+		}
 	}
 	var err error
 	var indexer *indexers.Indexer
@@ -36,7 +39,6 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 	var prometheusClients []*prometheus.Prometheus
 	var alertM *alerting.AlertManager
 	var alertMs []*alerting.AlertManager
-	metadata := make(map[string]interface{})
 	if scraperConfig.UserMetaData != "" {
 		metadata, err = util.ReadUserMetadata(scraperConfig.UserMetaData)
 		if err != nil {


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Removing metadata when it is empty to have more cleaner metrics.

## Testing
Tested in local and verified
```
  {
    "timestamp": "2024-07-07T19:27:14.434Z",
    "labels": {
      "container": "lightspeed-service-api",
      "namespace": "openshift-lightspeed",
      "node": "ip-10-0-78-217.us-west-2.compute.internal",
      "pod": "lightspeed-app-server-6c695f7995-ztp4q"
    },
    "value": 0.11032656977364322,
    "uuid": "158de0a0-7fd0-4879-8798-ae1ddcb8b5c2",
    "query": "(sum(irate(container_cpu_usage_seconds_total{name!=\"\",container!~\"POD|\",namespace=~\"openshift-lightspeed\"}[2m]) * 100) by (container, pod, namespace, node)) > 0",
    "metricName": "containerCPU"
  }
```
