### PR TITLE
Adding kube-virt to the CI tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,6 +1,7 @@
 name: CI tests
 on:
   workflow_call:
+  workflow_dispatch:
   pull_request_target:
     branches:
       - master

--- a/kube-burner-virt.yml
+++ b/kube-burner-virt.yml
@@ -1,0 +1,59 @@
+---
+
+global:
+  gc: {{env "GC"}}
+  measurements:
+  - name: vmiLatency
+{{ if .TIMESERIES_INDEXER }}
+    timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
+{{ end }}
+metricsEndpoints:
+{{ if .ES_INDEXING }}
+  - endpoint: http://localhost:9090
+    indexer:
+      type: opensearch
+      esServers: ["{{ .ES_SERVER }}"]
+      defaultIndex: {{ .ES_INDEX }}
+    metrics: [metrics-profile.yaml]
+{{ if .ALERTING }}
+    alerts: [alert-profile.yaml]
+{{ end }}
+{{ end }}
+{{ if .LOCAL_INDEXING }}
+  - endpoint: http://localhost:9090
+    indexer: 
+      type: local
+      metricsDirectory: {{ .METRICS_FOLDER }}
+    metrics: [metrics-profile.yaml]
+{{ if .ALERTING }}
+    alerts: [alert-profile.yaml]
+{{ end }}
+{{ end }}
+
+
+jobs:
+  # create the VMs
+  - name: kubevirt-density
+    jobType: create
+    jobIterations: 1
+    qps: 20
+    burst: 20
+    namespacedIterations: false
+    namespace: kubevirt-density
+    verifyObjects: true
+    errorOnVerify: true
+    jobIterationDelay: 1s
+    waitWhenFinished: true
+    podWait: false
+    maxWaitTimeout: 1h   
+    cleanup: true
+    objects:
+
+    - objectTemplate: objectTemplates/vm-ephemeral.yml
+      replicas: 1
+      inputVars:
+        name: kubevirt-density
+        image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:v0.48.1
+        OS: fedora27
+        memory: 64M
+        createVMI: true

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -23,6 +23,12 @@ setup-kind() {
   fi
   echo "Deploying cluster"
   "${KIND_FOLDER}/kind-linux-${ARCH}" create cluster --config kind.yml --image ${IMAGE} --name kind --wait 300s -v=1
+  echo "Deploying kubevirt operator"
+  KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases/latest | jq -r .tag_name)
+  kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/"${KUBEVIRT_VERSION}"/kubevirt-operator.yaml
+  kubectl create -f objectTemplates/kubevirt-cr.yaml
+  kubectl wait --for=condition=Available --timeout=600s -n kubevirt deployments/virt-operator
+  kubectl wait --for=condition=Available --timeout=600s -n kubevirt kv/kubevirt
 }
 
 create_test_kubeconfig() {

--- a/test/k8s/kind.yml
+++ b/test/k8s/kind.yml
@@ -1,5 +1,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-- role: control-plane
-- role: worker
+  - role: control-plane
+  - role: worker

--- a/test/k8s/kube-burner-virt.yml
+++ b/test/k8s/kube-burner-virt.yml
@@ -1,0 +1,59 @@
+---
+
+global:
+  gc: {{env "GC"}}
+  measurements:
+  - name: vmiLatency
+{{ if .TIMESERIES_INDEXER }}
+    timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
+{{ end }}
+metricsEndpoints:
+{{ if .ES_INDEXING }}
+  - endpoint: http://localhost:9090
+    indexer:
+      type: opensearch
+      esServers: ["{{ .ES_SERVER }}"]
+      defaultIndex: {{ .ES_INDEX }}
+    metrics: [metrics-profile.yaml]
+{{ if .ALERTING }}
+    alerts: [alert-profile.yaml]
+{{ end }}
+{{ end }}
+{{ if .LOCAL_INDEXING }}
+  - endpoint: http://localhost:9090
+    indexer: 
+      type: local
+      metricsDirectory: {{ .METRICS_FOLDER }}
+    metrics: [metrics-profile.yaml]
+{{ if .ALERTING }}
+    alerts: [alert-profile.yaml]
+{{ end }}
+{{ end }}
+
+
+jobs:
+  # create the VMs
+  - name: kubevirt-density
+    jobType: create
+    jobIterations: 1
+    qps: 20
+    burst: 20
+    namespacedIterations: false
+    namespace: kubevirt-density
+    verifyObjects: true
+    errorOnVerify: true
+    jobIterationDelay: 1s
+    waitWhenFinished: true
+    podWait: false
+    maxWaitTimeout: 1h   
+    cleanup: true
+    objects:
+
+    - objectTemplate: objectTemplates/vm-ephemeral.yml
+      replicas: 1
+      inputVars:
+        name: kubevirt-density
+        image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:v0.48.1
+        OS: fedora27
+        memory: 64M
+        createVMI: true

--- a/test/k8s/objectTemplates/kubevirt-cr.yaml
+++ b/test/k8s/objectTemplates/kubevirt-cr.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  certificateRotateStrategy: {}
+  configuration:
+    developerConfiguration:
+      featureGates:
+        - Root
+  customizeComponents: {}
+  imagePullPolicy: IfNotPresent
+  workloadUpdateStrategy: {}

--- a/test/k8s/objectTemplates/vm-ephemeral.yml
+++ b/test/k8s/objectTemplates/vm-ephemeral.yml
@@ -1,0 +1,50 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  creationTimestamp: null
+  labels:
+    kubevirt-vm: vm-{{.name}}-{{.Replica}}
+    kubevirt.io/os: {{.OS}}
+  name: {{.name}}-{{.Replica}}
+spec:
+  running: {{.createVMI}}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        kubevirt-vm: vm-{{.name}}-{{.Replica}}
+        kubevirt.io/os: {{.OS}}
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+          - disk:
+              bus: virtio
+            name: containerdisk
+          interfaces:
+          - masquerade: {}
+            model: virtio
+            name: default
+          networkInterfaceMultiqueue: true
+          rng: {}
+        resources:
+          requests:
+            memory: {{.memory}}
+      networks:
+      - name: default
+        pod: {}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk
+      - containerDisk:
+          image:  {{.image}}
+          imagePullPolicy: IfNotPresent
+        name: containerdisk

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -61,6 +61,15 @@ teardown_file() {
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }
 
+@test "kube-burner init: os-indexing=true; local-indexing=true; vm-latency-indexing=true" {
+  export ES_INDEXING=true LOCAL_INDEXING=true ALERTING=true
+  run_cmd kube-burner init -c kube-burner-virt.yml --uuid="${UUID}" --log-level=debug
+  check_metric_value jobSummary top2PrometheusCPU prometheusRSS vmiLatencyMeasurement vmiLatencyQuantilesMeasurement alert
+  check_file_list ${METRICS_FOLDER}/jobSummary.json  ${METRICS_FOLDER}/vmiLatencyMeasurement-kubevirt-density.json ${METRICS_FOLDER}/vmiLatencyQuantilesMeasurement-kubevirt-density.json
+  check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
+  check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
+}
+
 @test "kube-burner init: local-indexing=true; pod-latency-metrics-indexing=true" {
   export LOCAL_INDEXING=true
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
@@ -154,4 +163,3 @@ teardown_file() {
   check_custom_status_path kube-burner-uuid="${UUID}" "{.items[*].status.conditions[].type}" Available
   kube-burner destroy --uuid "${UUID}"
 }
-


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adding kube-virt into the CI. This will help us deploy VMs and validate our code against them. Pre-requisite: https://github.com/kube-burner/kube-burner/pull/700

## Related Tickets & Documents
- Closes # https://issues.redhat.com/browse/PERFSCALE-3400?filter=-1

## Testing
Tested and verified the lifecycle through fork github actions: https://github.com/vishnuchalla/kube-burner/actions/runs/10927130633/job/30332622126
