### PR TITLE
[GH#728] Add --job-pause CLI option for workload pausing

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -77,6 +77,7 @@ func initCmd() *cobra.Command {
 	var uuid, userMetadata string
 	var skipTLSVerify bool
 	var timeout time.Duration
+	var jobPause time.Duration
 	var rc int
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -97,6 +98,12 @@ func initCmd() *cobra.Command {
 			configSpec, err := config.Parse(uuid, timeout, f)
 			if err != nil {
 				log.Fatalf("Config error: %s", err.Error())
+			}
+			// Apply jobPause to all jobs if specified via CLI flag
+			if jobPause > 0 {
+				for i := range configSpec.Jobs {
+					configSpec.Jobs[i].JobPause = jobPause
+				}
 			}
 			metricsScraper := metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
 				ConfigSpec:      &configSpec,
@@ -119,6 +126,7 @@ func initCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&metricsEndpoint, "metrics-endpoint", "e", "", "YAML file with a list of metric endpoints")
 	cmd.Flags().BoolVar(&skipTLSVerify, "skip-tls-verify", true, "Verify prometheus TLS certificate")
 	cmd.Flags().DurationVarP(&timeout, "timeout", "", 4*time.Hour, "Benchmark timeout")
+	cmd.Flags().DurationVar(&jobPause, "job-pause", 0, "Duration to pause after each job")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "Config file path or URL")
 	cmd.Flags().StringVar(&userMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
 	cmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to the kubeconfig file")

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -41,12 +41,13 @@ This is the main subcommand; it triggers a new kube-burner benchmark and it supp
 - `metrics-endpoint`: Path to a valid metrics endpoint file.
 - `skip-tls-verify`: Skip TLS verification for Prometheus. The default is `true`.
 - `timeout`: Kube-burner benchmark global timeout. When timing out, return code is 2. The default is `4h`.
+- `job-pause`: Duration to pause after each job completes. Accepts Go duration format (e.g. 30s, 1m, 2h). Default is no pause.
 - `kubeconfig`: Path to the kubeconfig file.
 - `kube-context`: The name of the kubeconfig context to use.
 - `user-metadata`: YAML file path containing custom user-metadata to be indexed along with the `jobSummary` document.
 
 !!! Note "Prometheus authentication"
-    Both basic and token authentication methods need permissions able to query the given Prometheus endpoint.
+Both basic and token authentication methods need permissions able to query the given Prometheus endpoint.
 
 With the above, running a kube-burner benchmark would be as simple as:
 
@@ -60,7 +61,7 @@ Kube-burner also supports remote configuration files served by a web server. To 
 kube-burner init -c http://web.domain.com:8080/cfg.yml --uuid 67f9ec6d-6a9e-46b6-a3bb-065cde988790`
 ```
 
-To scrape metrics from multiple endpoints, the  `init` command can be triggered. For example:
+To scrape metrics from multiple endpoints, the `init` command can be triggered. For example:
 
 ```console
 kube-burner init -c cluster-density.yml -e metrics-endpoints.yaml
@@ -84,13 +85,13 @@ A metrics-endpoints.yaml file with valid keys for the `init` command would look 
 
 Kube-burner has defined a series of exit codes that can help to programmatically identify a benchmark execution error.
 
-| Exit code | Meaning |
-|--------|--------|
-| 0 | Benchmark execution finished normally |
-| 1 | Generic exit code, returned on a unrecoverable error (i.e: API Authorization error or config parsing error) |
-| 2 | Benchmark timeout, returned when kube-burner's execution time exceeds the value passed in the `--timeout` flag |
-| 3 | Alerting error, returned when a `error` or `critical` level alert is fired |
-| 4 | Measurement error, returned on some measurements error conditions, like `thresholds` |
+| Exit code | Meaning                                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------------------------- |
+| 0         | Benchmark execution finished normally                                                                          |
+| 1         | Generic exit code, returned on a unrecoverable error (i.e: API Authorization error or config parsing error)    |
+| 2         | Benchmark timeout, returned when kube-burner's execution time exceeds the value passed in the `--timeout` flag |
+| 3         | Alerting error, returned when a `error` or `critical` level alert is fired                                     |
+| 4         | Measurement error, returned on some measurements error conditions, like `thresholds`                           |
 
 ## Index
 
@@ -108,7 +109,7 @@ We can specify a list of namespaces and selector labels as input.
 - `selector`: comma-separated list of selector labels in the format key1=value1,key2=value2. This is optional, by default no labels will be used for filtering.
 
 !!! Note
-    This subcommand should only be used to fetch measurements of a workload ran in the past. Also those resources should be active on the cluster. For present cases, please refer to the alternate options in this tool.
+This subcommand should only be used to fetch measurements of a workload ran in the past. Also those resources should be active on the cluster. For present cases, please refer to the alternate options in this tool.
 
 ## Check alerts
 
@@ -131,4 +132,4 @@ Or permanently imported with:
 `kube-burner completion > /etc/bash_completion.d/kube-burner`
 
 !!! note
-    the `bash-completion` utils must be installed for the kube-burner completion script to work.
+the `bash-completion` utils must be installed for the kube-burner completion script to work.


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR adds a --job-pause CLI option that allows users to specify a pause duration between jobs. This feature is useful for:

- Controlling the pace of workload execution
- Allowing system cool-down periods between jobs
- Managing resource utilization by introducing delays between intensive operations

Changes made:

1. Added --job-pause flag to the init command that accepts Go duration format (e.g. 30s, 1m, 2h)
2. Updated documentation in docs/cli/index.md to describe the new flag
3. Added test case in test/test-k8s.bats to verify the pause functionality

The jobPause field was already defined in the Job struct, so this PR simply exposes it via CLI and allows overriding any jobPause values defined in the configuration file.

Example usage:

`kube-burner init --job-pause=1m --config=your-config.yml`

## Related Tickets & Documents

- Closes #728 
