### PR TITLE
Allow passing additional variables when using as a package

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -104,7 +104,7 @@ func initCmd() *cobra.Command {
 					log.Fatalf("Error reading user data file %s: %s", userDataFile, err)
 				}
 			}
-			configSpec, err := config.ParseWithUserdata(uuid, timeout, configFileReader, userDataFileReader, allowMissingKeys)
+			configSpec, err := config.ParseWithUserdata(uuid, timeout, configFileReader, userDataFileReader, allowMissingKeys, nil)
 			if err != nil {
 				log.Fatalf("Config error: %s", err.Error())
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,19 +114,28 @@ func (j *Job) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func getInputData(userDataFileReader io.Reader) (map[string]interface{}, error) {
+func getInputData(userDataFileReader io.Reader, additionalVars map[string]interface{}) (map[string]interface{}, error) {
 	inputData := make(map[string]interface{})
+	// First copy from additionalVars
+	for key, value := range additionalVars {
+		inputData[key] = value
+	}
+	// If a userDataFileReader was provided use it to override values
 	if userDataFileReader != nil {
+		userDataFileVars := make(map[string]interface{})
 		userData, err := io.ReadAll(userDataFileReader)
 		if err != nil {
 			return nil, fmt.Errorf("error reading user data file: %w", err)
 		}
-		err = yaml.Unmarshal(userData, &inputData)
+		err = yaml.Unmarshal(userData, &userDataFileVars)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse file: %w", err)
 		}
+		for key, value := range userDataFileVars {
+			inputData[key] = value
+		}
 	}
-	// Add all entries from map2, overriding duplicates from map1
+	// Add all entries from environment variables, overriding duplicates
 	for key, value := range util.EnvToMap() {
 		inputData[key] = value
 	}
@@ -134,16 +143,16 @@ func getInputData(userDataFileReader io.Reader) (map[string]interface{}, error) 
 }
 
 func Parse(uuid string, timeout time.Duration, configFileReader io.Reader) (Spec, error) {
-	return ParseWithUserdata(uuid, timeout, configFileReader, nil, false)
+	return ParseWithUserdata(uuid, timeout, configFileReader, nil, false, nil)
 }
 
 // Parse parses a configuration file
-func ParseWithUserdata(uuid string, timeout time.Duration, configFileReader, userDataFileReader io.Reader, allowMissingKeys bool) (Spec, error) {
+func ParseWithUserdata(uuid string, timeout time.Duration, configFileReader, userDataFileReader io.Reader, allowMissingKeys bool, additionalVars map[string]interface{}) (Spec, error) {
 	cfg, err := io.ReadAll(configFileReader)
 	if err != nil {
 		return configSpec, fmt.Errorf("error reading configuration file: %s", err)
 	}
-	inputData, err := getInputData(userDataFileReader)
+	inputData, err := getInputData(userDataFileReader, additionalVars)
 	if err != nil {
 		return configSpec, err
 	}

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -45,6 +45,10 @@ func NewWorkloadHelper(config Config, embedConfig *embed.FS, kubeClientProvider 
 }
 
 func (wh *WorkloadHelper) Run(workload string) int {
+	return wh.RunWithAdditionalVars(workload, nil)
+}
+
+func (wh *WorkloadHelper) RunWithAdditionalVars(workload string, additionalVars map[string]interface{}) int {
 	configFile := fmt.Sprintf("%s.yml", workload)
 	var embedFS *embed.FS
 	var embedFSDir string
@@ -56,7 +60,7 @@ func (wh *WorkloadHelper) Run(workload string) int {
 	if err != nil {
 		log.Fatalf("Error reading configuration file: %v", err.Error())
 	}
-	ConfigSpec, err = config.Parse(wh.UUID, wh.Timeout, f)
+	ConfigSpec, err = config.ParseWithUserdata(wh.UUID, wh.Timeout, f, nil, false, additionalVars)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

When using kube-burner as a package passing parameters as environment variables may be cumbersome. Instead, allow passing the values via a method parameter 
