### PR TITLE
Reuse runJob for Delete and Read

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -83,7 +83,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | `churnDelay`                 | Length of time to wait between each churn period                                                                                      | Duration | 5m       |
 | `churnDeletionStrategy`      | Churn deletion strategy to apply, `default` or `gvr` (where `default` churns namespaces and `gvr` churns objects within namespaces)   | String   | default  |
 | `defaultMissingKeysWithZero` | Stops templates from exiting with an error when a missing key is found, meaning users will have to ensure templates hand missing keys | Boolean  | false    |
-| `patchExecutionMode`         | Execution mode of a `patch` job. More details at [patch execution modes](#execution-modes)                                            | String   | parallel |
+| `executionMode`              | Job execution mode. More details at [execution modes](#execution-modes)                                                               | String   | parallel |
 | `objectDelay`                | How long to wait between each object in a job                                                                                         | Duration | 0s       |
 
 !!! note
@@ -280,9 +280,9 @@ jobs:
     labelSelector: {kube-burner-job: create-objects}
 ```
 
-#### Execution Modes
+## Execution Modes
 
-Valid patch job execution modes
+Patch jobs support different execution modes
 
 - `parallel` - run all steps without any waiting between objects or iterations
 - `sequential` - Run for each object before moving to the next job iteration with an optional wait between objects and/or between iterations

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -44,7 +44,9 @@ func setupCreateJob(jobConfig config.Job) Executor {
 	var f io.Reader
 	mapper := newRESTMapper()
 	log.Debugf("Preparing create job: %s", jobConfig.Name)
-	ex := Executor{}
+	ex := Executor{
+		Job: jobConfig,
+	}
 	ex.DefaultMissingKeysWithZero = jobConfig.DefaultMissingKeysWithZero
 	for _, o := range jobConfig.Objects {
 		if o.Replicas < 1 {
@@ -149,7 +151,7 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 				"kube-burner-index": strconv.Itoa(objectIndex),
 				"kube-burner-runid": ex.runid,
 			}
-			ex.objects[objectIndex].labelSelector = labels
+			ex.objects[objectIndex].LabelSelector = labels
 			if obj.RunOnce {
 				if i == 0 {
 					// this executes only once during the first iteration of an object

--- a/pkg/burner/delete.go
+++ b/pkg/burner/delete.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/kube-burner/kube-burner/pkg/config"
-	"github.com/kube-burner/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,8 +30,20 @@ import (
 )
 
 func setupDeleteJob(jobConfig config.Job) Executor {
-	var ex Executor
 	log.Debugf("Preparing delete job: %s", jobConfig.Name)
+	ex := Executor{
+		Job:         jobConfig,
+		itemHandler: deleteHandler,
+	}
+	if ex.WaitForDeletion {
+		ex.objectFinalizer = verifyDelete
+	}
+
+	// Only a single iteration is supported for Delete job
+	ex.JobIterations = 1
+	// Use the sequencial mode
+	ex.ExecutionMode = config.ExecutionModeSequential
+
 	mapper := newRESTMapper()
 	for _, o := range jobConfig.Objects {
 		if o.APIVersion == "" {
@@ -47,72 +58,47 @@ func setupDeleteJob(jobConfig config.Job) Executor {
 			log.Fatalf("Empty labelSelectors not allowed with: %s", o.Kind)
 		}
 		obj := object{
-			gvr:           mapping.Resource,
-			labelSelector: o.LabelSelector,
+			Object: o,
+			gvr:    mapping.Resource,
 		}
 		obj.Namespaced = mapping.Scope.Name() == meta.RESTScopeNameNamespace
-		log.Debugf("Job %s: Delete %s with selector %s", jobConfig.Name, gvk.Kind, labels.Set(obj.labelSelector))
+		log.Debugf("Job %s: Delete %s with selector %s", jobConfig.Name, gvk.Kind, labels.Set(obj.LabelSelector))
 		ex.objects = append(ex.objects, obj)
 	}
 	return ex
 }
 
-// RunDeleteJob executes a deletion job
-func (ex *Executor) RunDeleteJob() {
-	var wg sync.WaitGroup
-	var itemList *unstructured.UnstructuredList
-	for _, obj := range ex.objects {
-		labelSelector := labels.Set(obj.labelSelector).String()
-		listOptions := metav1.ListOptions{
-			LabelSelector: labelSelector,
-		}
-		err := util.RetryWithExponentialBackOff(func() (done bool, err error) {
-			itemList, err = DynamicClient.Resource(obj.gvr).List(context.TODO(), listOptions)
-			if err != nil {
-				log.Errorf("Error found listing %s labeled with %s: %s", obj.gvr.Resource, labelSelector, err)
-				return false, nil
-			}
-			return true, nil
-		}, 1*time.Second, 3, 0, ex.MaxWaitTimeout)
-		if err != nil {
-			continue
-		}
-		log.Infof("Found %d %s with selector %s, removing them", len(itemList.Items), obj.gvr.Resource, labelSelector)
-		for _, item := range itemList.Items {
-			wg.Add(1)
-			go func(item unstructured.Unstructured) {
-				defer wg.Done()
-				ex.limiter.Wait(context.TODO())
-				var err error
-				if obj.Namespaced {
-					log.Debugf("Removing %s/%s from namespace %s", item.GetKind(), item.GetName(), item.GetNamespace())
-					err = DynamicClient.Resource(obj.gvr).Namespace(item.GetNamespace()).Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
-				} else {
-					log.Debugf("Removing %s/%s", item.GetKind(), item.GetName())
-					err = DynamicClient.Resource(obj.gvr).Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
-				}
-				if err != nil {
-					log.Errorf("Error found removing %s/%s: %s", item.GetKind(), item.GetName(), err)
-				}
-			}(item)
-			if ex.JobIterationDelay > 0 {
-				log.Infof("Sleeping for %v", ex.JobIterationDelay)
-				time.Sleep(ex.JobIterationDelay)
-			}
-		}
-		if ex.Job.WaitForDeletion {
-			wait.PollUntilContextCancel(context.TODO(), 2*time.Second, true, func(ctx context.Context) (done bool, err error) {
-				itemList, err = DynamicClient.Resource(obj.gvr).List(context.TODO(), listOptions)
-				if err != nil {
-					log.Error(err.Error())
-					return false, nil
-				}
-				if len(itemList.Items) > 0 {
-					log.Debugf("Waiting for %d %s labeled with %s to be deleted", len(itemList.Items), obj.gvr.Resource, labelSelector)
-					return false, nil
-				}
-				return true, nil
-			})
-		}
+func deleteHandler(ex *Executor, obj object, item unstructured.Unstructured, iteration int, wg *sync.WaitGroup) {
+	defer wg.Done()
+	ex.limiter.Wait(context.TODO())
+	var err error
+	if obj.Namespaced {
+		log.Debugf("Removing %s/%s from namespace %s", item.GetKind(), item.GetName(), item.GetNamespace())
+		err = DynamicClient.Resource(obj.gvr).Namespace(item.GetNamespace()).Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
+	} else {
+		log.Debugf("Removing %s/%s", item.GetKind(), item.GetName())
+		err = DynamicClient.Resource(obj.gvr).Delete(context.TODO(), item.GetName(), metav1.DeleteOptions{})
 	}
+	if err != nil {
+		log.Errorf("Error found removing %s/%s: %s", item.GetKind(), item.GetName(), err)
+	}
+}
+
+func verifyDelete(obj object) {
+	labelSelector := labels.Set(obj.LabelSelector).String()
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+	wait.PollUntilContextCancel(context.TODO(), 2*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		itemList, err := DynamicClient.Resource(obj.gvr).List(context.TODO(), listOptions)
+		if err != nil {
+			log.Error(err.Error())
+			return false, nil
+		}
+		if len(itemList.Items) > 0 {
+			log.Debugf("Waiting for %d %s labeled with %s to be deleted", len(itemList.Items), obj.gvr.Resource, labelSelector)
+			return false, nil
+		}
+		return true, nil
+	})
 }

--- a/pkg/burner/patch.go
+++ b/pkg/burner/patch.go
@@ -19,12 +19,10 @@ import (
 	"io"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,28 +32,21 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var (
-	defaultPatchExecutionMode   = config.PatchExecutionModeParallel
-	supportedPatchExecutionMode = map[config.PatchExecutionMode]struct{}{
-		config.PatchExecutionModeParallel:   {},
-		config.PatchExecutionModeSequential: {},
-	}
-)
-
 func setupPatchJob(jobConfig config.Job) Executor {
 	var f io.Reader
 	var err error
 	log.Debugf("Preparing patch job: %s", jobConfig.Name)
 
 	ex := Executor{
-		Job: jobConfig,
+		Job:         jobConfig,
+		itemHandler: patchHandler,
 	}
 
-	if len(ex.PatchExecutionMode) == 0 {
-		ex.PatchExecutionMode = defaultPatchExecutionMode
+	if len(ex.ExecutionMode) == 0 {
+		ex.ExecutionMode = config.ExecutionModeParallel
 	}
-	if _, ok := supportedPatchExecutionMode[ex.PatchExecutionMode]; !ok {
-		log.Fatalf("Unsupported Patch Execution Mode: %s", ex.PatchExecutionMode)
+	if _, ok := supportedExecutionMode[ex.ExecutionMode]; !ok {
+		log.Fatalf("Unsupported Execution Mode: %s", ex.ExecutionMode)
 	}
 
 	mapper := newRESTMapper()
@@ -88,108 +79,18 @@ func setupPatchJob(jobConfig config.Job) Executor {
 			log.Fatalln("Empty Patch Type not allowed")
 		}
 		obj := object{
-			gvr:           mapping.Resource,
-			objectSpec:    t,
-			Object:        o,
-			labelSelector: o.LabelSelector,
-			patchType:     o.PatchType,
+			gvr:        mapping.Resource,
+			objectSpec: t,
+			Object:     o,
 		}
 		obj.Namespaced = mapping.Scope.Name() == meta.RESTScopeNameNamespace
-		log.Infof("Job %s: Patch %s with selector %s", jobConfig.Name, gvk.Kind, labels.Set(obj.labelSelector))
+		log.Infof("Job %s: Patch %s with selector %s", jobConfig.Name, gvk.Kind, labels.Set(obj.LabelSelector))
 		ex.objects = append(ex.objects, obj)
 	}
 	return ex
 }
 
-func getItemListForObject(obj object, maxWaitTimeout time.Duration) (*unstructured.UnstructuredList, error) {
-	var itemList *unstructured.UnstructuredList
-	labelSelector := labels.Set(obj.labelSelector).String()
-	listOptions := metav1.ListOptions{
-		LabelSelector: labelSelector,
-	}
-
-	// Try to find the list of resources by GroupVersionResource.
-	err := util.RetryWithExponentialBackOff(func() (done bool, err error) {
-		itemList, err = DynamicClient.Resource(obj.gvr).List(context.TODO(), listOptions)
-		if err != nil {
-			log.Errorf("Error found listing %s labeled with %s: %s", obj.gvr.Resource, labelSelector, err)
-			return false, nil
-		}
-		log.Infof("Found %d %s with selector %s; patching them", len(itemList.Items), obj.gvr.Resource, labelSelector)
-		return true, nil
-	}, 1*time.Second, 3, 0, maxWaitTimeout)
-	if err != nil {
-		return nil, err
-	}
-	return itemList, nil
-}
-
-// RunPatchJob executes a patch job
-func (ex *Executor) RunPatchJob() {
-	switch ex.PatchExecutionMode {
-	case config.PatchExecutionModeParallel, "":
-		log.Info("Running patch in parallel mode")
-		ex.runParallel()
-	case config.PatchExecutionModeSequential:
-		log.Info("Running patch in sequential mode")
-		ex.runSequential()
-	}
-}
-
-func (ex *Executor) runSequential() {
-	for i := 0; i < ex.JobIterations; i++ {
-		for _, obj := range ex.objects {
-			itemList, err := getItemListForObject(obj, ex.MaxWaitTimeout)
-			if err != nil {
-				continue
-			}
-			var wg sync.WaitGroup
-			for _, item := range itemList.Items {
-				wg.Add(1)
-				go ex.patchHandler(obj, item, i, &wg)
-			}
-			// Wait for all items in the object
-			wg.Wait()
-			waitRateLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
-			ex.waitForObjects("", waitRateLimiter)
-
-			// Wait between object
-			if ex.ObjectDelay > 0 {
-				log.Infof("Sleeping between objects for %v", ex.ObjectDelay)
-				time.Sleep(ex.ObjectDelay)
-			}
-		}
-		// Wait between job iterations
-		if ex.JobIterationDelay > 0 {
-			log.Infof("Sleeping between job iterations for %v", ex.JobIterationDelay)
-			time.Sleep(ex.JobIterationDelay)
-		}
-	}
-}
-
-// runParallel executes all objects for all jobs in parallel
-func (ex *Executor) runParallel() {
-	var wg sync.WaitGroup
-	for _, obj := range ex.objects {
-		itemList, err := getItemListForObject(obj, ex.MaxWaitTimeout)
-		if err != nil {
-			continue
-		}
-		for j := 0; j < ex.JobIterations; j++ {
-			for _, item := range itemList.Items {
-				wg.Add(1)
-				go ex.patchHandler(obj, item, j, &wg)
-			}
-		}
-	}
-	wg.Wait()
-	waitRateLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
-	ex.waitForObjects("", waitRateLimiter)
-}
-
-func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructured,
-	iteration int, wg *sync.WaitGroup) {
-
+func patchHandler(ex *Executor, obj object, originalItem unstructured.Unstructured, iteration int, wg *sync.WaitGroup) {
 	defer wg.Done()
 	// There are several patch modes. Three of them are client-side, and one
 	// of them is server-side.
@@ -197,7 +98,7 @@ func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructu
 	patchOptions := metav1.PatchOptions{}
 
 	if strings.HasSuffix(obj.ObjectTemplate, "json") {
-		if obj.patchType == string(types.ApplyPatchType) {
+		if obj.PatchType == string(types.ApplyPatchType) {
 			log.Fatalf("Apply patch type requires YAML")
 		}
 		data = obj.objectSpec
@@ -223,7 +124,7 @@ func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructu
 		}
 
 		// Converting to JSON if patch type is not Apply
-		if obj.patchType == string(types.ApplyPatchType) {
+		if obj.PatchType == string(types.ApplyPatchType) {
 			data = renderedObj
 			patchOptions.FieldManager = "kube-controller-manager"
 		} else {
@@ -246,21 +147,20 @@ func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructu
 	if obj.Namespaced {
 		uns, err = DynamicClient.Resource(obj.gvr).Namespace(ns).
 			Patch(context.TODO(), originalItem.GetName(),
-				types.PatchType(obj.patchType), data, patchOptions)
+				types.PatchType(obj.PatchType), data, patchOptions)
 	} else {
 		uns, err = DynamicClient.Resource(obj.gvr).
 			Patch(context.TODO(), originalItem.GetName(),
-				types.PatchType(obj.patchType), data, patchOptions)
+				types.PatchType(obj.PatchType), data, patchOptions)
 	}
 	if err != nil {
 		if errors.IsForbidden(err) {
 			log.Fatalf("Authorization error patching %s/%s: %s", originalItem.GetKind(), originalItem.GetName(), err)
-		} else if err != nil {
+		} else {
 			log.Errorf("Error patching object %s/%s in namespace %s: %s", originalItem.GetKind(),
 				originalItem.GetName(), ns, err)
 		}
 	} else {
 		log.Debugf("Patched %s/%s in namespace %s", uns.GetKind(), uns.GetName(), ns)
 	}
-
 }

--- a/pkg/burner/read.go
+++ b/pkg/burner/read.go
@@ -16,11 +16,10 @@ package burner
 
 import (
 	"context"
-	"time"
+	"sync"
 
 	"github.com/kube-burner/kube-burner/pkg/config"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,8 +28,12 @@ import (
 )
 
 func setupReadJob(jobConfig config.Job) Executor {
-	var ex Executor
 	log.Debugf("Preparing read job: %s", jobConfig.Name)
+	ex := Executor{
+		Job:         jobConfig,
+		itemHandler: readHandler,
+	}
+	ex.ExecutionMode = config.ExecutionModeSequential
 	mapper := newRESTMapper()
 	for _, o := range jobConfig.Objects {
 		if o.APIVersion == "" {
@@ -45,69 +48,29 @@ func setupReadJob(jobConfig config.Job) Executor {
 			log.Fatalf("Empty labelSelectors not allowed with: %s", o.Kind)
 		}
 		obj := object{
-			gvr:           mapping.Resource,
-			labelSelector: o.LabelSelector,
+			Object: o,
+			gvr:    mapping.Resource,
 		}
 		obj.Namespaced = mapping.Scope.Name() == meta.RESTScopeNameNamespace
-		log.Debugf("Job %s: Read %s with selector %s", jobConfig.Name, gvk.Kind, labels.Set(obj.labelSelector))
+		log.Debugf("Job %s: Read %s with selector %s", jobConfig.Name, gvk.Kind, labels.Set(obj.LabelSelector))
 		ex.objects = append(ex.objects, obj)
 	}
 	log.Infof("Job %s: %d iterations", jobConfig.Name, jobConfig.JobIterations)
 	return ex
 }
 
-// RunReadJob executes a reading job
-func (ex *Executor) RunReadJob(iterationStart, iterationEnd int) {
-	var itemList *unstructured.UnstructuredList
-
-	// We have to sum 1 since the iterations start from 1
-	iterationProgress := (iterationEnd - iterationStart) / 10
-	percent := 1
-	waitRateLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
-	ex.waitForObjects("", waitRateLimiter)
-	for i := iterationStart; i < iterationEnd; i++ {
-		if i == iterationStart+iterationProgress*percent {
-			log.Infof("%v/%v iterations completed", i-iterationStart, iterationEnd-iterationStart)
-			percent++
-		}
-		log.Debugf("Reading object from iteration %d", i)
-		for _, obj := range ex.objects {
-			labelSelector := labels.Set(obj.labelSelector).String()
-			listOptions := metav1.ListOptions{
-				LabelSelector: labelSelector,
-			}
-			err := RetryWithExponentialBackOff(func() (done bool, err error) {
-				itemList, err = DynamicClient.Resource(obj.gvr).List(context.TODO(), listOptions)
-				if err != nil {
-					log.Errorf("Error found listing %s labeled with %s: %s", obj.gvr.Resource, labelSelector, err)
-					return false, nil
-				}
-				return true, nil
-			}, 1*time.Second, 3, 0, ex.MaxWaitTimeout)
-			if err != nil {
-				continue
-			}
-			log.Infof("Found %d %s with selector %s, reading them", len(itemList.Items), obj.gvr.Resource, labelSelector)
-			for _, item := range itemList.Items {
-				go func(item unstructured.Unstructured) {
-					ex.limiter.Wait(context.TODO())
-					var err error
-					if obj.Namespaced {
-						log.Debugf("Reading %s/%s from namespace %s", item.GetKind(), item.GetName(), item.GetNamespace())
-						_, err = DynamicClient.Resource(obj.gvr).Namespace(item.GetNamespace()).Get(context.TODO(), item.GetName(), metav1.GetOptions{})
-					} else {
-						log.Debugf("Reading %s/%s", item.GetKind(), item.GetName())
-						_, err = DynamicClient.Resource(obj.gvr).Get(context.TODO(), item.GetName(), metav1.GetOptions{})
-					}
-					if err != nil {
-						log.Errorf("Error found reading %s/%s: %s", item.GetKind(), item.GetName(), err)
-					}
-				}(item)
-				if ex.JobIterationDelay > 0 {
-					log.Infof("Sleeping for %v", ex.JobIterationDelay)
-					time.Sleep(ex.JobIterationDelay)
-				}
-			}
-		}
+func readHandler(ex *Executor, obj object, item unstructured.Unstructured, iteration int, wg *sync.WaitGroup) {
+	defer wg.Done()
+	ex.limiter.Wait(context.TODO())
+	var err error
+	if obj.Namespaced {
+		log.Debugf("Reading %s/%s from namespace %s", item.GetKind(), item.GetName(), item.GetNamespace())
+		_, err = DynamicClient.Resource(obj.gvr).Namespace(item.GetNamespace()).Get(context.TODO(), item.GetName(), metav1.GetOptions{})
+	} else {
+		log.Debugf("Reading %s/%s", item.GetKind(), item.GetName())
+		_, err = DynamicClient.Resource(obj.gvr).Get(context.TODO(), item.GetName(), metav1.GetOptions{})
+	}
+	if err != nil {
+		log.Errorf("Error found reading %s/%s: %s", item.GetKind(), item.GetName(), err)
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -180,8 +180,8 @@ type Job struct {
 	// Skip this job from indexing
 	SkipIndexing               bool `yaml:"skipIndexing" json:"skipIndexing,omitempty"`
 	DefaultMissingKeysWithZero bool `yaml:"defaultMissingKeysWithZero" json:"defaultMissingKeysWithZero,omitempty"`
-	// Patch jobs execution mode can be either parallel or sequential. Default: parallel
-	PatchExecutionMode PatchExecutionMode `yaml:"patchExecutionMode" json:"patchExecutionMode,omitempty"`
+	// Execute objects in a job either parallel or sequential. Default: parallel
+	ExecutionMode ExecutionMode `yaml:"executionMode" json:"executionMode,omitempty"`
 	// ObjectDelay how much time to wait between objects processing in patch jobs
 	ObjectDelay time.Duration `yaml:"objectDelay" json:"objectDelay,omitempty"`
 }
@@ -202,9 +202,9 @@ type KubeClientProvider struct {
 }
 
 // Execution mode for Patch jobs
-type PatchExecutionMode string
+type ExecutionMode string
 
 const (
-	PatchExecutionModeParallel   PatchExecutionMode = "parallel"
-	PatchExecutionModeSequential PatchExecutionMode = "sequential"
+	ExecutionModeParallel   ExecutionMode = "parallel"
+	ExecutionModeSequential ExecutionMode = "sequential"
 )

--- a/test/k8s/kube-burner-sequential-patch.yml
+++ b/test/k8s/kube-burner-sequential-patch.yml
@@ -27,7 +27,7 @@ jobs:
 
   - name: relabel
     jobType: patch
-    patchExecutionMode: sequential
+    executionMode: sequential
     jobIterations: 1
     qps: {{ .QPS }}
     burst: {{ .BURST }}


### PR DESCRIPTION
## Type of change

- [x] Refactor

## Description

Rename executionMode to unlink from patch
Move runJob and its internals to utiles  and use in Read and Delete jobs
Add ObjectFinalizer in addition to ItemHandler
Set Job for Executor and make sure it is not accesses once it is passed to executor
Remove redundant labelSelector and patchType fields from object
