### PR TITLE
Populate executedJobs from the the beginning

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -96,7 +96,7 @@ func setupCreateJob(jobConfig config.Job) Executor {
 }
 
 // RunCreateJob executes a creation job
-func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNamespaces *[]string) {
+func (ex *Executor) RunCreateJob(ctx context.Context, iterationStart, iterationEnd int, waitListNamespaces *[]string) {
 	waitRateLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
 	nsAnnotations := make(map[string]string)
 	nsLabels := map[string]string{
@@ -126,6 +126,9 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 	var namespacesCreated = make(map[string]bool)
 	var namespacesWaited = make(map[string]bool)
 	for i := iterationStart; i < iterationEnd; i++ {
+		if ctx.Err() != nil {
+			return
+		}
 		if i == iterationStart+iterationProgress*percent {
 			log.Infof("%v/%v iterations completed", i-iterationStart, iterationEnd-iterationStart)
 			percent++
@@ -154,10 +157,10 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 				if i == 0 {
 					// this executes only once during the first iteration of an object
 					log.Debugf("RunOnce set to %s, so creating object once", obj.ObjectTemplate)
-					ex.replicaHandler(labels, obj, ns, i, &wg)
+					ex.replicaHandler(ctx, labels, obj, ns, i, &wg)
 				}
 			} else {
-				ex.replicaHandler(labels, obj, ns, i, &wg)
+				ex.replicaHandler(ctx, labels, obj, ns, i, &wg)
 			}
 		}
 		if !ex.WaitWhenFinished && ex.PodWait {
@@ -211,10 +214,13 @@ func (ex *Executor) generateNamespace(iteration int) string {
 	return fmt.Sprintf("%s-%d", ex.Namespace, nsIndex)
 }
 
-func (ex *Executor) replicaHandler(labels map[string]string, obj object, ns string, iteration int, replicaWg *sync.WaitGroup) {
+func (ex *Executor) replicaHandler(ctx context.Context, labels map[string]string, obj object, ns string, iteration int, replicaWg *sync.WaitGroup) {
 	var wg sync.WaitGroup
 
 	for r := 1; r <= obj.Replicas; r++ {
+		if ctx.Err() != nil {
+			return
+		}
 		// make a copy of the labels map for each goroutine to prevent panic from concurrent read and write
 		copiedLabels := make(map[string]string)
 		for k, v := range labels {
@@ -263,7 +269,7 @@ func (ex *Executor) replicaHandler(labels map[string]string, obj object, ns stri
 				if !obj.Namespaced {
 					n = ""
 				}
-				createRequest(obj.gvr, n, newObject, ex.MaxWaitTimeout)
+				createRequest(ctx, obj.gvr, n, newObject, ex.MaxWaitTimeout)
 				replicaWg.Done()
 			}(ns)
 		}(r)
@@ -271,10 +277,13 @@ func (ex *Executor) replicaHandler(labels map[string]string, obj object, ns stri
 	wg.Wait()
 }
 
-func createRequest(gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, timeout time.Duration) {
+func createRequest(ctx context.Context, gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, timeout time.Duration) {
 	var uns *unstructured.Unstructured
 	var err error
 	util.RetryWithExponentialBackOff(func() (bool, error) {
+		if ctx.Err() != nil {
+			return true, err
+		}
 		// When the object has a namespace already specified, use it
 		if objNs := obj.GetNamespace(); objNs != "" {
 			ns = objNs
@@ -317,7 +326,10 @@ func createRequest(gvr schema.GroupVersionResource, ns string, obj *unstructured
 }
 
 // RunCreateJobWithChurn executes a churn creation job
-func (ex *Executor) RunCreateJobWithChurn() {
+func (ex *Executor) RunCreateJobWithChurn(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
 	if !ex.nsRequired {
 		log.Info("No namespaces were created in this job, skipping churning stage")
 		return
@@ -378,7 +390,7 @@ func (ex *Executor) RunCreateJobWithChurn() {
 		util.CleanupNamespaces(ctx, ClientSet, "churndelete=delete")
 		log.Info("Re-creating deleted objects")
 		// Re-create objects that were deleted
-		ex.RunCreateJob(randStart, numToChurn+randStart, &[]string{})
+		ex.RunCreateJob(ctx, randStart, numToChurn+randStart, &[]string{})
 		log.Infof("Sleeping for %v", ex.ChurnDelay)
 		time.Sleep(ex.ChurnDelay)
 		cyclesCount++

--- a/pkg/burner/delete.go
+++ b/pkg/burner/delete.go
@@ -58,10 +58,13 @@ func setupDeleteJob(jobConfig config.Job) Executor {
 }
 
 // RunDeleteJob executes a deletion job
-func (ex *Executor) RunDeleteJob() {
+func (ex *Executor) RunDeleteJob(ctx context.Context) {
 	var wg sync.WaitGroup
 	var itemList *unstructured.UnstructuredList
 	for _, obj := range ex.objects {
+		if ctx.Err() != nil {
+			return
+		}
 		labelSelector := labels.Set(obj.labelSelector).String()
 		listOptions := metav1.ListOptions{
 			LabelSelector: labelSelector,

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -122,6 +122,10 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 		}
 		// Iterate job list
 		for jobPosition, job := range jobList {
+			executedJobs = append(executedJobs, prometheus.Job{
+				Start:     time.Now().UTC(),
+				JobConfig: job.Job,
+			})
 			var waitListNamespaces []string
 			if job.QPS == 0 || job.Burst == 0 {
 				log.Infof("QPS or Burst rates not set, using default client-go values: %v %v", rest.DefaultQPS, rest.DefaultBurst)
@@ -134,10 +138,6 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 			ClientSet, restConfig = kubeClientProvider.ClientSet(job.QPS, job.Burst)
 			discoveryClient = discovery.NewDiscoveryClientForConfigOrDie(restConfig)
 			DynamicClient = dynamic.NewForConfigOrDie(restConfig)
-			currentJob := prometheus.Job{
-				Start:     time.Now().UTC(),
-				JobConfig: job.Job,
-			}
 			measurements.SetJobConfig(&job.Job, kubeClientProvider)
 			log.Infof("Triggering job: %s", job.Name)
 			measurements.Start()
@@ -168,9 +168,9 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				}
 				if job.Churn {
 					now := time.Now().UTC()
-					currentJob.ChurnStart = &now
+					executedJobs[len(executedJobs)-1].ChurnStart = &now
 					job.RunCreateJobWithChurn()
-					currentJob.ChurnEnd = &now
+					executedJobs[len(executedJobs)-1].ChurnEnd = &now
 				}
 				globalWaitMap[strconv.Itoa(jobPosition)+job.Name] = waitListNamespaces
 				executorMap[strconv.Itoa(jobPosition)+job.Name] = job
@@ -200,10 +200,9 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				log.Infof("Pausing for %v before finishing job", job.JobPause)
 				time.Sleep(job.JobPause)
 			}
-			currentJob.End = time.Now().UTC()
-			executedJobs = append(executedJobs, currentJob)
+			executedJobs[len(executedJobs)-1].End = time.Now().UTC()
 			if !globalConfig.WaitWhenFinished {
-				elapsedTime := currentJob.End.Sub(currentJob.Start).Round(time.Second)
+				elapsedTime := executedJobs[len(executedJobs)-1].End.Sub(executedJobs[len(executedJobs)-1].Start).Round(time.Second)
 				log.Infof("Job %s took %v", job.Name, elapsedTime)
 			}
 			// We stop and index measurements per job
@@ -271,6 +270,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	select {
 	case rc = <-res:
 	case <-time.After(timeout):
+		executedJobs[len(executedJobs)-1].End = time.Now().UTC()
 		err := fmt.Errorf("%v timeout reached", timeout)
 		log.Error(err.Error())
 		errs = append(errs, err)

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -108,6 +108,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	executorMap := make(map[string]Executor)
 	returnMap := make(map[string]returnPair)
 	log.Infof("🔥 Starting kube-burner (%s@%s) with UUID %s", version.Version, version.GitCommit, uuid)
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
 	go func() {
 		var innerRC int
 		measurements.NewMeasurementFactory(configSpec, metricsScraper.MetricsMetadata)
@@ -155,7 +156,10 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 					log.Infof("Churn delay: %v", job.ChurnDelay)
 					log.Infof("Churn deletion strategy: %v", job.ChurnDeletionStrategy)
 				}
-				job.RunCreateJob(0, job.JobIterations, &waitListNamespaces)
+				job.RunCreateJob(ctx, 0, job.JobIterations, &waitListNamespaces)
+				if ctx.Err() != nil {
+					return
+				}
 				// If object verification is enabled
 				if job.VerifyObjects && !job.Verify() {
 					err := errors.New("object verification failed")
@@ -169,17 +173,17 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				if job.Churn {
 					now := time.Now().UTC()
 					executedJobs[len(executedJobs)-1].ChurnStart = &now
-					job.RunCreateJobWithChurn()
+					job.RunCreateJobWithChurn(ctx)
 					executedJobs[len(executedJobs)-1].ChurnEnd = &now
 				}
 				globalWaitMap[strconv.Itoa(jobPosition)+job.Name] = waitListNamespaces
 				executorMap[strconv.Itoa(jobPosition)+job.Name] = job
 			case config.DeletionJob:
-				job.RunDeleteJob()
+				job.RunDeleteJob(ctx)
 			case config.PatchJob:
-				job.RunPatchJob()
+				job.RunPatchJob(ctx)
 			case config.ReadJob:
-				job.RunReadJob(0, job.JobIterations)
+				job.RunReadJob(ctx, 0, job.JobIterations)
 			}
 			if job.BeforeCleanup != "" {
 				log.Infof("Waiting for beforeCleanup command %s to finish", job.BeforeCleanup)
@@ -270,9 +274,15 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	select {
 	case rc = <-res:
 	case <-time.After(timeout):
-		executedJobs[len(executedJobs)-1].End = time.Now().UTC()
 		err := fmt.Errorf("%v timeout reached", timeout)
 		log.Error(err.Error())
+		executedJobs[len(executedJobs)-1].End = time.Now().UTC()
+		//nolint:govet
+		gcCtx, _ := context.WithTimeout(context.Background(), globalConfig.GCTimeout)
+		for _, job := range jobList {
+			gcWg.Add(1)
+			go garbageCollectJob(gcCtx, job, fmt.Sprintf("kube-burner-job=%s", job.Name), &gcWg)
+		}
 		errs = append(errs, err)
 		rc = rcTimeout
 		indexMetrics(uuid, executedJobs, returnMap, metricsScraper, configSpec, false, utilerrors.NewAggregate(errs).Error(), true)

--- a/pkg/burner/patch.go
+++ b/pkg/burner/patch.go
@@ -84,12 +84,14 @@ func setupPatchJob(jobConfig config.Job) Executor {
 }
 
 // RunPatchJob executes a patch job
-func (ex *Executor) RunPatchJob() {
+func (ex *Executor) RunPatchJob(ctx context.Context) {
 	var itemList *unstructured.UnstructuredList
 	log.Infof("Running patch job %s", ex.Name)
 	var wg sync.WaitGroup
 	for _, obj := range ex.objects {
-
+		if ctx.Err() != nil {
+			return
+		}
 		labelSelector := labels.Set(obj.labelSelector).String()
 		listOptions := metav1.ListOptions{
 			LabelSelector: labelSelector,

--- a/pkg/burner/read.go
+++ b/pkg/burner/read.go
@@ -57,7 +57,7 @@ func setupReadJob(jobConfig config.Job) Executor {
 }
 
 // RunReadJob executes a reading job
-func (ex *Executor) RunReadJob(iterationStart, iterationEnd int) {
+func (ex *Executor) RunReadJob(ctx context.Context, iterationStart, iterationEnd int) {
 	var itemList *unstructured.UnstructuredList
 
 	// We have to sum 1 since the iterations start from 1
@@ -66,6 +66,9 @@ func (ex *Executor) RunReadJob(iterationStart, iterationEnd int) {
 	waitRateLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
 	ex.waitForObjects("", waitRateLimiter)
 	for i := iterationStart; i < iterationEnd; i++ {
+		if ctx.Err() != nil {
+			return
+		}
 		if i == iterationStart+iterationProgress*percent {
 			log.Infof("%v/%v iterations completed", i-iterationStart, iterationEnd-iterationStart)
 			percent++


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

We should populate the executedJobs array from the beginning to ensure indexing runs even on a timeout event

Tests:

```shell
$ kube-burner init -c kubelet-density.yml --timeout=10s                                                                          
time="2024-10-15 12:47:20" level=info msg="📁 Creating local indexer: indexer-0" file="metrics.go:63"                                                                                                                                         
time="2024-10-15 12:47:20" level=info msg="👽 Initializing prometheus client with URL: http://localhost:9090" file="prometheus.go:47"                                                                                                         
time="2024-10-15 12:47:20" level=info msg="🔥 Starting kube-burner (index-timeout@487c3f0c784dfb75161af8492379c99302ac087b) with UUID c0207b6d-f64b-47cc-909f-462e1b3eb3d6" file="job.go:110"                                                 
time="2024-10-15 12:47:20" level=info msg="📈 Registered measurement: podLatency" file="factory.go:90"                                                                                                                                        
time="2024-10-15 12:47:22" level=info msg="Job kubelet-density: 50 iterations with 1 Pod replicas" file="create.go:92"                                                                                                                        
time="2024-10-15 12:47:22" level=info msg="QPS: 2" file="job.go:136"                                                                                                                                                                          
time="2024-10-15 12:47:22" level=info msg="Burst: 2" file="job.go:137"                                                                                                                                                                        
time="2024-10-15 12:47:22" level=info msg="Triggering job: kubelet-density" file="job.go:143"                                                                                                                                                 
time="2024-10-15 12:47:22" level=info msg="Creating Pod latency watcher for kubelet-density" file="pod_latency.go:148"   
time="2024-10-15 12:47:21" level=info msg="5/50 iterations completed" file="create.go:133"
time="2024-10-15 12:47:26" level=info msg="10/50 iterations completed" file="create.go:133"
time="2024-10-15 12:47:30" level=error msg="10s timeout reached" file="job.go:278"
time="2024-10-15 12:47:30" level=info msg="Indexing job summaries" file="metadata.go:45"
time="2024-10-15 12:47:30" level=info msg="File collected-metrics/jobSummary.json created with 1 documents" file="metadata.go:64"
time="2024-10-15 12:47:30" level=info msg="🔍 Endpoint: http://localhost:9090; profile: metrics-profile.yaml start: 2024-10-15T10:47:22Z end: 2024-10-15T10:47:30Z; job: kubelet-density" file="prometheus.go:70"
time="2024-10-15 12:47:30" level=info msg="Indexing [2] documents from metric Up" file="prometheus.go:236"
time="2024-10-15 12:47:30" level=info msg="File collected-metrics/Up.json created with 2 documents" file="prometheus.go:241"
time="2024-10-15 12:47:30" level=info msg="Garbage collecting jobs" file="job.go:292"
time="2024-10-15 12:47:30" level=info msg="Deleting 1 namespaces with label: kube-burner-job=kubelet-density" file="namespaces.go:67"
time="2024-10-15 12:47:44" level=error msg="10s timeout reached" file="kube-burner.go:113"
```

