### PR TITLE
Removing metadata from documents except jobSummary

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -441,7 +441,7 @@ func alertCmd() *cobra.Command {
 				Token:         token,
 				SkipTLSVerify: skipTLSVerify,
 			}
-			p, err := prometheus.NewPrometheusClient(configSpec, url, auth, prometheusStep, nil, false, indexer)
+			p, err := prometheus.NewPrometheusClient(configSpec, url, auth, prometheusStep, false, indexer)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,7 +49,7 @@ This is the main subcommand; it triggers a new kube-burner benchmark and it supp
 - `timeout`: Kube-burner benchmark global timeout. When timing out, return code is 2. The default is `4h`. 
 - `kubeconfig`: Path to the kubeconfig file.
 - `kube-context`: The name of the kubeconfig context to use.
-- `user-metadata`: YAML file path containing custom user-metadata to be indexed.
+- `user-metadata`: YAML file path containing custom user-metadata to be indexed along with the `jobSummary` document.
 
 !!! Note "Prometheus authentication"
     Both basic and token authentication methods need permissions able to query the given Prometheus endpoint.

--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -94,7 +94,6 @@ This document looks like:
   "timestamp": "2023-08-29T00:17:27.942960538Z",
   "endTimestamp": "2023-08-29T00:18:15.817272025Z",
   "uuid": "83bfcb20-54f1-43f4-b2ad-ad04c2f4fd16",
-  "metricName": "jobSummary",
   "elapsedTime": 48,
   "cleanupTimestamp": "2023-08-29T00:18:18.015107794Z",
   "cleanupEndTimestamp": "2023-08-29T00:18:49.014541929Z",

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -46,14 +46,13 @@ type podMetric struct {
 	containersReady        time.Time
 	ContainersReadyLatency int `json:"containersReadyLatency"`
 	podReady               time.Time
-	PodReadyLatency        int         `json:"podReadyLatency"`
-	MetricName             string      `json:"metricName"`
-	UUID                   string      `json:"uuid"`
-	JobName                string      `json:"jobName,omitempty"`
-	Namespace              string      `json:"namespace"`
-	Name                   string      `json:"podName"`
-	NodeName               string      `json:"nodeName"`
-	Metadata               interface{} `json:"metadata,omitempty"`
+	PodReadyLatency        int    `json:"podReadyLatency"`
+	MetricName             string `json:"metricName"`
+	UUID                   string `json:"uuid"`
+	JobName                string `json:"jobName,omitempty"`
+	Namespace              string `json:"namespace"`
+	Name                   string `json:"podName"`
+	NodeName               string `json:"nodeName"`
 }
 
 type podLatency struct {
@@ -78,8 +77,7 @@ func (p *podLatency) handleCreatePod(obj interface{}) {
 		Name:       pod.Name,
 		MetricName: podLatencyMeasurement,
 		UUID:       globalCfg.UUID,
-		Metadata:   factory.metadata,
-    JobName:    factory.jobConfig.Name,
+		JobName:    factory.jobConfig.Name,
 	})
 }
 
@@ -209,13 +207,12 @@ func (p *podLatency) collect(measurementWg *sync.WaitGroup) {
 			MetricName:      podLatencyMeasurement,
 			NodeName:        pod.Spec.NodeName,
 			UUID:            globalCfg.UUID,
-			Metadata:        factory.metadata,
 			scheduled:       scheduled,
 			initialized:     initialized,
 			containersReady: containersReady,
 			podReady:        podReady,
 			JobName:         factory.jobConfig.Name,
-    })
+		})
 	}
 }
 

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -59,7 +59,6 @@ type svcMetric struct {
 	UUID              string             `json:"uuid"`
 	Namespace         string             `json:"namespace"`
 	Name              string             `json:"service"`
-	Metadata          interface{}        `json:"metadata,omitempty"`
 	ServiceType       corev1.ServiceType `json:"type"`
 	JobName           string             `json:"jobName,omitempty"`
 }
@@ -166,7 +165,6 @@ func (s *serviceLatency) handleCreateSvc(obj interface{}) {
 			ServiceType:       svc.Spec.Type,
 			ReadyLatency:      svcLatency,
 			UUID:              globalCfg.UUID,
-			Metadata:          factory.metadata,
 			IPAssignedLatency: ipAssignedLatency,
       JobName:           factory.jobConfig.Name,
 		})

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -71,13 +71,12 @@ type vmiMetric struct {
 	vmReady        time.Time
 	VMReadyLatency int `json:"vmReadyLatency"`
 
-	MetricName string      `json:"metricName"`
-	Metadata   interface{} `json:"metadata,omitempty"`
-	UUID       string      `json:"uuid"`
-	Namespace  string      `json:"namespace"`
-	Name       string      `json:"podName"`
-	NodeName   string      `json:"nodeName"`
-	JobName    string      `json:"jobName,omitempty"`
+	MetricName string `json:"metricName"`
+	UUID       string `json:"uuid"`
+	Namespace  string `json:"namespace"`
+	Name       string `json:"podName"`
+	NodeName   string `json:"nodeName"`
+	JobName    string `json:"jobName,omitempty"`
 }
 
 type vmiLatency struct {
@@ -105,8 +104,7 @@ func (p *vmiLatency) handleCreateVM(obj interface{}) {
 				Name:       vm.Name,
 				MetricName: vmiLatencyMeasurement,
 				UUID:       globalCfg.UUID,
-				Metadata:   factory.metadata,
-        JobName:    factory.jobConfig.Name,
+				JobName:    factory.jobConfig.Name,
 			})
 		}
 	}
