### PR TITLE
New PodReadyToStartContainers condition to pod_latency measurement

### DIFF
--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -12,7 +12,9 @@ Collects latencies from the different pod/vm/vmi startup phases, these **latency
   measurements:
   - name: podLatency
 ```
+
 or
+
 ```yaml
   measurements:
   - name: vmiLatency
@@ -71,6 +73,7 @@ Pod latency quantile sample:
 Where `quantileName` matches with the pod conditions and can be:
 
 - `PodScheduled`: Pod has been scheduled in to a node.
+- `PodReadyToStartContainers`: The Pod sandbox has been successfully created and networking configured.
 - `Initialized`: All init containers in the pod have started successfully
 - `ContainersReady`: Indicates whether all containers in the pod are ready.
 - `Ready`: The pod is able to service requests and should be added to the load balancing pools of all matching services.

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -100,7 +100,7 @@ func (p *podLatency) handleUpdatePod(obj interface{}) {
 							pm.NodeName = pod.Spec.NodeName
 						}
 					case corev1.PodReadyToStartContainers:
-						if pm.podReady.IsZero() {
+						if pm.readyToStartContainers.IsZero() {
 							pm.readyToStartContainers = c.LastTransitionTime.Time.UTC()
 						}
 					case corev1.PodInitialized:
@@ -327,7 +327,7 @@ func (p *podLatency) calcQuantiles() {
 			string(corev1.ContainersReady):           float64(podMetric.ContainersReadyLatency),
 			string(corev1.PodInitialized):            float64(podMetric.InitializedLatency),
 			string(corev1.PodReady):                  float64(podMetric.PodReadyLatency),
-			string(corev1.PodReadyToStartContainers): float64(podMetric.ReadyToStartContainers),
+			string(corev1.PodReadyToStartContainers): float64(podMetric.ReadyToStartContainersLatency),
 		}
 	}
 	p.latencyQuantiles = calculateQuantiles(p.normLatencies, getLatency, podLatencyQuantilesMeasurement)

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -38,24 +38,24 @@ const (
 )
 
 type podMetric struct {
-	Timestamp              time.Time `json:"timestamp"`
-	scheduled              time.Time
-	SchedulingLatency      int `json:"schedulingLatency"`
-	initialized            time.Time
-	InitializedLatency     int `json:"initializedLatency"`
-	containersReady        time.Time
-	ContainersReadyLatency int `json:"containersReadyLatency"`
-	podReady               time.Time
-	PodReadyLatency        int `json:"podReadyLatency"`
-	readyToStartContainers time.Time
-	ReadyToStartContainers int         `json:"readyToStartContainersLatency"`
-	MetricName             string      `json:"metricName"`
-	UUID                   string      `json:"uuid"`
-	JobName                string      `json:"jobName,omitempty"`
-	Namespace              string      `json:"namespace"`
-	Name                   string      `json:"podName"`
-	NodeName               string      `json:"nodeName"`
-	Metadata               interface{} `json:"metadata,omitempty"`
+	Timestamp                     time.Time `json:"timestamp"`
+	scheduled                     time.Time
+	SchedulingLatency             int `json:"schedulingLatency"`
+	initialized                   time.Time
+	InitializedLatency            int `json:"initializedLatency"`
+	containersReady               time.Time
+	ContainersReadyLatency        int `json:"containersReadyLatency"`
+	podReady                      time.Time
+	PodReadyLatency               int `json:"podReadyLatency"`
+	readyToStartContainers        time.Time
+	ReadyToStartContainersLatency int         `json:"readyToStartContainersLatency"`
+	MetricName                    string      `json:"metricName"`
+	UUID                          string      `json:"uuid"`
+	JobName                       string      `json:"jobName,omitempty"`
+	Namespace                     string      `json:"namespace"`
+	Name                          string      `json:"podName"`
+	NodeName                      string      `json:"nodeName"`
+	Metadata                      interface{} `json:"metadata,omitempty"`
 }
 
 type podLatency struct {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2086,SC2068
 
 KIND_VERSION=${KIND_VERSION:-v0.19.0}
-K8S_VERSION=${K8S_VERSION:-v1.27.0}
+K8S_VERSION=${K8S_VERSION:-v1.31.0}
 OCI_BIN=${OCI_BIN:-podman}
 ARCH=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
 KUBE_BURNER=${KUBE_BURNER:-kube-burner}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Very interesting new pod condition, enabled by default as of k8s 1.29 (OCP 4.16)

![image](https://github.com/user-attachments/assets/34b32613-7a47-4900-8ab3-2e40a09d61ea)

More info at https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-has-network


We can look at it to establish a new KPI directly inherited from CNI performance

## Related Tickets & Documents

- Related Issue #
- Closes #
