### PR TITLE
Support running shell scripts from the embedded filesystem

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -15,11 +15,9 @@
 package burner
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"sync"
 	"time"
@@ -141,18 +139,14 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 			}
 			if job.BeforeCleanup != "" {
 				log.Infof("Waiting for beforeCleanup command %s to finish", job.BeforeCleanup)
-				cmd := exec.Command("/bin/sh", job.BeforeCleanup)
-				var outb, errb bytes.Buffer
-				cmd.Stdout = &outb
-				cmd.Stderr = &errb
-				err := cmd.Run()
+				stdOut, stdErr, err := util.RunShellCmd(job.BeforeCleanup, configSpec.EmbedFS, configSpec.EmbedFSDir)
 				if err != nil {
 					err = fmt.Errorf("BeforeCleanup failed: %v", err)
 					log.Error(err.Error())
 					errs = append(errs, err)
 					innerRC = 1
 				}
-				log.Infof("BeforeCleanup out: %v, err: %v", outb.String(), errb.String())
+				log.Infof("BeforeCleanup out: %v, err: %v", stdOut.String(), stdErr.String())
 			}
 			if job.JobPause > 0 {
 				log.Infof("Pausing for %v before finishing job", job.JobPause)

--- a/pkg/util/bash.go
+++ b/pkg/util/bash.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"embed"
+	"os/exec"
+	"strings"
+)
+
+func RunShellCmd(shellCmdLine string, configEmbedFS *embed.FS, configEmbedFSDir string) (*bytes.Buffer, *bytes.Buffer, error) {
+	// Split the shell script from its args
+	parts := strings.Split(shellCmdLine, " ")
+
+	// Get a reader (embedded, local or remote) for the contents of the file
+	shellScriptReader, err := GetReader(parts[0], configEmbedFS, configEmbedFSDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Add the script arguments into the command
+	var c []string
+	if len(parts) > 1 {
+		c = append([]string{"-s", "-"}, parts[1:]...)
+	}
+
+	// Create a command
+	cmd := exec.Command("/bin/sh", c...)
+
+	// Run the shell script from STDIN
+	cmd.Stdin = shellScriptReader
+
+	// Store STDOUR and STDERR to local variables
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+
+	// Run the command and return its return and outputs
+	err = cmd.Run()
+	return &outb, &errb, err
+}


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Instead of calling `/bin/sh` on the script file, read the content of the file and run it from stdin. 
Note, this works only when all the script code is in a single file

## Related Tickets & Documents

Fail to execute shell scripts when using embedded file system