### PR TITLE
Template - pass the job run id to the template

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -404,6 +404,7 @@ All object templates are injected with the variables below by default:
 - `Replica`: Object replica number. Keep in mind that this number is reset to 1 with each job iteration.
 - `JobName`: Job name.
 - `UUID`: Benchmark UUID.
+- `RunID`: Internal run id. Can be used to match resources for metrics collection
 
 In addition, you can also inject arbitrary variables with the option `inputVars` of the object:
 

--- a/pkg/burner/executor.go
+++ b/pkg/burner/executor.go
@@ -89,6 +89,7 @@ func (ex *Executor) renderTemplateForObject(obj object, iteration, replicaIndex 
 		jobName:      ex.Name,
 		jobIteration: iteration,
 		jobUUID:      ex.uuid,
+		jobRunId:     ex.runid,
 		replica:      replicaIndex,
 	}
 	for k, v := range obj.InputVars {

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -47,6 +47,7 @@ const (
 	replica              = "Replica"
 	jobIteration         = "Iteration"
 	jobUUID              = "UUID"
+	jobRunId             = "RunID"
 	rcTimeout            = 2
 	rcAlert              = 3
 	rcMeasurement        = 4


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Add the RunID to the template param to allow marking sub-resources for metrics