### PR TITLE
Skip churnStartTimestamp and churnEndTimestamp from jobSummary when churning is not on

### DIFF
--- a/pkg/alerting/alert_manager.go
+++ b/pkg/alerting/alert_manager.go
@@ -143,7 +143,7 @@ func (a *AlertManager) Evaluate(job prometheus.Job) error {
 			log.Warnf("Error performing query %s: %s", expr, err)
 			continue
 		}
-		alertData, err := parseMatrix(v, alert.Description, alert.Severity, &job.ChurnStart, &job.ChurnEnd)
+		alertData, err := parseMatrix(v, alert.Description, alert.Severity, job.ChurnStart, job.ChurnEnd)
 		if err != nil {
 			log.Error(err.Error())
 			errs = append(errs, err)

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -186,7 +186,7 @@ func (p *Prometheus) createMetric(query, metricName string, job Job, labels mode
 	} else {
 		m.Value = float64(value)
 	}
-	if !isInstant && timestamp.After(job.ChurnStart) && timestamp.Before(job.ChurnEnd) {
+	if !isInstant && timestamp.After(*job.ChurnStart) && timestamp.Before(*job.ChurnEnd) {
 		m.ChurnMetric = true
 	}
 	return m

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -186,8 +186,10 @@ func (p *Prometheus) createMetric(query, metricName string, job Job, labels mode
 	} else {
 		m.Value = float64(value)
 	}
-	if !isInstant && timestamp.After(*job.ChurnStart) && timestamp.Before(*job.ChurnEnd) {
-		m.ChurnMetric = true
+	if job.ChurnStart != nil && job.ChurnEnd != nil {
+		if !isInstant && timestamp.After(*job.ChurnStart) && timestamp.Before(*job.ChurnEnd) {
+			m.ChurnMetric = true
+		}
 	}
 	return m
 }

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -45,8 +45,8 @@ type Prometheus struct {
 type Job struct {
 	Start      time.Time
 	End        time.Time
-	ChurnStart time.Time
-	ChurnEnd   time.Time
+	ChurnStart *time.Time // A pointer to time.Time is required to skip this field when nil
+	ChurnEnd   *time.Time
 	JobConfig  config.Job
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Prevent indexing `churnStartTimestamp` and `churnEndTimestamp` when churning is not enabled

## Related Tickets & Documents

- Related Issue #
- Closes #
