### PR TITLE
Handle absolute file system paths

### DIFF
--- a/pkg/util/url_reader.go
+++ b/pkg/util/url_reader.go
@@ -33,7 +33,7 @@ func ReadEmbedConfig(embedFs embed.FS, configFile string) (io.Reader, error) {
 func ReadConfig(configFile string) (io.Reader, error) {
 	var f io.Reader
 	var err error
-	if _, err = url.ParseRequestURI(configFile); err == nil {
+	if u, err := url.ParseRequestURI(configFile); err == nil && u.Host != "" {
 		f, err = readURL(configFile, f)
 	} else {
 		f, err = os.Open(configFile)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Running kube-burner with a config file with an absolute path was causing the it to be handled as a URL. I fixed it by treating urls with an empty host as a local file.
