### PR TITLE
Allow running the test suite on a local Linux machine

### DIFF
--- a/.github/workflows/test-k8s.yml
+++ b/.github/workflows/test-k8s.yml
@@ -38,7 +38,6 @@ jobs:
 
     - name: Execute Tests
       run: |
-        export PATH=${PATH}:/tmp/
         chmod +x /tmp/kube-burner
         make test-k8s
       env:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BIN_NAME = kube-burner
 BIN_DIR = bin
 BIN_PATH = $(BIN_DIR)/$(ARCH)/$(BIN_NAME)
 CGO = 0
+TEST_BINARY ?= $(CURDIR)/$(BIN_PATH)
 
 GIT_COMMIT = $(shell git rev-parse HEAD)
 VERSION ?= $(shell hack/tag_name.sh)
@@ -77,4 +78,4 @@ manifest-build:
 test: lint test-k8s
 
 test-k8s:
-	cd test && bats -F pretty -T --print-output-on-failure test-k8s.bats
+	cd test && KUBE_BURNER=$(TEST_BINARY) bats -F pretty -T --print-output-on-failure test-k8s.bats

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -8,3 +8,34 @@ Tests can be executed locally with `make test`, some requirements are needed tho
 - bats
 - kubectl
 - podman or docker (required to run [kind](https://kind.sigs.k8s.io/))
+
+### Running test with Podman
+
+Since the test suite includes KubeVirt VMs, it must run with rootful Podman.
+Either run the tests as root, or access the rootful Podman socket.
+
+#### Allow access to the rootful Podman socket
+
+Assuming the user is in `wheel` group please do the following (one time):
+
+As root, create a Drop-In file `/etc/systemd/system/podman.socket.d/10-socketgroup.conf`
+with the following content:
+```
+[Socket]
+SocketGroup=wheel
+ExecStartPost=/usr/bin/chmod 755 /run/podman
+```
+
+The 1st line is needed in order to create the socket accessible by the `wheel` group.
+2nd line because systemd-tmpfiles recreates the folder as root:root without group reading rights.
+
+Stop `podman.socket` if it is running,
+reload the daemon `systemctl daemon-reload` since we changed the systemd settings
+and restart it again `systemctl enable --now podman.socket`
+
+#### Running the test
+
+Instruct Podman to communicate with the rootful Podman socket by setting the environment variable:
+```
+CONTAINER_HOST=unix://run/podman/podman.sock make test-k8s
+```

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -48,6 +48,13 @@ setup-prometheus() {
   sleep 10
 }
 
+setup-opensearch() {
+  echo "Setting up open-search"
+  # Use version 1 to avoid the password requirement
+  $OCI_BIN run --rm -d --name opensearch --env="discovery.type=single-node" --env="plugins.security.disabled=true" --publish=9200:9200 docker.io/opensearchproject/opensearch:1
+  sleep 10
+}
+
 check_ns() {
   echo "Checking the number of namespaces labeled with \"${1}\" is \"${2}\""
   if [[ $(kubectl get ns -l "${1}" -o name | wc -l) != "${2}" ]]; then

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -6,6 +6,7 @@ KIND_VERSION=${KIND_VERSION:-v0.19.0}
 K8S_VERSION=${K8S_VERSION:-v1.27.0}
 OCI_BIN=${OCI_BIN:-podman}
 ARCH=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+KUBE_BURNER=${KUBE_BURNER:-kube-burner}
 
 setup-kind() {
   KIND_FOLDER=$(mktemp -d)

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -44,7 +44,7 @@ destroy-kind() {
 
 setup-prometheus() {
   echo "Setting up prometheus instance"
-  $OCI_BIN run --rm -d --name prometheus --network=host docker.io/prom/prometheus:latest
+  $OCI_BIN run --rm -d --name prometheus --publish=9090:9090 docker.io/prom/prometheus:latest
   sleep 10
 }
 

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -18,11 +18,14 @@ setup_file() {
   setup-kind
   create_test_kubeconfig
   setup-prometheus
+  if [[ -z "$PERFSCALE_PROD_ES_SERVER" ]]; then
+    setup-opensearch
+  fi
 }
 
 setup() {
   export UUID; UUID=$(uuidgen)
-  export ES_SERVER="$PERFSCALE_PROD_ES_SERVER"
+  export ES_SERVER=${PERFSCALE_PROD_ES_SERVER:-"http://localhost:9200"}
   export ES_INDEX="kube-burner"
   export METRICS_FOLDER="metrics-${UUID}"
   export ES_INDEXING=""
@@ -38,6 +41,9 @@ teardown() {
 teardown_file() {
   destroy-kind
   $OCI_BIN rm -f prometheus
+  if [[ -z "$PERFSCALE_PROD_ES_SERVER" ]]; then
+    $OCI_BIN rm -f opensearch
+  fi
 }
 
 @test "kube-burner init: churn=true; absolute-path=true" {


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

The tests failed to run on a local Linux machine. To allow running it locally two main changes were required:
1. Run `opensearch` locally and instruct the tests to report to it
2. Run the tests with the locally built binary

In addition, instructions on running rootful Podman were added.
