### PR TITLE
Enhancing waitoptions to work with lablels, custom conditions & read jobs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -116,17 +116,24 @@ If you want to override the default waiter behaviors, you can specify wait optio
 
 | Option       | Description                                             | Type    | Default |
 |--------------|---------------------------------------------------------|---------|---------|
-| `forCondition` | Wait for the object condition with this name to be true | String  | ""      |
+| `kind` | Object kind to consider for wait | String | "" |
+| `labelSelector` | Objects with these labels will be considered for wait | Object | {} |
+| `forCondition` | Wait for the object condition with this name to be true | String  | "" |
 
 For example, the snippet below can be used to make kube-burner wait for all containers from the pod defined at `pod.yml` to be ready.
 
 ```yaml
 objects:
-- objectTemplate: pod.yml
+- objectTemplate: deployment.yml
   replicas: 3
   waitOptions:
+    kind: Pod
+    labelSelector: {kube-burner-label : abcd}
     forCondition: Ready
 ```
+
+!!! note
+    `waitOptions.kind` and `waitOptions.labelSelector` are fully optional. `waitOptions.kind` is used when an application has child objects to be waited & `waitOptions.labelSelector` is used when we want to wait on objects with specific labels.
 
 ### Default labels
 

--- a/pkg/burner/patch.go
+++ b/pkg/burner/patch.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"golang.org/x/time/rate"
 )
 
 func setupPatchJob(jobConfig config.Job) Executor {
@@ -114,6 +115,8 @@ func (ex *Executor) RunPatchJob() {
 		}
 	}
 	wg.Wait()
+	waitRateLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
+	ex.waitForObjects("", waitRateLimiter)
 }
 
 func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructured,

--- a/pkg/burner/read.go
+++ b/pkg/burner/read.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -62,6 +63,8 @@ func (ex *Executor) RunReadJob(iterationStart, iterationEnd int) {
 	// We have to sum 1 since the iterations start from 1
 	iterationProgress := (iterationEnd - iterationStart) / 10
 	percent := 1
+	waitRateLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
+	ex.waitForObjects("", waitRateLimiter)
 	for i := iterationStart; i < iterationEnd; i++ {
 		if i == iterationStart+iterationProgress*percent {
 			log.Infof("%v/%v iterations completed", i-iterationStart, iterationEnd-iterationStart)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -182,6 +182,10 @@ type Job struct {
 }
 
 type WaitOptions struct {
+	// Kind object kind to consider for wait
+	Kind string `yaml:"kind" json:"kind,omitempty"`
+	// LabelSelector objects with these labels will be considered
+	LabelSelector map[string]string `yaml:"labelSelector" json:"labelSelector,omitempty"`
 	// ForCondition wait for this condition to become true
 	ForCondition string `yaml:"forCondition" json:"forCondition,omitempty"`
 }


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Enhancing wait options to work with labels, custom conditions also for the read jobs.
* Scans only objects with specified labels.
* Works with custom condition if specified.
* Works with nested resources of an application deployment.
* Also works with 

## Related Tickets & Documents

- Related Issue # https://github.com/kube-burner/kube-burner/issues/653

## Testing
Went through the CI tests.
Tested and verified in local with a config change
```
      - objectTemplate: app-deployment.yml
        replicas: 1
        inputVars:
          probesPeriod: {{.PROBES_PERIOD}}
        waitOptions:
          labelSelector: {kube-burner-uuid: abcd}
          forCondition: Available
```