@@ -247,25 +245,25 @@ func (p *vmiLatency) handleUpdateVMIPod(obj interface{}) {
 			for _, c := range pod.Status.Conditions {
 				if c.Status == corev1.ConditionTrue {
 					switch c.Type {
-						case corev1.PodScheduled:
-							if vmiMetric.podScheduled.IsZero() {
-								vmiMetric.podScheduled = time.Now().UTC()
-								vmiMetric.NodeName = pod.Spec.NodeName
-								log.Infof("Updated pod scheduling time for VMI: %s", pod.Name)
-							}
-						case corev1.PodInitialized:
-							if vmiMetric.podInitialized.IsZero() {
-								vmiMetric.podInitialized = time.Now().UTC()
-								log.Infof("Updated pod initialization time for VMI: %s", pod.Name)
-							}
-						case corev1.ContainersReady:
-							if vmiMetric.podContainersReady.IsZero() {
-								vmiMetric.podContainersReady = time.Now().UTC()
-								log.Infof("Updated pod containers ready time for VMI: %s", pod.Name)
-							}
-						case corev1.PodReady:
-							vmiMetric.podReady = time.Now().UTC()
-							log.Infof("Updated pod readiness time for VMI: %s", pod.Name)
+					case corev1.PodScheduled:
+						if vmiMetric.podScheduled.IsZero() {
+							vmiMetric.podScheduled = time.Now().UTC()
+							vmiMetric.NodeName = pod.Spec.NodeName
+							log.Infof("Updated pod scheduling time for VMI: %s", pod.Name)
+						}
+					case corev1.PodInitialized:
+						if vmiMetric.podInitialized.IsZero() {
+							vmiMetric.podInitialized = time.Now().UTC()
+							log.Infof("Updated pod initialization time for VMI: %s", pod.Name)
+						}
+					case corev1.ContainersReady:
+						if vmiMetric.podContainersReady.IsZero() {
+							vmiMetric.podContainersReady = time.Now().UTC()
+							log.Infof("Updated pod containers ready time for VMI: %s", pod.Name)
+						}
+					case corev1.PodReady:
+						vmiMetric.podReady = time.Now().UTC()
+						log.Infof("Updated pod readiness time for VMI: %s", pod.Name)
 					}
 				}
 			}

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -177,7 +177,7 @@ func (p *Prometheus) createMetric(query, metricName string, job Job, labels mode
 		JobName:    job.JobConfig.Name,
 	}
 	for k, v := range labels {
-		if k != "__name__" {
+		if k != model.MetricNameLabel {
 			m.Labels[string(k)] = string(v)
 		}
 	}

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -33,14 +33,13 @@ import (
 )
 
 // NewPrometheusClient creates a prometheus struct instance with the given parameters
-func NewPrometheusClient(configSpec config.Spec, url string, auth Auth, step time.Duration, metadata map[string]interface{}, embedConfig bool, indexer *indexers.Indexer) (*Prometheus, error) {
+func NewPrometheusClient(configSpec config.Spec, url string, auth Auth, step time.Duration, embedConfig bool, indexer *indexers.Indexer) (*Prometheus, error) {
 	var err error
 	p := Prometheus{
 		Step:        step,
 		UUID:        configSpec.GlobalConfig.UUID,
 		ConfigSpec:  configSpec,
 		Endpoint:    url,
-		metadata:    metadata,
 		embedConfig: embedConfig,
 		indexer:     indexer,
 	}
@@ -176,9 +175,6 @@ func (p *Prometheus) createMetric(query, metricName string, job Job, labels mode
 		MetricName: metricName,
 		Timestamp:  timestamp,
 		JobName:    job.JobConfig.Name,
-	}
-	if len(p.metadata) != 0 {
-		m.Metadata = p.metadata 
 	}
 	for k, v := range labels {
 		if k != "__name__" {

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -38,7 +38,6 @@ type Prometheus struct {
 	Step           time.Duration
 	UUID           string
 	ConfigSpec     config.Spec
-	metadata       map[string]interface{}
 	embedConfig    bool
 	indexer        *indexers.Indexer
 }
@@ -73,5 +72,4 @@ type metric struct {
 	ChurnMetric bool              `json:"churnMetric,omitempty"`
 	MetricName  string            `json:"metricName,omitempty"`
 	JobName     string            `json:"jobName,omitempty"`
-	Metadata    interface{}       `json:"metadata,omitempty"`
 }

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -75,7 +75,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 				Token:         metricsEndpoint.Token,
 				SkipTLSVerify: metricsEndpoint.SkipTLSVerify,
 			}
-			p, err := prometheus.NewPrometheusClient(*scraperConfig.ConfigSpec, metricsEndpoint.Endpoint, auth, metricsEndpoint.Step, metadata, scraperConfig.EmbedConfig, indexer)
+			p, err := prometheus.NewPrometheusClient(*scraperConfig.ConfigSpec, metricsEndpoint.Endpoint, auth, metricsEndpoint.Step, scraperConfig.EmbedConfig, indexer)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -34,9 +34,8 @@ type Config struct {
 
 type WorkloadHelper struct {
 	Config
-	ClusterMetadata    ocpmetadata.ClusterMetadata
 	embedConfig        embed.FS
 	kubeClientProvider *config.KubeClientProvider
 	MetadataAgent      ocpmetadata.Metadata
-	MetricsMetadata    map[string]interface{}
+	Metadata           map[string]interface{}
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

With this PR, cluster's metadata is no longer added to all documents except `jobSummary`. This helps to reduce the size of the generated documents.

## Related Tickets & Documents

- Related Issue #
- Closes #
