### PR TITLE
Measurements - use new instances for each job to allow deferred indexing

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -249,8 +249,7 @@ func measureCmd() *cobra.Command {
 				namespaceLabels[req.Key()] = req.Values().List()[0]
 			}
 			log.Infof("%v", namespaceLabels)
-			measurements.NewMeasurementFactory(configSpec, metadata)
-			measurements.SetJobConfig(
+			measurementsInstance := measurements.NewMeasurementsFactory(configSpec, metadata).NewMeasurements(
 				&config.Job{
 					Name:                 jobName,
 					Namespace:            rawNamespaces,
@@ -259,11 +258,11 @@ func measureCmd() *cobra.Command {
 				},
 				config.NewKubeClientProvider(kubeConfig, kubeContext),
 			)
-			measurements.Collect()
-			if err = measurements.Stop(); err != nil {
+			measurementsInstance.Collect()
+			if err = measurementsInstance.Stop(); err != nil {
 				log.Error(err.Error())
 			}
-			measurements.Index(jobName, indexerList)
+			measurementsInstance.Index(jobName, indexerList)
 		},
 	}
 	cmd.Flags().StringVar(&uuid, "uuid", "", "UUID")

--- a/pkg/measurements/common.go
+++ b/pkg/measurements/common.go
@@ -18,19 +18,84 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
+	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/measurements/metrics"
 	"github.com/kube-burner/kube-burner/pkg/measurements/types"
 	kutil "github.com/kube-burner/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 )
+
+var (
+	supportedLatencyMetricsMap = map[string]struct{}{
+		"P99": {},
+		"P95": {},
+		"P50": {},
+		"Avg": {},
+		"Max": {},
+	}
+)
+
+type baseLatencyMeasurementFactory struct {
+	config   types.Measurement
+	uuid     string
+	runid    string
+	metadata map[string]interface{}
+}
+
+type baseLatencyMeasurement struct {
+	config     types.Measurement
+	uuid       string
+	runid      string
+	jobConfig  *config.Job
+	clientSet  kubernetes.Interface
+	restConfig *rest.Config
+	metadata   map[string]interface{}
+}
+
+func newBaseLatencyMeasurementFactory(configSpec config.Spec, measurement types.Measurement, metadata map[string]interface{}) baseLatencyMeasurementFactory {
+	return baseLatencyMeasurementFactory{
+		config:   measurement,
+		uuid:     configSpec.GlobalConfig.UUID,
+		runid:    configSpec.GlobalConfig.RUNID,
+		metadata: metadata,
+	}
+}
+
+func (blmf baseLatencyMeasurementFactory) newBaseLatency(jobConfig *config.Job, clientSet kubernetes.Interface, restConfig *rest.Config) baseLatencyMeasurement {
+	return baseLatencyMeasurement{
+		config:     blmf.config,
+		uuid:       blmf.uuid,
+		runid:      blmf.runid,
+		jobConfig:  jobConfig,
+		clientSet:  clientSet,
+		restConfig: restConfig,
+		metadata:   blmf.metadata,
+	}
+}
+
+func verifyMeasurementConfig(config types.Measurement, supportedConditions map[string]struct{}) error {
+	for _, th := range config.LatencyThresholds {
+		if _, supported := supportedConditions[th.ConditionType]; !supported {
+			return fmt.Errorf("unsupported condition type in measurement: %s", th.ConditionType)
+		}
+		if _, supportedLatency := supportedLatencyMetricsMap[th.Metric]; !supportedLatency {
+			return fmt.Errorf("unsupported metric %s in measurement, supported are: %s", th.Metric, strings.Join(maps.Keys(supportedLatencyMetricsMap), ", "))
+		}
+	}
+	return nil
+}
 
 func IndexLatencyMeasurement(config types.Measurement, jobName string, metricMap map[string][]interface{}, indexerList map[string]indexers.Indexer) {
 	indexDocuments := func(indexer indexers.Indexer, metricName string, data []interface{}) {
@@ -65,7 +130,7 @@ func IndexLatencyMeasurement(config types.Measurement, jobName string, metricMap
 
 // Common function to calculate quantiles for both node and pod latencies
 // Receives a list of normalized latencies and a function to get the latencies for each condition
-func calculateQuantiles(normLatencies []interface{}, getLatency func(interface{}) map[string]float64, metricName string) []interface{} {
+func calculateQuantiles(uuid, jobName string, metadata map[string]interface{}, normLatencies []interface{}, getLatency func(interface{}) map[string]float64, metricName string) []interface{} {
 	quantileMap := map[string][]float64{}
 	for _, normLatency := range normLatencies {
 		for condition, latency := range getLatency(normLatency) {
@@ -74,10 +139,10 @@ func calculateQuantiles(normLatencies []interface{}, getLatency func(interface{}
 	}
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
 		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
-		latencySummary.UUID = globalCfg.UUID
-		latencySummary.Metadata = factory.metadata
+		latencySummary.UUID = uuid
+		latencySummary.Metadata = metadata
 		latencySummary.MetricName = metricName
-		latencySummary.JobName = factory.jobConfig.Name
+		latencySummary.JobName = jobName
 		return latencySummary
 	}
 
@@ -100,7 +165,7 @@ func getIntFromLabels(labels map[string]string, key string) int {
 	return 0
 }
 
-func deployPodInNamespace(namespace, podName, image string, command []string) error {
+func deployPodInNamespace(clientSet kubernetes.Interface, namespace, podName, image string, command []string) error {
 	var podObj = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -127,10 +192,10 @@ func deployPodInNamespace(namespace, podName, image string, command []string) er
 	}
 
 	var err error
-	if err = kutil.CreateNamespace(factory.clientSet, namespace, nil, nil); err != nil {
+	if err = kutil.CreateNamespace(clientSet, namespace, nil, nil); err != nil {
 		return err
 	}
-	if _, err = factory.clientSet.CoreV1().Pods(namespace).Create(context.TODO(), podObj, metav1.CreateOptions{}); err != nil {
+	if _, err = clientSet.CoreV1().Pods(namespace).Create(context.TODO(), podObj, metav1.CreateOptions{}); err != nil {
 		if errors.IsAlreadyExists(err) {
 			log.Warn(err)
 		} else {
@@ -138,7 +203,7 @@ func deployPodInNamespace(namespace, podName, image string, command []string) er
 		}
 	}
 	err = wait.PollUntilContextCancel(context.TODO(), 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
-		pod, err := factory.clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+		pod, err := clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -15,8 +15,6 @@
 package measurements
 
 import (
-	"embed"
-	"fmt"
 	"sync"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
@@ -28,93 +26,103 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-type measurementFactory struct {
-	jobConfig   *config.Job
-	clientSet   kubernetes.Interface
-	restConfig  *rest.Config
-	createFuncs map[string]measurement
-	metadata    map[string]interface{}
+type MeasurementsFactory struct {
+	metadata  map[string]interface{}
+	factories map[string]measurementFactory
 }
+
+type Measurements struct {
+	measurementsMap map[string]measurement
+}
+
+type measurementFactory interface {
+	newMeasurement(*config.Job, kubernetes.Interface, *rest.Config) measurement
+}
+type newMeasurementFactory func(config.Spec, types.Measurement, map[string]interface{}) (measurementFactory, error)
 
 type measurement interface {
 	start(*sync.WaitGroup) error
 	stop() error
 	collect(*sync.WaitGroup)
-	setConfig(types.Measurement) error
 	index(string, map[string]indexers.Indexer)
 	getMetrics() *sync.Map
 }
 
-var factory measurementFactory
-var measurementMap = make(map[string]measurement)
-var globalCfg config.GlobalConfig
-var embedFS *embed.FS
-var embedFSDir string
-
-// NewMeasurementFactory initializes the measurement facture
-func NewMeasurementFactory(configSpec config.Spec, metadata map[string]interface{}) {
-	var indexerFound bool
-	embedFS = configSpec.EmbedFS
-	embedFSDir = configSpec.EmbedFSDir
-	globalCfg = configSpec.GlobalConfig
-	factory = measurementFactory{
-		createFuncs: make(map[string]measurement),
-		metadata:    metadata,
-	}
-	for _, measurement := range globalCfg.Measurements {
-		indexerFound = false
-		if measurement.QuantilesIndexer != "" || measurement.TimeseriesIndexer != "" {
-			for _, indexer := range configSpec.MetricsEndpoints {
-				if indexer.Alias == measurement.QuantilesIndexer || indexer.Alias == measurement.TimeseriesIndexer {
-					indexerFound = true
-					break
-				}
-			}
-			if !indexerFound {
-				log.Fatalf("One of the indexers for measurement %s has not been found", measurement.Name)
-			}
-		}
-		if measurementFunc, exists := measurementMap[measurement.Name]; exists {
-			if err := factory.register(measurement, measurementFunc); err != nil {
-				log.Fatal(err.Error())
-			}
-		} else {
-			log.Warnf("Measurement not found: %s", measurement.Name)
-		}
-	}
+var measurementFactoryMap = map[string]newMeasurementFactory{
+	"podLatency":     newPodLatencyMeasurementFactory,
+	"nodeLatency":    newNodeLatencyMeasurementFactory,
+	"vmiLatency":     newVmiLatencyMeasurementFactory,
+	"serviceLatency": newServiceLatencyMeasurementFactory,
+	"pprof":          newPprofLatencyMeasurementFactory,
+	"netpolLatency":  newNetpolLatencyMeasurementFactory,
 }
 
-func (mf *measurementFactory) register(measurement types.Measurement, measurementFunc measurement) error {
-	if _, exists := mf.createFuncs[measurement.Name]; exists {
-		log.Warnf("Measurement already registered: %s", measurement.Name)
-	} else {
-		if err := measurementFunc.setConfig(measurement); err != nil {
-			return fmt.Errorf("%s config error: %s", measurement.Name, err)
+func isIndexerOk(configSpec config.Spec, measurement types.Measurement) bool {
+	if measurement.QuantilesIndexer != "" || measurement.TimeseriesIndexer != "" {
+		for _, indexer := range configSpec.MetricsEndpoints {
+			if indexer.Alias == measurement.QuantilesIndexer || indexer.Alias == measurement.TimeseriesIndexer {
+				return true
+			}
 		}
-		mf.createFuncs[measurement.Name] = measurementFunc
+		return false
+	}
+	return true
+}
+
+// NewMeasurementsFactory initializes the measurement facture
+func NewMeasurementsFactory(configSpec config.Spec, metadata map[string]interface{}) *MeasurementsFactory {
+	measurementsFactory := MeasurementsFactory{
+		metadata:  metadata,
+		factories: make(map[string]measurementFactory, len(configSpec.GlobalConfig.Measurements)),
+	}
+	for _, measurement := range configSpec.GlobalConfig.Measurements {
+		if !isIndexerOk(configSpec, measurement) {
+			log.Fatalf("One of the indexers for measurement %s has not been found", measurement.Name)
+		}
+		if _, alreadyRegistered := measurementsFactory.factories[measurement.Name]; alreadyRegistered {
+			log.Warnf("Measurement [%s] is registered more than once", measurement.Name)
+			continue
+		}
+		newMeasurementFactoryFunc, exists := measurementFactoryMap[measurement.Name]
+		if !exists {
+			log.Warnf("Measurement [%s] is not supported", measurement.Name)
+			continue
+		}
+		mf, err := newMeasurementFactoryFunc(configSpec, measurement, metadata)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		measurementsFactory.factories[measurement.Name] = mf
 		log.Infof("📈 Registered measurement: %s", measurement.Name)
 	}
-	return nil
+	return &measurementsFactory
 }
 
-func SetJobConfig(jobConfig *config.Job, kubeClientProvider *config.KubeClientProvider) {
-	factory.jobConfig = jobConfig
-	factory.clientSet, factory.restConfig = kubeClientProvider.ClientSet(factory.jobConfig.QPS, factory.jobConfig.Burst)
+func (msf *MeasurementsFactory) NewMeasurements(jobConfig *config.Job, kubeClientProvider *config.KubeClientProvider) *Measurements {
+	ms := Measurements{
+		measurementsMap: make(map[string]measurement, len(msf.factories)),
+	}
+	clientSet, restConfig := kubeClientProvider.ClientSet(jobConfig.QPS, jobConfig.Burst)
+	for name, factory := range msf.factories {
+		ms.measurementsMap[name] = factory.newMeasurement(jobConfig, clientSet, restConfig)
+	}
+
+	return &ms
 }
 
 // Start starts registered measurements
-func Start() {
+func (ms *Measurements) Start() {
 	var wg sync.WaitGroup
-	for _, measurement := range factory.createFuncs {
+	for _, measurement := range ms.measurementsMap {
 		wg.Add(1)
 		go measurement.start(&wg)
 	}
 	wg.Wait()
 }
 
-func Collect() {
+func (ms *Measurements) Collect() {
 	var wg sync.WaitGroup
-	for _, measurement := range factory.createFuncs {
+	for _, measurement := range ms.measurementsMap {
 		wg.Add(1)
 		go measurement.collect(&wg)
 	}
@@ -123,9 +131,9 @@ func Collect() {
 
 // Stop stops registered measurements
 // returns a concatenated list of error strings with a new line between each string
-func Stop() error {
+func (ms *Measurements) Stop() error {
 	errs := []error{}
-	for name, measurement := range factory.createFuncs {
+	for name, measurement := range ms.measurementsMap {
 		log.Infof("Stopping measurement: %s", name)
 		errs = append(errs, measurement.stop())
 	}
@@ -136,16 +144,16 @@ func Stop() error {
 //
 // jobName is the name of the job to index data for.
 // indexerList is a variadic parameter of indexers.Indexer implementations.
-func Index(jobName string, indexerList map[string]indexers.Indexer) {
-	for name, measurement := range factory.createFuncs {
+func (ms *Measurements) Index(jobName string, indexerList map[string]indexers.Indexer) {
+	for name, measurement := range ms.measurementsMap {
 		log.Infof("Indexing collected data from measurement: %s", name)
 		measurement.index(jobName, indexerList)
 	}
 }
 
-func GetMetrics() []*sync.Map {
+func (ms *Measurements) GetMetrics() []*sync.Map {
 	var metricList []*sync.Map
-	for name, measurement := range factory.createFuncs {
+	for name, measurement := range ms.measurementsMap {
 		log.Infof("Fetching metrics from measurement: %s", name)
 		metricList = append(metricList, measurement.getMetrics())
 	}

--- a/pkg/measurements/netpol_latency.go
+++ b/pkg/measurements/netpol_latency.go
@@ -17,6 +17,7 @@ package measurements
 import (
 	"bytes"
 	"context"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubectl/pkg/scheme"
@@ -83,7 +85,10 @@ type ProxyResponse struct {
 }
 
 type netpolLatency struct {
-	config           types.Measurement
+	baseLatencyMeasurement
+	embedFS    *embed.FS
+	embedFSDir string
+
 	netpolWatcher    *metrics.Watcher
 	metrics          sync.Map
 	latencyQuantiles []interface{}
@@ -102,18 +107,34 @@ type netpolMetric struct {
 	JobName         string        `json:"jobName,omitempty"`
 }
 
+type netpolLatencyMeasurementFactory struct {
+	baseLatencyMeasurementFactory
+	embedFS    *embed.FS
+	embedFSDir string
+}
+
+func newNetpolLatencyMeasurementFactory(configSpec kconfig.Spec, measurement types.Measurement, metadata map[string]interface{}) (measurementFactory, error) {
+	return netpolLatencyMeasurementFactory{
+		baseLatencyMeasurementFactory: newBaseLatencyMeasurementFactory(configSpec, measurement, metadata),
+		embedFS:                       configSpec.EmbedFS,
+		embedFSDir:                    configSpec.EmbedFSDir,
+	}, nil
+}
+
+func (nplmf netpolLatencyMeasurementFactory) newMeasurement(jobConfig *kconfig.Job, clientSet kubernetes.Interface, restConfig *rest.Config) measurement {
+	return &netpolLatency{
+		baseLatencyMeasurement: nplmf.newBaseLatency(jobConfig, clientSet, restConfig),
+		embedFS:                nplmf.embedFS,
+		embedFSDir:             nplmf.embedFSDir,
+	}
+}
+
 func yamlToUnstructured(fileName string, y []byte, uns *unstructured.Unstructured) (runtime.Object, *schema.GroupVersionKind) {
 	o, gvk, err := scheme.Codecs.UniversalDeserializer().Decode(y, nil, uns)
 	if err != nil {
 		log.Fatalf("Error decoding YAML (%s): %s", fileName, err)
 	}
 	return o, gvk
-}
-
-func init() {
-	measurementMap["netpolLatency"] = &netpolLatency{
-		metrics: sync.Map{},
-	}
 }
 
 func getNamespacesByLabel(s *metav1.LabelSelector) []string {
@@ -142,7 +163,7 @@ func getNamespacesByLabel(s *metav1.LabelSelector) []string {
 // might be using the same remote namespace pod selector. As the pod addresses for
 // the pod selector already stored in nsPodAddresses, fetches by the later
 // namespaces can use from nsPodAddresses instead of querying kube-apiserver
-func addPodsByLabel(ns string, ps *metav1.LabelSelector) []string {
+func addPodsByLabel(clientSet kubernetes.Interface, ns string, ps *metav1.LabelSelector) []string {
 	var addresses []string
 	selectorString := ns
 	listOptions := metav1.ListOptions{}
@@ -158,7 +179,7 @@ func addPodsByLabel(ns string, ps *metav1.LabelSelector) []string {
 		selectorString = selector.String()
 	}
 	if podsMap, ok := nsPodAddresses[ns]; !ok || podsMap[selectorString] == nil {
-		pods, err := factory.clientSet.CoreV1().Pods(ns).List(context.TODO(), listOptions)
+		pods, err := clientSet.CoreV1().Pods(ns).List(context.TODO(), listOptions)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -183,18 +204,13 @@ func (n *netpolLatency) handleCreateNetpol(obj interface{}) {
 	npCreationTime[netpol.Name] = netpol.CreationTimestamp.Time.UTC()
 }
 
-func (n *netpolLatency) setConfig(cfg types.Measurement) error {
-	n.config = cfg
-	return nil
-}
-
 // Render the network policy from the object template using iteration details as input
-func getNetworkPolicy(iteration int, replica int, obj kconfig.Object, objectSpec []byte) *networkingv1.NetworkPolicy {
+func (n *netpolLatency) getNetworkPolicy(iteration int, replica int, obj kconfig.Object, objectSpec []byte) *networkingv1.NetworkPolicy {
 
 	templateData := map[string]interface{}{
-		"JobName":   factory.jobConfig.Name,
+		"JobName":   n.jobConfig.Name,
 		"Iteration": strconv.Itoa(iteration),
-		"UUID":      globalCfg.UUID,
+		"UUID":      n.uuid,
 		"Replica":   strconv.Itoa(replica),
 	}
 	for k, v := range obj.InputVars {
@@ -224,22 +240,22 @@ func getNetworkPolicy(iteration int, replica int, obj kconfig.Object, objectSpec
 // For example, local pods in namespace-1 will be accepting http requests from remote namespace-2 pods when ingress-1 in namespace-1 specify namespace-2 as remote.
 // connections is map of each client pod with list of addresses it has to send connection requests. Network policy name is also stored along with the addresses.
 // Note: this measurement package only parses template to get IP addresses of pods but never creates network policies. kube-burner's "burner" package creates network policies
-func prepareConnections() {
+func (n *netpolLatency) prepareConnections() {
 	// Reset latency slices, required in multi-job benchmarks
-	for _, obj := range factory.jobConfig.Objects {
-		cleanTemplate, err := readTemplate(obj)
+	for _, obj := range n.jobConfig.Objects {
+		cleanTemplate, err := readTemplate(obj, n.embedFS, n.embedFSDir)
 		if err != nil {
 			log.Fatalf("Error in readTemplate %s: %s", obj.ObjectTemplate, err)
 		}
 		if getObjectType(obj, cleanTemplate) != "NetworkPolicy" {
 			continue
 		}
-		for i := 0; i < factory.jobConfig.JobIterations; i++ {
+		for i := 0; i < n.jobConfig.JobIterations; i++ {
 			for r := 1; r <= obj.Replicas; r++ {
-				networkPolicy := getNetworkPolicy(i, r, obj, cleanTemplate)
-				nsIndex := i / factory.jobConfig.IterationsPerNamespace
-				namespace := fmt.Sprintf("%s-%d", factory.jobConfig.Namespace, nsIndex)
-				localPods := addPodsByLabel(namespace, &networkPolicy.Spec.PodSelector)
+				networkPolicy := n.getNetworkPolicy(i, r, obj, cleanTemplate)
+				nsIndex := i / n.jobConfig.IterationsPerNamespace
+				namespace := fmt.Sprintf("%s-%d", n.jobConfig.Namespace, nsIndex)
+				localPods := addPodsByLabel(n.clientSet, namespace, &networkPolicy.Spec.PodSelector)
 				for _, ingress := range networkPolicy.Spec.Ingress {
 					var ingressPorts []int32
 					for _, from := range ingress.From {
@@ -259,7 +275,7 @@ func prepareConnections() {
 						}
 						namespaces := getNamespacesByLabel(from.NamespaceSelector)
 						for _, namepsace := range namespaces {
-							remoteAddrs := addPodsByLabel(namepsace, from.PodSelector)
+							remoteAddrs := addPodsByLabel(n.clientSet, namepsace, from.PodSelector)
 							for _, ra := range remoteAddrs {
 								// exclude sending connection request to same ip address
 								otherIPs := []string{}
@@ -367,7 +383,7 @@ func waitForCondition(url string) {
 }
 
 // Get results from proxy pod and parse them.
-func processResults(n *netpolLatency) {
+func (n *netpolLatency) processResults() {
 	serverURL := fmt.Sprintf("http://%s", proxyEndpoint)
 	resp, err := http.Get(fmt.Sprintf("%s/stop", serverURL))
 	if err != nil {
@@ -428,15 +444,15 @@ func processResults(n *netpolLatency) {
 			MetricName:      netpolLatencyMeasurement,
 			MinReadyLatency: time.Duration(latencySummary.Min),
 			ReadyLatency:    time.Duration(latencySummary.Max),
-			UUID:            globalCfg.UUID,
-			Metadata:        factory.metadata,
-			JobName:         factory.jobConfig.Name,
+			UUID:            n.uuid,
+			Metadata:        n.metadata,
+			JobName:         n.jobConfig.Name,
 		})
 	}
 }
 
 // Read network policy object template
-func readTemplate(o kconfig.Object) ([]byte, error) {
+func readTemplate(o kconfig.Object, embedFS *embed.FS, embedFSDir string) ([]byte, error) {
 	f, err := kutil.GetReader(o.ObjectTemplate, embedFS, embedFSDir)
 	if err != nil {
 		log.Fatalf("Error reading template %s: %s", o.ObjectTemplate, err)
@@ -464,21 +480,21 @@ func (n *netpolLatency) start(measurementWg *sync.WaitGroup) error {
 	var err error
 	defer measurementWg.Done()
 	// Skip latency measurement for 1st job which creates only pods
-	if value, ok := factory.jobConfig.NamespaceLabels["kube-burner.io/skip-networkpolicy-latency"]; ok {
+	if value, ok := n.jobConfig.NamespaceLabels["kube-burner.io/skip-networkpolicy-latency"]; ok {
 		if value == "true" {
-			log.Debugf("Discarding network policy latency measurement for the job %v", factory.jobConfig.Name)
+			log.Debugf("Discarding network policy latency measurement for the job %v", n.jobConfig.Name)
 			return nil
 		}
 	}
-	_, err = factory.clientSet.CoreV1().Pods(networkPolicyProxy).Get(context.TODO(), networkPolicyProxy, metav1.GetOptions{})
+	_, err = n.clientSet.CoreV1().Pods(networkPolicyProxy).Get(context.TODO(), networkPolicyProxy, metav1.GetOptions{})
 	if err != nil {
-		err = deployPodInNamespace(networkPolicyProxy, networkPolicyProxy, "quay.io/cloud-bulldozer/netpolproxy:latest", nil)
+		err = deployPodInNamespace(n.clientSet, networkPolicyProxy, networkPolicyProxy, "quay.io/cloud-bulldozer/netpolproxy:latest", nil)
 		if err != nil {
 			return err
 		}
 	}
 	if proxyPortForwarder == nil {
-		proxyPortForwarder, err = util.NewPodPortForwarder(factory.clientSet, *factory.restConfig, networkPolicyProxyPort, networkPolicyProxy, networkPolicyProxy)
+		proxyPortForwarder, err = util.NewPodPortForwarder(n.clientSet, *n.restConfig, networkPolicyProxyPort, networkPolicyProxy, networkPolicyProxy)
 		if err != nil {
 			return err
 		}
@@ -486,7 +502,7 @@ func (n *netpolLatency) start(measurementWg *sync.WaitGroup) error {
 		proxyEndpoint = fmt.Sprintf("127.0.0.1:%s", networkPolicyProxyPort)
 	}
 	// Parse network policy template for each iteration and prepare connections for client pods
-	prepareConnections()
+	n.prepareConnections()
 	// send connection information to proxy to deliver to client pods
 	if len(connections) > 0 {
 		sendConnections()
@@ -494,14 +510,14 @@ func (n *netpolLatency) start(measurementWg *sync.WaitGroup) error {
 	n.latencyQuantiles, n.normLatencies = nil, nil
 
 	// Create watchers to record network policy creation timestamp
-	log.Infof("Creating netpol latency watcher for %s", factory.jobConfig.Name)
+	log.Infof("Creating netpol latency watcher for %s", n.jobConfig.Name)
 	n.netpolWatcher = metrics.NewWatcher(
-		factory.clientSet.NetworkingV1().RESTClient().(*rest.RESTClient),
+		n.clientSet.NetworkingV1().RESTClient().(*rest.RESTClient),
 		"netpolWatcher",
 		"networkpolicies",
 		corev1.NamespaceAll,
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = fmt.Sprintf("kube-burner-uuid=%v", globalCfg.UUID)
+			options.LabelSelector = fmt.Sprintf("kube-burner-uuid=%v", n.uuid)
 		},
 		cache.Indexers{},
 	)
@@ -516,13 +532,13 @@ func (n *netpolLatency) start(measurementWg *sync.WaitGroup) error {
 
 func (n *netpolLatency) stop() error {
 	// Skip latency measurement for 1st job which creates only pods
-	if value, ok := factory.jobConfig.NamespaceLabels["kube-burner.io/skip-networkpolicy-latency"]; ok {
+	if value, ok := n.jobConfig.NamespaceLabels["kube-burner.io/skip-networkpolicy-latency"]; ok {
 		if value == "true" {
 			return nil
 		}
 	}
 	if len(connections) > 0 {
-		processResults(n)
+		n.processResults()
 	}
 	proxyPortForwarder.CancelPodPortForwarder()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -530,12 +546,12 @@ func (n *netpolLatency) stop() error {
 		cancel()
 		n.netpolWatcher.StopWatcher()
 	}()
-	kutil.CleanupNamespaces(ctx, factory.clientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", networkPolicyProxy))
+	kutil.CleanupNamespaces(ctx, n.clientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", networkPolicyProxy))
 	n.normalizeMetrics()
 	for _, q := range n.latencyQuantiles {
 		pq := q.(metrics.LatencyQuantiles)
 		// Divide nanoseconds by 1e6 to get milliseconds
-		log.Infof("%s: %s 50th: %d 99th: %d max: %d avg: %d", factory.jobConfig.Name, pq.QuantileName, pq.P50, pq.P99, pq.Max, pq.Avg)
+		log.Infof("%s: %s 50th: %d 99th: %d max: %d avg: %d", n.jobConfig.Name, pq.QuantileName, pq.P50, pq.P99, pq.Max, pq.Avg)
 
 	}
 	return nil
@@ -559,11 +575,11 @@ func (n *netpolLatency) normalizeMetrics() {
 	})
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
 		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
-		latencySummary.UUID = globalCfg.UUID
+		latencySummary.UUID = n.uuid
 		latencySummary.Timestamp = time.Now().UTC()
-		latencySummary.Metadata = factory.metadata
+		latencySummary.Metadata = n.metadata
 		latencySummary.MetricName = netpolLatencyQuantilesMeasurement
-		latencySummary.JobName = factory.jobConfig.Name
+		latencySummary.JobName = n.jobConfig.Name
 		return latencySummary
 	}
 	if sLen > 0 {


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] Bug fix
- [x] Optimization

## Description

Create two layers of factories to allow handling of global and per job parameters
Use instances and their methods to manage measurements
Remove all runtime global variables from the measurements factory
Adjust the different implementations to the new scheme
Adjust the different users of measurements to the new scheme

## Related Tickets & Documents

- Closes #766
