### PR TITLE
Verify - limit the objects list to the ones created in the current run

### DIFF
--- a/pkg/burner/utils.go
+++ b/pkg/burner/utils.go
@@ -92,7 +92,7 @@ func (ex *Executor) Verify() bool {
 	log.Info("Verifying created objects")
 	for objectIndex, obj := range ex.objects {
 		listOptions := metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("kube-burner-uuid=%s,kube-burner-job=%s,kube-burner-index=%d", ex.uuid, ex.Name, objectIndex),
+			LabelSelector: fmt.Sprintf("kube-burner-uuid=%s,kube-burner-runid=%s,kube-burner-job=%s,kube-burner-index=%d", ex.uuid, ex.runid, ex.Name, objectIndex),
 			Limit:         objectLimit,
 		}
 		err := util.RetryWithExponentialBackOff(func() (done bool, err error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,7 +36,6 @@ import (
 
 var configSpec = Spec{
 	GlobalConfig: GlobalConfig{
-		RUNID:            uid.NewString(),
 		GC:               false,
 		GCMetrics:        false,
 		GCTimeout:        1 * time.Hour,
@@ -181,6 +180,7 @@ func ParseWithUserdata(uuid string, timeout time.Duration, configFileReader, use
 	}
 	configSpec.GlobalConfig.Timeout = timeout
 	configSpec.GlobalConfig.UUID = uuid
+	configSpec.GlobalConfig.RUNID = uid.NewString()
 	return configSpec, nil
 }
 


### PR DESCRIPTION

## Type of change

- [x] Optimization

## Description
To allow running the same test sequence with the same UUID, generate the RUNID every time the configuration spec is loaded and verify objects that were created under the specific runid
