### PR TITLE
Add support for sequential handling on Patch jobs and objects

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -50,39 +50,41 @@ kube-burner connects k8s clusters using the following methods in this order:
 
 This section contains the list of jobs `kube-burner` will execute. Each job can hold the following parameters.
 
-| Option                       | Description                                                                                                                           | Type     | Default |
-|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|----------|---------|
-| `name`                       | Job name                                                                                                                              | String   | ""      |
-| `jobType`                    | Type of job to execute. More details at [job types](#job-types)                                                                       | String   | create  |
-| `jobIterations`              | How many times to execute the job                                                                                                     | Integer  | 0       |
-| `namespace`                  | Namespace base name to use                                                                                                            | String   | ""      |
-| `namespacedIterations`       | Whether to create a namespace per job iteration                                                                                       | Boolean  | true    |
-| `iterationsPerNamespace`     | The maximum number of `jobIterations` to create in a single namespace. Important for node-density workloads that create Services.     | Integer  | 1       |
-| `cleanup`                    | Cleanup clean up old namespaces                                                                                                       | Boolean  | true    |
-| `podWait`                    | Wait for all pods/jobs (including probes) to be running/completed before moving forward to the next job iteration                     | Boolean  | false   |
-| `waitWhenFinished`           | Wait for all pods/jobs (including probes) to be running/completed when all job iterations are completed                               | Boolean  | true    |
-| `maxWaitTimeout`             | Maximum wait timeout per namespace                                                                                                    | Duration | 4h      |
-| `jobIterationDelay`          | How long to wait between each job iteration. This is also the wait interval between each delete operation                             | Duration | 0s      |
-| `jobPause`                   | How long to pause after finishing the job                                                                                             | Duration | 0s      |
-| `beforeCleanup`              | Allows to run a bash script before the workload is deleted                                                                            | String   | ""      |
-| `qps`                        | Limit object creation queries per second                                                                                              | Integer  | 0       |
-| `burst`                      | Maximum burst for throttle                                                                                                            | Integer  | 0       |
-| `objects`                    | List of objects the job will create. Detailed on the [objects section](#objects)                                                      | List     | []      |
-| `verifyObjects`              | Verify object count after running each job                                                                                            | Boolean  | true    |
-| `errorOnVerify`              | Set RC to 1 when objects verification fails                                                                                           | Boolean  | true    |
-| `skipIndexing`               | Skip metric indexing on this job                                                                                                      | Boolean  | false   |
-| `preLoadImages`              | Kube-burner will create a DS before triggering the job to pull all the images of the job                                              | Boolean  |         |
-| `preLoadPeriod`              | How long to wait for the preload DaemonSet                                                                                            | Duration | 1m      |
-| `preloadNodeLabels`          | Add node selector labels for the resources created in preload stage                                                                   | Object   | {}      |
-| `namespaceLabels`            | Add custom labels to the namespaces created by kube-burner                                                                            | Object   | {}      |
-| `namespaceAnnotations`       | Add custom annotations to the namespaces created by kube-burner                                                                       | Object   | {}      |
-| `churn`                      | Churn the workload. Only supports namespace based workloads                                                                           | Boolean  | false   |
-| `churnCycles`                | Number of churn cycles to execute                                                                                                     | Integer  | 100     |
-| `churnPercent`               | Percentage of the jobIterations to churn each period                                                                                  | Integer  | 10      |
-| `churnDuration`              | Length of time that the job is churned for                                                                                            | Duration | 1h      |
-| `churnDelay`                 | Length of time to wait between each churn period                                                                                      | Duration | 5m      |
-| `churnDeletionStrategy`      | Churn deletion strategy to apply, `default` or `gvr` (where `default` churns namespaces and `gvr` churns objects within namespaces)   | String   | default |
-| `defaultMissingKeysWithZero` | Stops templates from exiting with an error when a missing key is found, meaning users will have to ensure templates hand missing keys | Boolean  | false   |
+| Option                       | Description                                                                                                                           | Type     | Default  |
+|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|----------|----------|
+| `name`                       | Job name                                                                                                                              | String   | ""       |
+| `jobType`                    | Type of job to execute. More details at [job types](#job-types)                                                                       | String   | create   |
+| `jobIterations`              | How many times to execute the job                                                                                                     | Integer  | 0        |
+| `namespace`                  | Namespace base name to use                                                                                                            | String   | ""       |
+| `namespacedIterations`       | Whether to create a namespace per job iteration                                                                                       | Boolean  | true     |
+| `iterationsPerNamespace`     | The maximum number of `jobIterations` to create in a single namespace. Important for node-density workloads that create Services.     | Integer  | 1        |
+| `cleanup`                    | Cleanup clean up old namespaces                                                                                                       | Boolean  | true     |
+| `podWait`                    | Wait for all pods/jobs (including probes) to be running/completed before moving forward to the next job iteration                     | Boolean  | false    |
+| `waitWhenFinished`           | Wait for all pods/jobs (including probes) to be running/completed when all job iterations are completed                               | Boolean  | true     |
+| `maxWaitTimeout`             | Maximum wait timeout per namespace                                                                                                    | Duration | 4h       |
+| `jobIterationDelay`          | How long to wait between each job iteration. This is also the wait interval between each delete operation                             | Duration | 0s       |
+| `jobPause`                   | How long to pause after finishing the job                                                                                             | Duration | 0s       |
+| `beforeCleanup`              | Allows to run a bash script before the workload is deleted                                                                            | String   | ""       |
+| `qps`                        | Limit object creation queries per second                                                                                              | Integer  | 0        |
+| `burst`                      | Maximum burst for throttle                                                                                                            | Integer  | 0        |
+| `objects`                    | List of objects the job will create. Detailed on the [objects section](#objects)                                                      | List     | []       |
+| `verifyObjects`              | Verify object count after running each job                                                                                            | Boolean  | true     |
+| `errorOnVerify`              | Set RC to 1 when objects verification fails                                                                                           | Boolean  | true     |
+| `skipIndexing`               | Skip metric indexing on this job                                                                                                      | Boolean  | false    |
+| `preLoadImages`              | Kube-burner will create a DS before triggering the job to pull all the images of the job                                              | Boolean  |          |
+| `preLoadPeriod`              | How long to wait for the preload DaemonSet                                                                                            | Duration | 1m       |
+| `preloadNodeLabels`          | Add node selector labels for the resources created in preload stage                                                                   | Object   | {}       |
+| `namespaceLabels`            | Add custom labels to the namespaces created by kube-burner                                                                            | Object   | {}       |
+| `namespaceAnnotations`       | Add custom annotations to the namespaces created by kube-burner                                                                       | Object   | {}       |
+| `churn`                      | Churn the workload. Only supports namespace based workloads                                                                           | Boolean  | false    |
+| `churnCycles`                | Number of churn cycles to execute                                                                                                     | Integer  | 100      |
+| `churnPercent`               | Percentage of the jobIterations to churn each period                                                                                  | Integer  | 10       |
+| `churnDuration`              | Length of time that the job is churned for                                                                                            | Duration | 1h       |
+| `churnDelay`                 | Length of time to wait between each churn period                                                                                      | Duration | 5m       |
+| `churnDeletionStrategy`      | Churn deletion strategy to apply, `default` or `gvr` (where `default` churns namespaces and `gvr` churns objects within namespaces)   | String   | default  |
+| `defaultMissingKeysWithZero` | Stops templates from exiting with an error when a missing key is found, meaning users will have to ensure templates hand missing keys | Boolean  | false    |
+| `patchExecutionMode`         | Execution mode of a `patch` job. More details at [patch execution modes](#execution-modes)                                            | String   | parallel |
+| `objectDelay`                | How long to wait between each object in a job                                                                                         | Duration | 0s       |
 
 !!! note
     Both `churnCycles` and `churnDuration` serve as termination conditions, with the churn process halting when either condition is met first. If someone wishes to exclusively utilize `churnDuration` to control churn, they can achieve this by setting `churnCycles` to `0`. Conversely, to prioritize `churnCycles`, one should set a longer `churnDuration` accordingly.
@@ -277,6 +279,13 @@ jobs:
   - kind: Secret
     labelSelector: {kube-burner-job: create-objects}
 ```
+
+#### Execution Modes
+
+Valid patch job execution modes
+
+- `parallel` - run all steps without any waiting between objects or iterations
+- `sequential` - Run for each object before moving to the next job iteration with an optional wait between objects and/or between iterations
 
 ## Churning Jobs
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -180,6 +180,10 @@ type Job struct {
 	// Skip this job from indexing
 	SkipIndexing               bool `yaml:"skipIndexing" json:"skipIndexing,omitempty"`
 	DefaultMissingKeysWithZero bool `yaml:"defaultMissingKeysWithZero" json:"defaultMissingKeysWithZero,omitempty"`
+	// Patch jobs execution mode can be either parallel or sequential. Default: parallel
+	PatchExecutionMode PatchExecutionMode `yaml:"patchExecutionMode" json:"patchExecutionMode,omitempty"`
+	// ObjectDelay how much time to wait between objects processing in patch jobs
+	ObjectDelay time.Duration `yaml:"objectDelay" json:"objectDelay,omitempty"`
 }
 
 type WaitOptions struct {
@@ -196,3 +200,11 @@ type WaitOptions struct {
 type KubeClientProvider struct {
 	restConfig *rest.Config
 }
+
+// Execution mode for Patch jobs
+type PatchExecutionMode string
+
+const (
+	PatchExecutionModeParallel   PatchExecutionMode = "parallel"
+	PatchExecutionModeSequential PatchExecutionMode = "sequential"
+)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -172,3 +172,17 @@ check_file_exists() {
   done
   return 0
 }
+
+check_deployment_count() {
+  local NAMESPACE=${1}
+  local LABEL_KEY=${2}
+  local LABEL_VALUE=${3}
+  local EXPECTED_COUNT=${4}
+
+  ACTUAL_COUNT=$(kubectl get deployment -n ${NAMESPACE} -l ${LABEL_KEY}=${LABEL_VALUE} -o json | jq '.items | length')
+  if [[ "${ACTUAL_COUNT}" != "${EXPECTED_COUNT}" ]]; then
+    echo "Expected ${EXPECTED_COUNT} replicas to be patches with ${LABEL_KEY}=${LABEL_VALUE_END} but found only ${ACTUAL_COUNT}"
+    return 1
+  fi
+  echo "Found the expected ${EXPECTED_COUNT} deployments"
+}

--- a/test/k8s/kube-burner-sequential-patch.yml
+++ b/test/k8s/kube-burner-sequential-patch.yml
@@ -1,0 +1,52 @@
+---
+jobs:
+  - name: sequential-patch
+    jobType: create
+    jobIterations: 1
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    namespacedIterations: false
+    preLoadImages: false
+    cleanup: true
+    namespace: {{ .NAMESPACE }}
+    podWait: false
+    waitWhenFinished: true
+    verifyObjects: true
+    errorOnVerify: true
+    jobIterationDelay: 5s
+    maxWaitTimeout: 2m
+    objects:
+
+    - objectTemplate: objectTemplates/deployment.yml
+      replicas: {{ .REPLICAS }}
+      inputVars:
+        containerImage: quay.io/cloud-bulldozer/sampleapp:latest
+      waitOptions:
+        forCondition: Available
+        customStatusPath: ".conditions[].type"
+
+  - name: relabel
+    jobType: patch
+    patchExecutionMode: sequential
+    jobIterations: 1
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    maxWaitTimeout: 10s
+    objects:
+    - kind: Deployment
+      objectTemplate: objectTemplates/deployment_patch_label.yaml
+      labelSelector: {kube-burner-job: sequential-patch}
+      patchType: "application/strategic-merge-patch+json"
+      apiVersion: apps/v1
+      inputVars:
+        labelKey: {{ .LABEL_KEY }}
+        labelValue: {{ .LABEL_VALUE_START }}
+    - kind: Deployment
+      objectTemplate: objectTemplates/deployment_patch_label.yaml
+      labelSelector:
+        {{ .LABEL_KEY }}: {{ .LABEL_VALUE_START }}
+      patchType: "application/strategic-merge-patch+json"
+      apiVersion: apps/v1
+      inputVars:
+        labelKey: {{ .LABEL_KEY }}
+        labelValue: {{ .LABEL_VALUE_END }}

--- a/test/k8s/objectTemplates/deployment_patch_label.yaml
+++ b/test/k8s/objectTemplates/deployment_patch_label.yaml
@@ -1,0 +1,5 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    {{ .labelKey }}: {{ .labelValue }}

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -163,3 +163,15 @@ teardown_file() {
   check_custom_status_path kube-burner-uuid="${UUID}" "{.items[*].status.conditions[].type}" Available
   kube-burner destroy --uuid "${UUID}"
 }
+
+@test "kube-burner init: sequential patch" {
+  export NAMESPACE="sequential-patch"
+  export LABEL_KEY="sequential.patch.test"
+  export LABEL_VALUE_START="start"
+  export LABEL_VALUE_END="end"
+  export REPLICAS=50
+
+  run_cmd kube-burner init -c  kube-burner-sequential-patch.yml --uuid="${UUID}" --log-level=debug
+  check_deployment_count ${NAMESPACE} ${LABEL_KEY} ${LABEL_VALUE_END} ${REPLICAS}
+  kubectl delete ns ${NAMESPACE}
+}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

Sequential execution runs all objects in a job iteration before reiterating
It allows delaying between objects and/or job iterations
Add PatchExecutionType for backward compatibility

## Related Tickets & Documents

- Related Issue #
- Closes #713 
