### PR TITLE
Makefile - allow passing a filter to bats when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,4 +78,4 @@ manifest-build:
 test: lint test-k8s
 
 test-k8s:
-	cd test && KUBE_BURNER=$(TEST_BINARY) bats -F pretty -T --print-output-on-failure test-k8s.bats
+	cd test && KUBE_BURNER=$(TEST_BINARY) bats $(if $(TEST_FILTER),--filter "$(TEST_FILTER)",) -F pretty -T --print-output-on-failure test-k8s.bats

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -57,3 +57,11 @@ Either save the kubeconfig file under `~/.kube/config` or set the environment va
 #### Run the tests
 
 In order to instruct the tests to use the existing cluster set `USE_EXISTING_CLUSTER=yes` when calling `make`.
+
+### Execute a subset of the tests
+
+The list of executed tests may be filtered by setting the environment variable `TEST_FILTER`:
+
+```bash
+TEST_FILTER="datavolume" make test-k8s
+```


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

Allow contributors to run specific tests while still using the test-k8s rule