### PR TITLE
Remove os.exit in Run

### DIFF
--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -44,7 +44,7 @@ func NewWorkloadHelper(config Config, embedConfig embed.FS, kubeClientProvider *
 	return wh
 }
 
-func (wh *WorkloadHelper) Run(workload string) {
+func (wh *WorkloadHelper) Run(workload string) int {
 	var f io.Reader
 	var rc int
 	var err error
@@ -88,8 +88,8 @@ func (wh *WorkloadHelper) Run(workload string) {
 	if err != nil {
 		log.Error(err.Error())
 	}
-	log.Info("👋 Exiting kube-burner ", wh.UUID)
-	os.Exit(rc)
+	log.Infof("👋 kube-burner run completed with rc %d for UUID %s", rc, wh.UUID)
+	return rc
 }
 
 // ExtractWorkload extracts the given workload and metrics profile to the current directory


### PR DESCRIPTION
kube-burner-ocp workloads are using workload helpers for Run command. However this Run() has os.exit(), which is blocking kube-burner-ocp to run any PostRun() commands.

As we removed os.exit() here, kube-burner-ocp workloads explicitly need to define PostRun() with os.exit().

kube-burner-ocp PR https://github.com/kube-burner/kube-burner-ocp/pull/115 which adds PostRun() in all workloads

