### PR TITLE
Plugable measurements

### DIFF
--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -97,7 +97,7 @@ And the metrics are:
 
 ### Pod latency thresholds
 
-It is possible to establish pod latency thresholds to the different pod conditions and metrics by defining the option `thresholds` within in the the config of this measurement:
+It is possible to establish pod latency thresholds to the different pod conditions and metrics by defining the option `thresholds` within the config of this measurement:
 
 Establishing a threshold of 2000ms in the P99 metric of the `Ready` condition.
 

--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -97,17 +97,18 @@ And the metrics are:
 
 ### Pod latency thresholds
 
-It is possible to establish pod latency thresholds to the different pod conditions and metrics by defining the option `thresholds` within this measurement:
+It is possible to establish pod latency thresholds to the different pod conditions and metrics by defining the option `thresholds` within in the the config of this measurement:
 
 Establishing a threshold of 2000ms in the P99 metric of the `Ready` condition.
 
 ```yaml
   measurements:
   - name: podLatency
-    thresholds:
-    - conditionType: Ready
-      metric: P99
-      threshold: 2000ms
+    config:
+      thresholds:
+      - conditionType: Ready
+        metric: P99
+        threshold: 2000ms
 ```
 
 Latency thresholds are evaluated at the end of each job, showing an informative message like the following:
@@ -232,7 +233,8 @@ This measure is enabled with:
 ```yaml
   measurements:
   - name: serviceLatency
-    svcTimeout: 5s
+    config:
+      svcTimeout: 5s
 ```
 
 Where `svcTimeout`, by default `5s`, defines the maximum amount of time the measurement will wait for a service to be ready, when this timeout is met, the metric from that service is **discarded**.
@@ -433,21 +435,22 @@ An example of how to configure this measurement to collect pprof HEAP and CPU pr
 ```yaml
   measurements:
   - name: pprof
-    pprofInterval: 30m
-    pprofDirectory: pprof-data
-    pprofTargets:
-    - name: kube-apiserver-heap
-      namespace: "openshift-kube-apiserver"
-      labelSelector: {app: openshift-kube-apiserver}
-      bearerToken: thisIsNotAValidToken
-      url: https://localhost:6443/debug/pprof/heap
+    config:
+      pprofInterval: 30m
+      pprofDirectory: pprof-data
+      pprofTargets:
+      - name: kube-apiserver-heap
+        namespace: "openshift-kube-apiserver"
+        labelSelector: {app: openshift-kube-apiserver}
+        bearerToken: thisIsNotAValidToken
+        url: https://localhost:6443/debug/pprof/heap
 
-    - name: etcd-heap
-      namespace: "openshift-etcd"
-      labelSelector: {app: etcd}
-      certFile: etcd-peer-pert.crt
-      keyFile: etcd-peer-pert.key
-      url: https://localhost:2379/debug/pprof/heap
+      - name: etcd-heap
+        namespace: "openshift-etcd"
+        labelSelector: {app: etcd}
+        certFile: etcd-peer-pert.crt
+        keyFile: etcd-peer-pert.key
+        url: https://localhost:2379/debug/pprof/heap
 ```
 
 !!! warning
@@ -494,8 +497,9 @@ metricsEndpoints:
 global:
   measurements:
   - name: podLatency
