### PR TITLE
[GH#683] fix: absolute file paths interpreted as urls

### DIFF
--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -40,9 +40,10 @@ teardown_file() {
   $OCI_BIN rm -f prometheus
 }
 
-@test "kube-burner init: churn=true" {
+@test "kube-burner init: churn=true; absolute-path=true" {
   export CHURN=true
   export CHURN_CYCLES=2
+  cp kube-burner.yml /tmp/kube-burner.yml
   run_cmd kube-burner init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current `ReadConfig` function attempts to read the `configFile` string as a URL. It falls back to treating it as a file path only if parsing the URL fails. This logic is causing the issue where absolute file paths pass the initial check. 

My suggested change uses `url.Parse` to check for a valid URL format. Instead of assuming any valid URI is a URL, it explicitly checks for the `http` or `https` schemes. Only if those schemes are present does it treat the `configFile` string as a URL.

## Related Tickets & Documents

- Closes #683 
