### PR TITLE
indexing metrics even in timeout cases

### DIFF
--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -32,7 +32,7 @@ type JobSummary struct {
 	MetricName          string                 `json:"metricName"`
 	JobConfig           config.Job             `json:"jobConfig"`
 	Metadata            map[string]interface{} `json:"metadata,omitempty"`
-	Version             string                 `json:"version"`
+	Version             string                 `json:"version,omitempty"`
 	Passed              bool                   `json:"passed"`
 	ExecutionErrors     string                 `json:"executionErrors,omitempty"`
 }


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Capturing metrics even in timeout cases. Also populating job status and execution errors appropriately.

## Related Tickets & Documents

- Related Issue # https://github.com/kube-burner/kube-burner/issues/626