-    timeseriesIndexer: local-indexer
-    quantilesIndexer: os-indexer
+    config:
+      timeseriesIndexer: local-indexer
+      quantilesIndexer: os-indexer
 ```
 
 With the configuration snippet above, the measurement `podLatency` would use the local indexer for timeseries metrics and opensearch for the quantile metrics.

--- a/examples/workloads/kubelet-density/kubelet-density.yml
+++ b/examples/workloads/kubelet-density/kubelet-density.yml
@@ -3,6 +3,11 @@ global:
   gc: true
   measurements:
    - name: podLatency
+     config:
+      thresholds:
+        - conditionType: Ready
+          metric: P99
+          threshold: 5s
 jobs:
   - name: kubelet-density
     jobIterations: 25

--- a/pkg/measurements/common.go
+++ b/pkg/measurements/common.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func IndexLatencyMeasurement(config types.Measurement, jobName string, metricMap map[string][]interface{}, indexerList map[string]indexers.Indexer) {
+func IndexLatencyMeasurement(config types.MeasurementConfig, jobName string, metricMap map[string][]interface{}, indexerList map[string]indexers.Indexer) {
 	indexDocuments := func(indexer indexers.Indexer, metricName string, data []interface{}) {
 		log.Infof("Indexing metric %s", metricName)
 		indexingOpts := indexers.IndexingOpts{

--- a/pkg/measurements/node_latency.go
+++ b/pkg/measurements/node_latency.go
@@ -55,7 +55,7 @@ type NodeMetric struct {
 }
 
 type nodeLatency struct {
-	config           types.Measurement
+	config           types.MeasurementConfig
 	watcher          *metrics.Watcher
 	metrics          sync.Map
 	latencyQuantiles []interface{}
@@ -111,7 +111,7 @@ func (n *nodeLatency) handleUpdateNode(obj interface{}) {
 	}
 }
 
-func (n *nodeLatency) setConfig(cfg types.Measurement) error {
+func (n *nodeLatency) setConfig(cfg types.MeasurementConfig) error {
 	n.config = cfg
 	var metricFound bool
 	var latencyMetrics = []string{"P99", "P95", "P50", "Avg", "Max"}

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -62,7 +62,7 @@ type podMetric struct {
 }
 
 type podLatency struct {
-	config           types.Measurement
+	config           types.MeasurementConfig
 	watcher          *metrics.Watcher
 	metrics          sync.Map
 	latencyQuantiles []interface{}
@@ -130,7 +130,7 @@ func (p *podLatency) handleUpdatePod(obj interface{}) {
 	}
 }
 
-func (p *podLatency) setConfig(cfg types.Measurement) error {
+func (p *podLatency) setConfig(cfg types.MeasurementConfig) error {
 	p.config = cfg
 	var metricFound bool
 	var latencyMetrics = []string{"P99", "P95", "P50", "Avg", "Max"}

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -38,7 +38,7 @@ import (
 )
 
 type pprof struct {
-	config      types.Measurement
+	config      types.MeasurementConfig
 	stopChannel chan bool
 }
 
@@ -46,7 +46,7 @@ func init() {
 	measurementMap["pprof"] = &pprof{}
 }
 
-func (p *pprof) setConfig(cfg types.Measurement) error {
+func (p *pprof) setConfig(cfg types.MeasurementConfig) error {
 	p.config = cfg
 	for _, target := range p.config.PProfTargets {
 		if target.BearerToken != "" && (target.CertFile != "" || target.Cert != "") {

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -40,7 +40,7 @@ const (
 )
 
 type serviceLatency struct {
-	config           types.Measurement
+	config           types.MeasurementConfig
 	svcWatcher       *metrics.Watcher
 	epWatcher        *metrics.Watcher
 	epLister         lcorev1.EndpointsLister
@@ -147,7 +147,7 @@ func (s *serviceLatency) handleCreateSvc(obj interface{}) {
 	}(svc)
 }
 
-func (s *serviceLatency) setConfig(cfg types.Measurement) error {
+func (s *serviceLatency) setConfig(cfg types.MeasurementConfig) error {
 	s.config = cfg
 	if s.config.ServiceTimeout == 0 {
 		return fmt.Errorf("svcTimeout cannot be 0")

--- a/pkg/measurements/types/types.go
+++ b/pkg/measurements/types/types.go
@@ -23,23 +23,22 @@ const (
 )
 
 // UnmarshalYAML implements Unmarshaller to customize object defaults
-func (m *Measurement) UnmarshalMeasurement(unmarshal func(interface{}) error) error {
-	type rawMeasurement Measurement
-	measurement := rawMeasurement{
+func (m *MeasurementConfig) UnmarshalMeasurementConfig(unmarshal func(interface{}) error) error {
+	type rawMeasurementConfig MeasurementConfig
+	measurementCfg := rawMeasurementConfig{
 		PProfDirectory: pprofDirectory,
 		ServiceTimeout: 5 * time.Second,
 	}
-	if err := unmarshal(&measurement); err != nil {
-		return err
-	}
-	*m = Measurement(measurement)
+	*m = MeasurementConfig(measurementCfg)
 	return nil
 }
 
-// Measurement holds the measurement configuration
-type Measurement struct {
-	// Name is the name the measurement
-	Name string `yaml:"name"`
+type MeasurementConfig struct {
+	Extra map[string]any `yaml:",inline"`
+	// Defines the indexer for quantile metrics
+	QuantilesIndexer string `yaml:"quantilesIndexer"`
+	// Defines the indexer for timeseries
+	TimeseriesIndexer string `yaml:"timeseriesIndexer"`
 	// LatencyThresholds config
 	LatencyThresholds []LatencyThreshold `yaml:"thresholds"`
 	// PPRofTargets targets config
@@ -50,10 +49,14 @@ type Measurement struct {
 	PProfDirectory string `yaml:"pprofDirectory"`
 	// Service latency endpoint timeout
 	ServiceTimeout time.Duration `yaml:"svcTimeout"`
-	// Defines the indexer for quantile metrics
-	QuantilesIndexer string `yaml:"quantilesIndexer"`
-	// Defines the indexer for timeseries
-	TimeseriesIndexer string `yaml:"timeseriesIndexer"`
+}
+
+// Measurement holds the measurement configuration
+type Measurement struct {
+	// Name is the name the measurement
+	Name string `yaml:"name"`
+	// Measurement config
+	Config MeasurementConfig `yaml:"config"`
 }
 
 // LatencyThreshold holds the thresholds configuration

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -83,7 +83,7 @@ type vmiMetric struct {
 }
 
 type vmiLatency struct {
-	config           types.Measurement
+	config           types.MeasurementConfig
 	vmWatcher        *metrics.Watcher
 	vmiWatcher       *metrics.Watcher
 	vmiPodWatcher    *metrics.Watcher
@@ -280,7 +280,7 @@ func (vmi *vmiLatency) handleUpdateVMIPod(obj interface{}) {
 	}
 }
 
-func (vmi *vmiLatency) setConfig(cfg types.Measurement) error {
+func (vmi *vmiLatency) setConfig(cfg types.MeasurementConfig) error {
 	vmi.config = cfg
 	var metricFound bool
 	var latencyMetrics = []string{"P99", "P95", "P50", "Avg", "Max"}

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kube-burner/kube-burner/pkg/burner"
 	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/measurements"
 	"github.com/kube-burner/kube-burner/pkg/util"
 	"github.com/kube-burner/kube-burner/pkg/util/metrics"
 	log "github.com/sirupsen/logrus"
@@ -68,6 +69,9 @@ func (wh *WorkloadHelper) Run(workload string) int {
 	ConfigSpec, err = config.Parse(wh.UUID, wh.Timeout, f)
 	if err != nil {
 		log.Fatal(err)
+	}
+	for _, cfg := range wh.CustomMeasurements {
+		measurements.Load(cfg.Name, cfg.Func)
 	}
 	if embedConfig {
 		ConfigSpec.EmbedFS = wh.embedConfig

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -20,16 +20,23 @@ import (
 
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/ocp-metadata"
 	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/measurements"
 )
 
+type CustomMeasurement struct {
+	Func measurements.Measurement
+	Name string
+}
+
 type Config struct {
-	UUID            string
-	Timeout         time.Duration
-	MetricsEndpoint string
-	UserMetadata    string
-	ConfigDir       string
-	PrometheusURL   string
-	PrometheusToken string
+	UUID               string
+	Timeout            time.Duration
+	MetricsEndpoint    string
+	UserMetadata       string
+	ConfigDir          string
+	PrometheusURL      string
+	PrometheusToken    string
+	CustomMeasurements []CustomMeasurement
 }
 
 type WorkloadHelper struct {

--- a/test/k8s/kube-burner-virt.yml
+++ b/test/k8s/kube-burner-virt.yml
@@ -4,8 +4,9 @@ global:
   gc: {{env "GC"}}
   measurements:
   - name: vmiLatency
+    config:
 {{ if .TIMESERIES_INDEXER }}
-    timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
+      timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
 {{ end }}
 metricsEndpoints:
 {{ if .ES_INDEXING }}

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -9,6 +9,7 @@ global:
       timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
 {{ end }}
   - name: nodeLatency
+    config:
 {{ if .TIMESERIES_INDEXER }}
       timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
 {{ end }}
@@ -45,7 +46,7 @@ jobs:
     qps: {{ .QPS }}
     burst: {{ .BURST }}
     namespacedIterations: true
-    preLoadImages: true
+    preLoadImages: {{ .PRELOAD }}
     preLoadPeriod: 5s
     cleanup: true
     namespace: namespaced

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -4,15 +4,17 @@ global:
   gc: {{env "GC"}}
   measurements:
   - name: podLatency
+    config:
 {{ if .TIMESERIES_INDEXER }}
-    timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
+      timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
 {{ end }}
   - name: nodeLatency
 {{ if .TIMESERIES_INDEXER }}
-    timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
+      timeseriesIndexer: {{env "TIMESERIES_INDEXER"}}
 {{ end }}
   - name: serviceLatency
-    svcTimeout: 5s
+    config:
+      svcTimeout: 5s
 metricsEndpoints:
 {{ if .ES_INDEXING }}
   - endpoint: http://localhost:9090

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -56,6 +56,7 @@ teardown_file() {
   export CHURN_CYCLES=1
   cp kube-burner.yml /tmp/kube-burner.yml
   run_cmd ${KUBE_BURNER} init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
+  check_file_exists "kube-burner-${UUID}.log"
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }
@@ -161,11 +162,6 @@ teardown_file() {
 @test "kube-burner check-alerts" {
   run_cmd ${KUBE_BURNER} check-alerts -a alerts.yml -u http://localhost:9090 --metrics-directory=alerts
   check_file_list alerts/alert.json
-}
-
-@test "kube-burner log file output" {
-  run_cmd ${KUBE_BURNER} init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
-  check_file_exists "kube-burner-${UUID}.log"
 }
 
 @test "kube-burner init: waitOptions for Deployment" {

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -33,6 +33,7 @@ setup() {
   export ES_INDEXING=""
   export LOCAL_INDEXING=""
   export ALERTING=""
+  export PRELOAD=false
   export TIMESERIES_INDEXER=""
 }
 
@@ -52,15 +53,16 @@ teardown_file() {
 
 @test "kube-burner init: churn=true; absolute-path=true" {
   export CHURN=true
-  export CHURN_CYCLES=2
+  export CHURN_CYCLES=1
   cp kube-burner.yml /tmp/kube-burner.yml
   run_cmd ${KUBE_BURNER} init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
   check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
   check_destroyed_pods default kube-burner-job=not-namespaced,kube-burner-uuid="${UUID}"
 }
 
-@test "kube-burner init: gc=false" {
+@test "kube-burner init: gc=false; preload=true" {
   export GC=false
+  export PRELOAD=true
   run_cmd ${KUBE_BURNER} init -c kube-burner.yml --uuid="${UUID}" --log-level=debug
   check_ns kube-burner-job=namespaced,kube-burner-uuid="${UUID}" 5
   check_running_pods kube-burner-job=namespaced,kube-burner-uuid="${UUID}" 10


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [x] Documentation Update

## Description

Add new mechanism to add custom measurements from wrappers. It can be used by populating `CustomMeasurements` in `workloads/types.go`

As new measurements can use an arbitrary configuration, it was needed to create a new field `config`  in each measurement, which holds the OOTB measurement configurations and arbitrary fields.

This is a **breaking** change and will require to update configuration files accordingly.


## Related Tickets & Documents

- Related Issue #
- Closes #
