### PR TITLE
fix localport in port forwarding

### DIFF
--- a/pkg/measurements/netpol_latency.go
+++ b/pkg/measurements/netpol_latency.go
@@ -54,7 +54,7 @@ const (
 	netpolLatencyQuantilesMeasurement = "netpolLatencyQuantilesMeasurement"
 )
 
-var proxyPortForwarder util.PodPortForwarder
+var proxyPortForwarder *util.PodPortForwarder
 var nsPodAddresses = make(map[string]map[string][]string)
 var proxyEndpoint string
 
@@ -488,13 +488,13 @@ func (n *netpolLatency) start(measurementWg *sync.WaitGroup) error {
 			return err
 		}
 	}
-	if proxyPortForwarder.LocalPort == "" {
+	if proxyPortForwarder == nil {
 		proxyPortForwarder, err = util.NewPodPortForwarder(factory.clientSet, *factory.restConfig, networkPolicyProxyPort, networkPolicyProxy, networkPolicyProxy)
 		if err != nil {
-			log.Error(err)
+			return err
 		}
 		// Use proxyEndpoint to communicate with proxy pod
-		proxyEndpoint = fmt.Sprintf("127.0.0.1:%s", proxyPortForwarder.LocalPort)
+		proxyEndpoint = fmt.Sprintf("127.0.0.1:%s", networkPolicyProxyPort)
 	}
 	// Parse network policy template for each iteration and prepare connections for client pods
 	prepareConnections()

--- a/pkg/measurements/util/port_forward.go
+++ b/pkg/measurements/util/port_forward.go
@@ -2,10 +2,7 @@ package util
 
 import (
 	"bytes"
-	"fmt"
-	"net"
 	"net/http"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
@@ -15,44 +12,14 @@ import (
 )
 
 type PodPortForwarder struct {
-	PodName   string
-	LocalPort string
-	StopChan  chan struct{}
+	PodName  string
+	StopChan chan struct{}
 }
 
-// parsePort parses out the local port from the port-forward output string.
-// Example: "Forwarding from 127.0.0.1:8000 -> 4000", returns "8000".
-func parsePort(forwardAddr string) (string, error) {
-	// Split the input into lines
-	lines := strings.Split(forwardAddr, "\n")
-	for _, line := range lines {
-		// Remove any leading/trailing whitespace
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		// Split the line into parts
-		parts := strings.Split(line, " ")
-		if len(parts) < 3 {
-			continue
-		}
-
-		// Attempt to parse the local port
-		_, localPort, err := net.SplitHostPort(parts[2])
-		if err == nil {
-			return localPort, nil
-		}
-	}
-
-	return "", fmt.Errorf("unable to parse local port from stdout: %s", forwardAddr)
-}
-
-func NewPodPortForwarder(clientset kubernetes.Interface, restConfig rest.Config, remotePort, namespace, podName string) (PodPortForwarder, error) {
-	var localPort string
+func NewPodPortForwarder(clientset kubernetes.Interface, restConfig rest.Config, port, namespace, podName string) (*PodPortForwarder, error) {
 	roundTripper, upgrader, err := spdy.RoundTripperFor(&restConfig)
 	if err != nil {
-		return PodPortForwarder{}, err
+		return &PodPortForwarder{}, err
 	}
 
 	req := clientset.CoreV1().RESTClient().
@@ -69,10 +36,9 @@ func NewPodPortForwarder(clientset kubernetes.Interface, restConfig rest.Config,
 	errorChan := make(chan error, 1)
 	out := new(bytes.Buffer)
 	errOut := new(bytes.Buffer)
-	ports := []string{fmt.Sprintf(":%s", remotePort)}
-	forwarder, err := portforward.New(dialer, ports, stopChan, readyChan, out, errOut)
+	forwarder, err := portforward.New(dialer, []string{port}, stopChan, readyChan, out, errOut)
 	if err != nil {
-		return PodPortForwarder{}, err
+		return &PodPortForwarder{}, err
 	}
 
 	go func() {
@@ -87,20 +53,17 @@ func NewPodPortForwarder(clientset kubernetes.Interface, restConfig rest.Config,
 	case <-readyChan:
 		if len(errOut.String()) != 0 {
 			panic(errOut.String())
-		} else if len(out.String()) != 0 {
-			localPort, _ = parsePort(out.String())
 		}
-		log.Infof("Port forwarding started between %s:%s", localPort, remotePort)
+		log.Infof("Port forwarding started between %s:%s", port, port)
 	case err := <-errorChan:
 		log.Errorf("Error during port-forwarding: %v", err)
 		close(stopChan)
-		return PodPortForwarder{}, err
+		return &PodPortForwarder{}, err
 	}
 
-	return PodPortForwarder{
-		PodName:   podName,
-		LocalPort: localPort,
-		StopChan:  stopChan,
+	return &PodPortForwarder{
+		PodName:  podName,
+		StopChan: stopChan,
 	}, nil
 }
 


### PR DESCRIPTION
On some environments, client port forwarding can use both ipv4 and ipv6 addresses for port forwarding. kube-burner has to consider this scenario as well while parsing the port forwarding output and fetch the local port.

- Closes #749
