### PR TITLE
Limit virt-launcher deletion to kube-burner pods

### DIFF
--- a/examples/workloads/kubevirt-density/kubevirt-density.yml
+++ b/examples/workloads/kubevirt-density/kubevirt-density.yml
@@ -31,7 +31,7 @@ jobs:
       apiVersion: kubevirt.io/v1
 
     - kind: Pod
-      labelSelector: {kubevirt.io: virt-launcher}
+      labelSelector: {kube-burner-job: kubevirt-density}
       apiVersion: v1
 
     - kind: Namespace
@@ -89,7 +89,7 @@ jobs:
       apiVersion: kubevirt.io/v1
 
     - kind: Pod
-      labelSelector: {kubevirt.io: virt-launcher}
+      labelSelector: {kube-burner-job: kubevirt-density}
       apiVersion: v1
 
     - kind: Namespace


### PR DESCRIPTION
Fix virt-launcher pod deletion selection, such that it only deletes kube-burner initiated virt-launcher pods. Else it attemps to delete all virt-launcher pods under all namespaces, a potential risk if this kube-burner example is ever executed in a production system.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Limit the label selection on  [L34](https://github.com/kube-burner/kube-burner/blob/main/examples/workloads/kubevirt-density/kubevirt-density.yml#L34)  and [L92 ](https://github.com/kube-burner/kube-burner/blob/main/examples/workloads/kubevirt-density/kubevirt-density.yml#L92)  to virt launcher pods created by kubevirt-density job. 
