### PR TITLE
Use sleep without specifying the unit

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -141,7 +141,7 @@ check_custom_status_path() {
 }
 
 check_metric_value() {
-  sleep 3s # There's some delay on the documents to show up in OpenSearch
+  sleep 3 # There's some delay on the documents to show up in OpenSearch
   for metric in "${@}"; do
     endpoint="${ES_SERVER}/${ES_INDEX}/_search?q=uuid.keyword:${UUID}+AND+metricName.keyword:${metric}"
     RESULT=$(curl -sS ${endpoint} | jq '.hits.total.value // error')

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -107,7 +107,7 @@ teardown_file() {
 
 @test "kube-burner init: crd" {
   kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/network-attachment-definition-client/master/artifacts/networks-crd.yaml
-  sleep 5s
+  sleep 5
   run_cmd kube-burner init -c kube-burner-crd.yml --uuid="${UUID}"
   kubectl delete -f objectTemplates/storageclass.yml
 }


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

Some implementations do not support setting the unit. Since seconds is already the default, no harm in just removing the s