### PR TITLE
Init - Add CLI arg to allow missing keys

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -79,6 +79,7 @@ func initCmd() *cobra.Command {
 	var skipTLSVerify bool
 	var timeout time.Duration
 	var userDataFile string
+	var allowMissingKeys bool
 	var rc int
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -103,7 +104,7 @@ func initCmd() *cobra.Command {
 					log.Fatalf("Error reading user data file %s: %s", userDataFile, err)
 				}
 			}
-			configSpec, err := config.ParseWithUserdata(uuid, timeout, configFileReader, userDataFileReader)
+			configSpec, err := config.ParseWithUserdata(uuid, timeout, configFileReader, userDataFileReader, allowMissingKeys)
 			if err != nil {
 				log.Fatalf("Config error: %s", err.Error())
 			}
@@ -133,6 +134,7 @@ func initCmd() *cobra.Command {
 	cmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "Path to the kubeconfig file")
 	cmd.Flags().StringVar(&kubeContext, "kube-context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().StringVar(&userDataFile, "user-data", "", "User provided data file for rendering the configuration file, in JSON or YAML format")
+	cmd.Flags().BoolVar(&allowMissingKeys, "allow-missing", false, "Do not fail on missing values in the config file")
 	cmd.Flags().SortFlags = false
 	cmd.MarkFlagRequired("config")
 	return cmd

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -45,6 +45,7 @@ This is the main subcommand; it triggers a new kube-burner benchmark and it supp
 - `kube-context`: The name of the kubeconfig context to use.
 - `user-metadata`: YAML file path containing custom user-metadata to be indexed along with the `jobSummary` document.
 - `user-data`: YAML or JSON file path containing input variables for rendering the configuration file.
+- `allow-missing`: Allow missing keys in the config file. Needed when using the [`default`](https://masterminds.github.io/sprig/defaults.html) template function
 
 !!! Note "Prometheus authentication"
     Both basic and token authentication methods need permissions able to query the given Prometheus endpoint.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,11 +135,11 @@ func getInputData(userDataFileReader io.Reader) (map[string]interface{}, error) 
 }
 
 func Parse(uuid string, timeout time.Duration, configFileReader io.Reader) (Spec, error) {
-	return ParseWithUserdata(uuid, timeout, configFileReader, nil)
+	return ParseWithUserdata(uuid, timeout, configFileReader, nil, false)
 }
 
 // Parse parses a configuration file
-func ParseWithUserdata(uuid string, timeout time.Duration, configFileReader, userDataFileReader io.Reader) (Spec, error) {
+func ParseWithUserdata(uuid string, timeout time.Duration, configFileReader, userDataFileReader io.Reader, allowMissingKeys bool) (Spec, error) {
 	cfg, err := io.ReadAll(configFileReader)
 	if err != nil {
 		return configSpec, fmt.Errorf("error reading configuration file: %s", err)
@@ -148,7 +148,11 @@ func ParseWithUserdata(uuid string, timeout time.Duration, configFileReader, use
 	if err != nil {
 		return configSpec, err
 	}
-	renderedCfg, err := util.RenderTemplate(cfg, inputData, util.MissingKeyError)
+	templateOptions := util.MissingKeyError
+	if allowMissingKeys {
+		templateOptions = util.MissingKeyZero
+	}
+	renderedCfg, err := util.RenderTemplate(cfg, inputData, templateOptions)
 	if err != nil {
 		return configSpec, fmt.Errorf("error rendering configuration template: %s", err)
 	}


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Add argument to the init command to allow missing keys in the configuration file.