### PR TITLE
Tests - allow running against an existing cluster

### DIFF
--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -39,3 +39,21 @@ Instruct Podman to communicate with the rootful Podman socket by setting the env
 ```
 CONTAINER_HOST=unix://run/podman/podman.sock make test-k8s
 ```
+
+### Running test with an External Cluster
+
+By default, the tests start a local cluster using [kind](https://kind.sigs.k8s.io/).
+Instead, you can use an already existsing cluster.
+
+#### Prerequisites
+
+Since the test suite includes KubeVirt VMs, the cluster must include the `kubevirt` operator.
+See the [Installation](https://kubevirt.io/user-guide/cluster_admin/installation/) guide for details.
+
+#### Kubeconfig
+
+Either save the kubeconfig file under `~/.kube/config` or set the environment variable `KUBECONFIG` to its location
+
+#### Run the tests
+
+In order to instruct the tests to use the existing cluster set `USE_EXISTING_CLUSTER=yes` when calling `make`.

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -34,8 +34,15 @@ setup-kind() {
 
 create_test_kubeconfig() {
   echo "Creating another kubeconfig"
-  "${KIND_FOLDER}/kind-linux-${ARCH}" export kubeconfig --kubeconfig "${TEST_KUBECONFIG}"
-  kubectl config rename-context kind-kind "${TEST_KUBECONTEXT}" --kubeconfig "${TEST_KUBECONFIG}"
+  if [[ "${USE_EXISTING_CLUSTER,,}" == "yes" ]]; then
+    EXISTING_KUBECONFIG=${KUBECONFIG:-"~/.kube/config"}
+    cp ${EXISTING_KUBECONFIG} ${TEST_KUBECONFIG}
+    EXISTING_CONTEXT=$(kubectl config current-context)
+  else
+    "${KIND_FOLDER}/kind-linux-${ARCH}" export kubeconfig --kubeconfig "${TEST_KUBECONFIG}"
+    EXISTING_CONTEXT="kind-kind"
+  fi
+  kubectl config rename-context ${EXISTING_CONTEXT} "${TEST_KUBECONTEXT}" --kubeconfig "${TEST_KUBECONFIG}"
 }
 
 destroy-kind() {

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -15,7 +15,9 @@ setup_file() {
   export CHURN_CYCLES=100
   export TEST_KUBECONFIG; TEST_KUBECONFIG=$(mktemp -d)/kubeconfig
   export TEST_KUBECONTEXT=test-context
-  setup-kind
+  if [[ "${USE_EXISTING_CLUSTER,,}" != "yes" ]]; then
+    setup-kind
+  fi
   create_test_kubeconfig
   setup-prometheus
   if [[ -z "$PERFSCALE_PROD_ES_SERVER" ]]; then
@@ -39,7 +41,9 @@ teardown() {
 }
 
 teardown_file() {
-  destroy-kind
+  if [[ "${USE_EXISTING_CLUSTER,,}" != "yes" ]]; then
+    destroy-kind
+  fi
   $OCI_BIN rm -f prometheus
   if [[ -z "$PERFSCALE_PROD_ES_SERVER" ]]; then
     $OCI_BIN rm -f opensearch


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

Allow running the tests with an existing cluster instead of running a dedicated one using Kind. This resolves cases in which users do not have root access in order to use rootless podman or if KVM is not supported (e.g. MacOS)