### PR TITLE
Adding PVC latency to measurements

### DIFF
--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -318,6 +318,99 @@ Where `quantileName` matches with the node conditions and can be:
 
 And the metrics, error rates, and their thresholds work the same way as in the pod latency measurement.
 
+## PVC latency
+Note: This measurement is not supported for patch, read and delete jobs. Because it requires all the events from creation to reaching a stable end state to happen during a job. 
+
+Collects latencies from different pvc phases on the cluster, these **latency metrics are in ms**. It can be enabled with:
+
+```yaml
+  measurements:
+  - name: pvcLatency
+```
+
+### Metrics
+
+The metrics collected are pvc latency timeseries (`pvcLatencyMeasurement`) and 2-3 documents holding a summary with different pvc latency quantiles of each lifecycle phase (`pvcLatencyQuantilesMeasurement`).
+
+One document, such as the following, is indexed per each pvc created by the workload that enters in `Bound/Lost` condition during the workload:
+
+```json
+{
+  "timestamp": "2025-01-10T02:50:50.247528962Z",
+  "pendingLatency": 37,
+  "bindingLatency": 4444,
+  "lostLatency": 0,
+  "uuid": "1f16ffd1-ac65-47c4-970f-a71d5f309cf5",
+  "pvcName": "deployment-pvc-move-1",
+  "jobName": "pvc-move",
+  "namespace": "deployment-pvc-move-0",
+  "metricName": "pvcLatencyMeasurement",
+  "size": "1Gi",
+  "storageClass": "gp3-csi",
+  "jobIteration": 0,
+  "replica": 1,
+}
+```
+
+---
+
+Node latency quantile sample:
+
+```json
+[
+  {
+    "quantileName": "Bound",
+    "uuid": "1f16ffd1-ac65-47c4-970f-a71d5f309cf5",
+    "P99": 4444,
+    "P95": 4444,
+    "P50": 4444,
+    "min": 4444,
+    "max": 4444,
+    "avg": 4444,
+    "timestamp": "2025-01-10T02:51:04.611059008Z",
+    "metricName": "podLatencyQuantilesMeasurement",
+    "jobName": "pvc-move",
+  },
+  {
+    "quantileName": "Lost",
+    "uuid": "1f16ffd1-ac65-47c4-970f-a71d5f309cf5",
+    "P99": 0,
+    "P95": 0,
+    "P50": 0,
+    "min": 0,
+    "max": 0,
+    "avg": 0,
+    "timestamp": "2025-01-10T02:51:04.611061474Z",
+    "metricName": "podLatencyQuantilesMeasurement",
+    "jobName": "pvc-move",
+  },
+  {
+    "quantileName": "Pending",
+    "uuid": "1f16ffd1-ac65-47c4-970f-a71d5f309cf5",
+    "P99": 37,
+    "P95": 37,
+    "P50": 37,
+    "min": 37,
+    "max": 37,
+    "avg": 37,
+    "timestamp": "2025-01-10T02:51:04.611062824Z",
+    "metricName": "podLatencyQuantilesMeasurement",
+    "jobName": "pvc-move",
+  }
+]
+```
+
+Where `quantileName` matches with the pvc phases and can be:
+
+- `Pending`: Indicates that PVC is not yet bound.
+- `Bound`: Indicates that PVC is bound.
+- `Lost`: Indicates that the PVC has lost their underlying PersistentVolume.
+
+!!! info
+    More information about the PVC phases can be found at the [kubernetes api documentation](https://pkg.go.dev/k8s.io/api/core/v1#PersistentVolumeClaimPhase).
+
+And the metrics, error rates, and their thresholds work the same way as in the other latency measurements.
+
 ## Service latency
 
 Calculates the time taken the services to serve requests once their endpoints are ready. This measurement works as follows.

--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -354,7 +354,7 @@ One document, such as the following, is indexed per each pvc created by the work
 
 ---
 
-Node latency quantile sample:
+PVC latency quantile sample:
 
 ```json
 [
@@ -368,7 +368,7 @@ Node latency quantile sample:
     "max": 4444,
     "avg": 4444,
     "timestamp": "2025-01-10T02:51:04.611059008Z",
-    "metricName": "podLatencyQuantilesMeasurement",
+    "metricName": "pvcLatencyQuantilesMeasurement",
     "jobName": "pvc-move",
   },
   {
@@ -381,7 +381,7 @@ Node latency quantile sample:
     "max": 0,
     "avg": 0,
     "timestamp": "2025-01-10T02:51:04.611061474Z",
-    "metricName": "podLatencyQuantilesMeasurement",
+    "metricName": "pvcLatencyQuantilesMeasurement",
     "jobName": "pvc-move",
   },
   {
@@ -394,7 +394,7 @@ Node latency quantile sample:
     "max": 37,
     "avg": 37,
     "timestamp": "2025-01-10T02:51:04.611062824Z",
-    "metricName": "podLatencyQuantilesMeasurement",
+    "metricName": "pvcLatencyQuantilesMeasurement",
     "jobName": "pvc-move",
   }
 ]

--- a/examples/workloads/deployment-pvc-move/deployment-pvc-move.yml
+++ b/examples/workloads/deployment-pvc-move/deployment-pvc-move.yml
@@ -6,6 +6,7 @@ metricsEndpoints:
 global:
   measurements:
     - name: podLatency
+    - name: pvcLatency
 
 jobs:
   - name: pvc-move

--- a/pkg/measurements/common.go
+++ b/pkg/measurements/common.go
@@ -48,10 +48,10 @@ func IndexLatencyMeasurement(config types.Measurement, jobName string, metricMap
 	}
 	for metricName, data := range metricMap {
 		// Use the configured TimeseriesIndexer or QuantilesIndexer when specified or else use all indexers
-		if config.TimeseriesIndexer != "" && (metricName == podLatencyMeasurement || metricName == svcLatencyMeasurement || metricName == nodeLatencyMeasurement) {
+		if config.TimeseriesIndexer != "" && (metricName == podLatencyMeasurement || metricName == svcLatencyMeasurement || metricName == nodeLatencyMeasurement || metricName == pvcLatencyMeasurement) {
 			indexer := indexerList[config.TimeseriesIndexer]
 			indexDocuments(indexer, metricName, data)
-		} else if config.QuantilesIndexer != "" && (metricName == podLatencyQuantilesMeasurement || metricName == svcLatencyQuantilesMeasurement || metricName == nodeLatencyQuantilesMeasurement) {
+		} else if config.QuantilesIndexer != "" && (metricName == podLatencyQuantilesMeasurement || metricName == svcLatencyQuantilesMeasurement || metricName == nodeLatencyQuantilesMeasurement || metricName == pvcLatencyQuantilesMeasurement) {
 			indexer := indexerList[config.QuantilesIndexer]
 			indexDocuments(indexer, metricName, data)
 		} else {

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -50,6 +50,7 @@ type measurement interface {
 
 var measurementFactoryMap = map[string]newMeasurementFactory{
 	"podLatency":     newPodLatencyMeasurementFactory,
+	"pvcLatency":     newPvcLatencyMeasurementFactory,
 	"nodeLatency":    newNodeLatencyMeasurementFactory,
 	"vmiLatency":     newVmiLatencyMeasurementFactory,
 	"serviceLatency": newServiceLatencyMeasurementFactory,

--- a/pkg/measurements/pvc_latency.go
+++ b/pkg/measurements/pvc_latency.go
@@ -1,0 +1,286 @@
+// Copyright 2025 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package measurements
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cloud-bulldozer/go-commons/indexers"
+	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/measurements/metrics"
+	"github.com/kube-burner/kube-burner/pkg/measurements/types"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	pvcLatencyMeasurement          = "pvcLatencyMeasurement"
+	pvcLatencyQuantilesMeasurement = "pvcLatencyQuantilesMeasurement"
+)
+
+type pvcMetric struct {
+	Timestamp      time.Time `json:"timestamp"`
+	pending        int64
+	PendingLatency int `json:"pendingLatency"`
+	bound          int64
+	BindingLatency int `json:"bindingLatency"`
+	lost           int64
+	LostLatency    int         `json:"lostLatency"`
+	UUID           string      `json:"uuid"`
+	Name           string      `json:"pvcName"`
+	JobName        string      `json:"jobName,omitempty"`
+	Namespace      string      `json:"namespace"`
+	MetricName     string      `json:"metricName"`
+	Size           string      `json:"size"`
+	StorageClass   string      `json:"storageClass"`
+	JobIteration   int         `json:"jobIteration"`
+	Replica        int         `json:"replica"`
+	Metadata       interface{} `json:"metadata,omitempty"`
+}
+
+type pvcLatency struct {
+	config           types.Measurement
+	watcher          *metrics.Watcher
+	metrics          sync.Map
+	latencyQuantiles []interface{}
+	normLatencies    []interface{}
+}
+
+func init() {
+	measurementMap["pvcLatency"] = &pvcLatency{
+		metrics: sync.Map{},
+	}
+}
+
+// creates pvc metric
+func (p *pvcLatency) handleCreatePVC(obj interface{}) {
+	pvc := obj.(*corev1.PersistentVolumeClaim)
+	pvcLabels := pvc.GetLabels()
+	p.metrics.LoadOrStore(string(pvc.UID), pvcMetric{
+		Timestamp:    time.Now().UTC(),
+		Namespace:    pvc.Namespace,
+		Name:         pvc.Name,
+		StorageClass: getStorageClassName(*pvc),
+		Size:         pvc.Spec.Resources.Requests.Storage().String(),
+		MetricName:   pvcLatencyMeasurement,
+		UUID:         globalCfg.UUID,
+		JobName:      factory.jobConfig.Name,
+		Metadata:     factory.metadata,
+		JobIteration: getIntFromLabels(pvcLabels, config.KubeBurnerLabelJobIteration),
+		Replica:      getIntFromLabels(pvcLabels, config.KubeBurnerLabelReplica),
+	})
+}
+
+// handles pvc update
+func (p *pvcLatency) handleUpdatePVC(obj interface{}) {
+	pvc := obj.(*corev1.PersistentVolumeClaim)
+	if value, exists := p.metrics.Load(string(pvc.UID)); exists {
+		pm := value.(pvcMetric)
+		if pm.bound == 0 || pm.lost == 0 {
+			// https://pkg.go.dev/k8s.io/api/core/v1#PersistentVolumeClaimPhase
+			if pvc.Status.Phase == corev1.ClaimPending {
+				if pm.pending == 0 {
+					log.Debugf("PVC %s is pending", pvc.Name)
+					pm.pending = time.Now().UTC().UnixMilli()
+				}
+			}
+			if pvc.Status.Phase == corev1.ClaimBound {
+				if pm.bound == 0 {
+					log.Debugf("PVC %s is bound", pvc.Name)
+					pm.bound = time.Now().UTC().UnixMilli()
+				}
+			}
+			if pvc.Status.Phase == corev1.ClaimLost {
+				if pm.lost == 0 {
+					log.Debugf("PVC %s is lost", pvc.Name)
+					pm.lost = time.Now().UTC().UnixMilli()
+				}
+			}
+			p.metrics.Store(string(pvc.UID), pm)
+		}
+	}
+}
+
+// sets cofiguration for pvc latency
+func (p *pvcLatency) setConfig(cfg types.Measurement) error {
+	p.config = cfg
+	var metricFound bool
+	var latencyMetrics = []string{"P99", "P95", "P50", "Avg", "Max"}
+	for _, th := range p.config.LatencyThresholds {
+		if th.ConditionType == string(corev1.ClaimPending) || th.ConditionType == string(corev1.ClaimBound) || th.ConditionType == string(corev1.ClaimLost) {
+			for _, lm := range latencyMetrics {
+				if th.Metric == lm {
+					metricFound = true
+					break
+				}
+			}
+			if !metricFound {
+				return fmt.Errorf("unsupported metric %s in pvcLatency measurement, supported are: %s", th.Metric, strings.Join(latencyMetrics, ", "))
+			}
+		} else {
+			return fmt.Errorf("unsupported pod condition type in pvcLatency measurement: %s", th.ConditionType)
+		}
+	}
+	return nil
+}
+
+// start pvcLatency measurement
+func (p *pvcLatency) start(measurementWg *sync.WaitGroup) error {
+	if factory.jobConfig.JobType == config.ReadJob || factory.jobConfig.JobType == config.PatchJob || factory.jobConfig.JobType == config.DeletionJob {
+		log.Fatalf("Unsupported jobType:%s for pvcLatency metric", factory.jobConfig.JobType)
+	}
+	p.latencyQuantiles, p.normLatencies = nil, nil
+	defer measurementWg.Done()
+	p.metrics = sync.Map{}
+	log.Infof("Creating PVC latency watcher for %s", factory.jobConfig.Name)
+	p.watcher = metrics.NewWatcher(
+		factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
+		"pvcWatcher",
+		"persistentvolumeclaims",
+		corev1.NamespaceAll,
+		func(options *metav1.ListOptions) {
+			options.LabelSelector = fmt.Sprintf("kube-burner-runid=%v", globalCfg.RUNID)
+		},
+		nil,
+	)
+	p.watcher.Informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: p.handleCreatePVC,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			p.handleUpdatePVC(newObj)
+		},
+	})
+	if err := p.watcher.StartAndCacheSync(); err != nil {
+		log.Errorf("PVC Latency measurement error: %s", err)
+	}
+	return nil
+}
+
+// collects PVC measurements triggered in the past
+func (p *pvcLatency) collect(measurementWg *sync.WaitGroup) {
+	log.Info("Collect method doesn't apply to PVC by design")
+	defer measurementWg.Done()
+}
+
+// helper to fetch the storage class name (handles nil cases)
+func getStorageClassName(pvc corev1.PersistentVolumeClaim) string {
+	if pvc.Spec.StorageClassName != nil {
+		return *pvc.Spec.StorageClassName
+	}
+	return "unknown"
+}
+
+// stop pvc latency measurement
+func (p *pvcLatency) stop() error {
+	var err error
+	defer func() {
+		if p.watcher != nil {
+			p.watcher.StopWatcher()
+		}
+	}()
+	errorRate := p.normalizeMetrics()
+	if errorRate > 10.00 {
+		log.Error("Latency errors beyond 10%. Hence invalidating the results")
+		return fmt.Errorf("Something is wrong with system under test. PVC latencies error rate was: %.2f", errorRate)
+	}
+	p.calcQuantiles()
+	if len(p.config.LatencyThresholds) > 0 {
+		err = metrics.CheckThreshold(p.config.LatencyThresholds, p.latencyQuantiles)
+	}
+	for _, q := range p.latencyQuantiles {
+		pq := q.(metrics.LatencyQuantiles)
+		log.Infof("%s: %v 99th: %v max: %v avg: %v", factory.jobConfig.Name, pq.QuantileName, pq.P99, pq.Max, pq.Avg)
+	}
+	if errorRate > 0 {
+		log.Infof("PVC latencies error rate was: %.2f", errorRate)
+	}
+	return err
+}
+
+// index sends metrics to the configured indexer
+func (p *pvcLatency) index(jobName string, indexerList map[string]indexers.Indexer) {
+	metricMap := map[string][]interface{}{
+		pvcLatencyMeasurement:          p.normLatencies,
+		pvcLatencyQuantilesMeasurement: p.latencyQuantiles,
+	}
+	IndexLatencyMeasurement(p.config, jobName, metricMap, indexerList)
+}
+
+// getter function to get metrics
+func (p *pvcLatency) getMetrics() *sync.Map {
+	return &p.metrics
+}
+
+// normalizes pvc latency metrics
+func (p *pvcLatency) normalizeMetrics() float64 {
+	totalPVCs := 0
+	erroredPVCs := 0
+
+	p.metrics.Range(func(key, value interface{}) bool {
+		m := value.(pvcMetric)
+		// If a pvc does not reach the stable state, we skip that one
+		if m.bound == 0 && m.lost == 0 {
+			log.Tracef("PVC %v latency ignored as it did not reach a stable state", m.Name)
+			return true
+		}
+		errorFlag := 0
+		m.PendingLatency = int(m.pending - m.Timestamp.UnixMilli())
+		if m.PendingLatency < 0 {
+			log.Tracef("PendingLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
+			errorFlag = 1
+			m.PendingLatency = 0
+		}
+
+		m.BindingLatency = int(m.bound - m.Timestamp.UnixMilli())
+		if m.BindingLatency < 0 {
+			log.Tracef("BindingLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
+			errorFlag = 1
+			m.BindingLatency = 0
+		}
+
+		m.LostLatency = int(m.lost - m.Timestamp.UnixMilli())
+		if m.LostLatency < 0 {
+			log.Tracef("LostLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
+			m.LostLatency = 0
+		}
+
+		totalPVCs++
+		erroredPVCs += errorFlag
+		p.normLatencies = append(p.normLatencies, m)
+		return true
+	})
+	if totalPVCs == 0 {
+		return 0.0
+	}
+	return float64(erroredPVCs) / float64(totalPVCs) * 100.0
+}
+
+// calculates latency quantiles
+func (p *pvcLatency) calcQuantiles() {
+	getLatency := func(normLatency interface{}) map[string]float64 {
+		pvcMetric := normLatency.(pvcMetric)
+		return map[string]float64{
+			string(corev1.ClaimPending): float64(pvcMetric.PendingLatency),
+			string(corev1.ClaimBound):   float64(pvcMetric.BindingLatency),
+			string(corev1.ClaimLost):    float64(pvcMetric.LostLatency),
+		}
+	}
+	p.latencyQuantiles = calculateQuantiles(p.normLatencies, getLatency, podLatencyQuantilesMeasurement)
+}

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -218,7 +218,9 @@ teardown_file() {
 
   local jobs=("create-vm" "create-base-image-dv")
   for job in "${jobs[@]}"; do
-    check_metric_recorded ${job} dvLatency dvReadyLatency
+    check_metric_recorded ${job} dvLatency dvReadyLatency 
+    check_metric_recorded ${job} pvcLatency bindingLatency
     check_quantile_recorded ${job} dvLatency Ready
+    check_quantile_recorded ${job} pvcLatency Bound
   done
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adding PVC latency to family of measurements.

## Related Tickets & Documents
Closes # https://github.com/kube-burner/kube-burner/issues/426

## Testing 
Tested and verified in local
```
time="2025-01-09 18:13:47" level=info msg="pvc-move: Bound 99th: 4544 max: 4544 avg: 4544" file="pvc_latency.go:206"
time="2025-01-09 18:13:47" level=info msg="pvc-move: Lost 99th: 0 max: 0 avg: 0" file="pvc_latency.go:206"
time="2025-01-09 18:13:47" level=info msg="pvc-move: Pending 99th: 93 max: 93 avg: 93" file="pvc_latency.go:206"
```
