### PR TITLE
Reuse Executor and object setup code

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kube-burner/kube-burner/pkg/config"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 
@@ -39,16 +38,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func setupCreateJob(jobConfig config.Job) Executor {
+func setupCreateJob(ex *Executor) {
 	var err error
 	var f io.Reader
 	mapper := newRESTMapper()
-	log.Debugf("Preparing create job: %s", jobConfig.Name)
-	ex := Executor{
-		Job: jobConfig,
-	}
-	ex.DefaultMissingKeysWithZero = jobConfig.DefaultMissingKeysWithZero
-	for _, o := range jobConfig.Objects {
+	log.Debugf("Preparing create job: %s", ex.Name)
+
+	for _, o := range ex.Objects {
 		if o.Replicas < 1 {
 			log.Warnf("Object template %s has replicas %d < 1, skipping", o.ObjectTemplate, o.Replicas)
 			continue
@@ -91,10 +87,9 @@ func setupCreateJob(jobConfig config.Job) Executor {
 		if obj.Namespaced && obj.namespace == "" {
 			ex.nsRequired = true
 		}
-		log.Infof("Job %s: %d iterations with %d %s replicas", jobConfig.Name, jobConfig.JobIterations, obj.Replicas, gvk.Kind)
+		log.Infof("Job %s: %d iterations with %d %s replicas", ex.Name, ex.JobIterations, obj.Replicas, gvk.Kind)
 		ex.objects = append(ex.objects, obj)
 	}
-	return ex
 }
 
 // RunCreateJob executes a creation job

--- a/pkg/burner/executor.go
+++ b/pkg/burner/executor.go
@@ -1,0 +1,63 @@
+// Copyright 2024 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"sync"
+
+	"github.com/kube-burner/kube-burner/pkg/config"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Executor contains the information required to execute a job
+type ItemHandler func(ex *Executor, obj object, originalItem unstructured.Unstructured, iteration int, wg *sync.WaitGroup)
+type ObjectFinalizer func(obj object)
+
+type Executor struct {
+	config.Job
+	objects         []object
+	uuid            string
+	runid           string
+	limiter         *rate.Limiter
+	nsRequired      bool
+	itemHandler     ItemHandler
+	objectFinalizer ObjectFinalizer
+}
+
+func newExecutor(job config.Job, uuid, runid string) *Executor {
+	ex := &Executor{
+		Job:     job,
+		limiter: rate.NewLimiter(rate.Limit(job.QPS), job.Burst),
+		uuid:    uuid,
+		runid:   runid,
+	}
+
+	switch job.JobType {
+	case config.CreationJob:
+		setupCreateJob(ex)
+	case config.DeletionJob:
+		setupDeleteJob(ex)
+	case config.PatchJob:
+		setupPatchJob(ex)
+	case config.ReadJob:
+		setupReadJob(ex)
+	default:
+		log.Fatalf("Unknown jobType: %s", job.JobType)
+	}
+
+	return ex
+}

--- a/pkg/burner/object.go
+++ b/pkg/burner/object.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"io"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/util"
+)
+
+type object struct {
+	config.Object
+	gvr        schema.GroupVersionResource
+	objectSpec []byte
+	kind       string
+	namespace  string
+}
+
+func newObject(obj config.Object, mapper meta.RESTMapper) object {
+	if obj.APIVersion == "" {
+		obj.APIVersion = "v1"
+	}
+
+	if len(obj.LabelSelector) == 0 {
+		log.Fatalf("Empty labelSelectors not allowed with: %s", obj.Kind)
+	}
+
+	gvk := schema.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
+	mapping, err := mapper.RESTMapping(gvk.GroupKind())
+	if err != nil {
+		log.Fatal(err)
+	}
+	obj.Namespaced = mapping.Scope.Name() == meta.RESTScopeNameNamespace
+
+	o := object{
+		Object: obj,
+		gvr:    mapping.Resource,
+	}
+
+	if obj.ObjectTemplate != "" {
+		log.Debugf("Rendering template: %s", obj.ObjectTemplate)
+		f, err := util.ReadConfig(obj.ObjectTemplate)
+		if err != nil {
+			log.Fatalf("Error reading template %s: %s", obj.ObjectTemplate, err)
+		}
+		t, err := io.ReadAll(f)
+		if err != nil {
+			log.Fatalf("Error reading template %s: %s", obj.ObjectTemplate, err)
+		}
+		o.objectSpec = t
+	}
+
+	return o
+}

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -41,7 +41,7 @@ type NestedPod struct {
 	} `json:"spec"`
 }
 
-func preLoadImages(job Executor) error {
+func preLoadImages(job *Executor) error {
 	log.Info("Pre-load: images from job ", job.Name)
 	imageList, err := getJobImages(job)
 	if err != nil {
@@ -64,7 +64,7 @@ func preLoadImages(job Executor) error {
 	return nil
 }
 
-func getJobImages(job Executor) ([]string, error) {
+func getJobImages(job *Executor) ([]string, error) {
 	var imageList []string
 	var unstructuredObject unstructured.Unstructured
 	for _, object := range job.objects {


### PR DESCRIPTION
## Type of change

- [x] Refactor

## Description

Consolidate the setup and creation of object and executor instances into a generic code.
For object, keep create with the old implantation as it is different from the rest
