### PR TITLE
Fix golangci-lint precommit hook

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - unused
     - misspell
     - ineffassign
-    - goconst
     - goimports
     - dupl
     - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
     - goimports
     - dupl
     - unparam
-    - revive
     - staticcheck
     - gosimple
     - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - unused
     - misspell
     - ineffassign
+    - goconst
     - goimports
     - dupl
     - unparam

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.55.2
+    rev: v1.60.3
     hooks:
       - id: golangci-lint
         entry: golangci-lint run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v1.55.2
     hooks:
       - id: golangci-lint
+        entry: golangci-lint run
         args: [--timeout=5m]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.38.0

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -221,7 +221,7 @@ func measureCmd() *cobra.Command {
 				if err != nil {
 					log.Fatalf("Error creating indexer %d: %v", pos, err.Error())
 				}
-				indexerList[string(indexer.Alias)] = *idx
+				indexerList[indexer.Alias] = *idx
 			}
 			if userMetadata != "" {
 				metadata, err = util.ReadUserMetadata(userMetadata)

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -110,7 +110,7 @@ func initCmd() *cobra.Command {
 
 			rc, err = burner.Run(configSpec, kubeClientProvider, metricsScraper, timeout)
 			if err != nil {
-				log.Errorf(err.Error())
+				log.Error(err.Error())
 				os.Exit(rc)
 			}
 		},

--- a/pkg/alerting/alert_manager.go
+++ b/pkg/alerting/alert_manager.go
@@ -16,6 +16,7 @@ package alerting
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -208,7 +209,7 @@ func parseMatrix(value model.Value, description string, severity severityLevel, 
 			case sevWarn:
 				log.Warnf("🚨 %s", msg)
 			case sevError:
-				errs = append(errs, fmt.Errorf(msg))
+				errs = append(errs, errors.New(msg))
 			case sevCritical:
 				log.Fatalf("🚨 %s", msg)
 			default:

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -298,12 +298,11 @@ func createRequest(gvr schema.GroupVersionResource, ns string, obj *unstructured
 			} else if kerrors.IsNotFound(err) {
 				log.Errorf("Error creating object %s/%s: %v", obj.GetKind(), obj.GetName(), err.Error())
 				return true, nil
+			}
+			if ns != "" {
+				log.Errorf("Error creating object %s/%s in namespace %s: %s", obj.GetKind(), obj.GetName(), ns, err)
 			} else {
-				if ns != "" {
-					log.Errorf("Error creating object %s/%s in namespace %s: %s", obj.GetKind(), obj.GetName(), ns, err)
-				} else {
-					log.Errorf("Error creating object %s/%s: %s", obj.GetKind(), obj.GetName(), err)
-				}
+				log.Errorf("Error creating object %s/%s: %s", obj.GetKind(), obj.GetName(), err)
 			}
 			log.Error("Retrying object creation")
 			return false, nil

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -269,7 +269,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	case rc = <-res:
 	case <-time.After(timeout):
 		err := fmt.Errorf("%v timeout reached", timeout)
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 		errs = append(errs, err)
 		rc = rcTimeout
 		indexMetrics(uuid, executedJobs, returnMap, metricsScraper, configSpec, false, utilerrors.NewAggregate(errs).Error(), true)

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -64,7 +64,7 @@ type Executor struct {
 
 // returnPair is a pair of return codes for a job
 type returnPair struct {
-	innerRC int
+	innerRC         int
 	executionErrors string
 }
 
@@ -88,6 +88,8 @@ var embedFSDir string
 // Returns:
 // - error code
 // - error
+//
+//nolint:gocyclo
 func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, metricsScraper metrics.Scraper, timeout time.Duration) (int, error) {
 	var err error
 	var rc int
@@ -285,7 +287,7 @@ func indexMetrics(uuid string, executedJobs []prometheus.Job, returnMap map[stri
 	var jobSummaries []JobSummary
 	for _, job := range executedJobs {
 		if !job.JobConfig.SkipIndexing {
-			if value, exists := returnMap[job.JobConfig.Name]; exists && !isTimeout{
+			if value, exists := returnMap[job.JobConfig.Name]; exists && !isTimeout {
 				innerRC = value.innerRC == 0
 				executionErrors = value.executionErrors
 			}

--- a/pkg/burner/read.go
+++ b/pkg/burner/read.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/kube-burner/kube-burner/pkg/config"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 

--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -53,30 +53,30 @@ func (ex *Executor) waitForObjects(ns string, limiter *rate.Limiter) {
 				waitNs = ""
 			}
 			switch kind {
-				case "Deployment":
-					waitForDeployments(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "ReplicaSet":
-					waitForRS(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "ReplicationController":
-					waitForRC(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "StatefulSet":
-					waitForStatefulSet(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "DaemonSet":
-					waitForDS(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "Pod":
-					waitForPod(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "Build", "BuildConfig":
-					waitForBuild(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "VirtualMachine":
-					waitForVM(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "VirtualMachineInstance":
-					waitForVMI(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "VirtualMachineInstanceReplicaSet":
-					waitForVMIRS(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "Job":
-					waitForJob(waitNs, ex.MaxWaitTimeout, obj, limiter)
-				case "PersistentVolumeClaim":
-					waitForPVC(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "Deployment":
+				waitForDeployments(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "ReplicaSet":
+				waitForRS(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "ReplicationController":
+				waitForRC(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "StatefulSet":
+				waitForStatefulSet(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "DaemonSet":
+				waitForDS(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "Pod":
+				waitForPod(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "Build", "BuildConfig":
+				waitForBuild(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "VirtualMachine":
+				waitForVM(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "VirtualMachineInstance":
+				waitForVMI(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "VirtualMachineInstanceReplicaSet":
+				waitForVMIRS(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "Job":
+				waitForJob(waitNs, ex.MaxWaitTimeout, obj, limiter)
+			case "PersistentVolumeClaim":
+				waitForPVC(waitNs, ex.MaxWaitTimeout, obj, limiter)
 			}
 		}
 	}
@@ -202,7 +202,7 @@ func waitForPod(ns string, maxWaitTimeout time.Duration, obj object, limiter *ra
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		// We need to paginate these requests to ensure we don't miss any pods
 		listOptions := metav1.ListOptions{
-			Limit: 1000,
+			Limit:         1000,
 			LabelSelector: labels.Set(obj.WaitOptions.LabelSelector).String(),
 		}
 		for {

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -166,7 +166,7 @@ func (s *serviceLatency) handleCreateSvc(obj interface{}) {
 			ReadyLatency:      svcLatency,
 			UUID:              globalCfg.UUID,
 			IPAssignedLatency: ipAssignedLatency,
-      JobName:           factory.jobConfig.Name,
+			JobName:           factory.jobConfig.Name,
 		})
 	}(svc)
 }

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -50,8 +50,8 @@ func RenderTemplate(original []byte, inputData interface{}, options templateOpti
 		addrSlice := strings.Split(Addresses, " ")
 		for i := 0; i < addressesPerIteration; i++ {
 			// For example, if iteration=6 and addressesPerIteration=2, return 12th address from list.
-			// All addresses till 12th address were used in previous job iterations 
-			retAddrs = append(retAddrs, addrSlice[(iteration * addressesPerIteration) + i])
+			// All addresses till 12th address were used in previous job iterations
+			retAddrs = append(retAddrs, addrSlice[(iteration*addressesPerIteration)+i])
 		}
 		return strings.Join(retAddrs, " ")
 	}

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -86,7 +86,7 @@ func (wh *WorkloadHelper) Run(workload string) {
 	})
 	rc, err = burner.Run(ConfigSpec, wh.kubeClientProvider, metricsScraper, wh.Timeout)
 	if err != nil {
-		log.Errorf(err.Error())
+		log.Error(err.Error())
 	}
 	log.Info("👋 Exiting kube-burner ", wh.UUID)
 	os.Exit(rc)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The previous hook wasn't working as expected as it was relying on this configuration https://github.com/golangci/golangci-lint/blob/master/.pre-commit-hooks.yaml#L1-L8 `golangci-lint run --new-from-rev HEAD --fix`, the hook's command basically fixes linting errors when the current code is different from HEAD (so no action is taken when changes are committed), this is not what we actually need, we want to report and hang on linting errors caused by a PR.

Also fixing some pieces of code to meet linting.

## Related Tickets & Documents

- Related Issue #
- Closes #
