### PR TITLE
Prevent indexing measurements when indexers list is empty

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -207,7 +207,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				log.Error(err.Error())
 				innerRC = 1
 			}
-			if !job.SkipIndexing {
+			if !job.SkipIndexing && len(metricsScraper.IndexerList) > 0 {
 				msWg.Add(1)
 				go func(jobName string) {
 					defer msWg.Done()


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Let's prevent calling measurements.Index() when the indexer list is empty

## Related Tickets & Documents

- Related Issue #
- Closes #
