### PR TITLE
Adding iterations churning

### DIFF
--- a/.github/workflows/check-docs-links.yml
+++ b/.github/workflows/check-docs-links.yml
@@ -3,10 +3,6 @@ name: Check Documentation Links
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - master
-      - main
   push:
     branches:
       - master


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Adding iteration churning. Churn workflow will now onwards automatically decide if to delete an entire namespace or just few iterations in case of single namespace workloads.

## Related Tickets & Documents
Closes # https://github.com/kube-burner/kube-burner/issues/673

## Testing
Tested on a self-managed OCP cluser using node-density and verified the funtionality.
```
vchalla@vchalla-thinkpadp1gen2:~/myforks/kube-burner-ocp$ kube-burner-ocp node-density --pods-per-node=23
time="2025-01-10 18:12:41" level=info msg="❤️ Checking for Cluster Health" file="cluster_health.go:45"
time="2025-01-10 18:12:42" level=info msg="Cluster is Healthy" file="cluster_health.go:53"
time="2025-01-10 18:12:43" level=info msg="🔥 Starting kube-burner (main@36359f30301b7f68e59f1c729b020ce57028dbfa) with UUID d787cc75-c9f6-45c3-be2e-23e3f0ac9430" file="job.go:82"
time="2025-01-10 18:12:43" level=info msg="📈 Registered measurement: podLatency" file="factory.go:95"
time="2025-01-10 18:12:43" level=info msg="QPS: 20" file="job.go:310"
time="2025-01-10 18:12:43" level=info msg="Burst: 20" file="job.go:311"
time="2025-01-10 18:12:43" level=info msg="Job node-density: 3 iterations with 1 Pod replicas" file="create.go:78"
time="2025-01-10 18:12:43" level=info msg="Pre-load: images from job node-density" file="pre_load.go:71"
time="2025-01-10 18:12:43" level=info msg="Pre-load: Creating DaemonSet using images [registry.k8s.io/pause:3.1] in namespace preload-kube-burner" file="pre_load.go:197"
time="2025-01-10 18:12:43" level=info msg="Pre-load: Sleeping for 10s" file="pre_load.go:84"
time="2025-01-10 18:12:53" level=info msg="Deleting 1 namespaces with label: kube-burner-preload=true" file="namespaces.go:67"
time="2025-01-10 18:12:59" level=info msg="Triggering job: node-density" file="job.go:98"
time="2025-01-10 18:12:59" level=info msg="Creating Pod latency watcher for node-density" file="pod_latency.go:161"
time="2025-01-10 18:13:00" level=info msg="Churning enabled" file="job.go:106"
time="2025-01-10 18:13:00" level=info msg="Churn cycles: 3" file="job.go:107"
time="2025-01-10 18:13:00" level=info msg="Churn duration: 1h0m0s" file="job.go:108"
time="2025-01-10 18:13:00" level=info msg="Churn percent: 20" file="job.go:109"
time="2025-01-10 18:13:00" level=info msg="Churn delay: 5s" file="job.go:110"
time="2025-01-10 18:13:00" level=info msg="Churn deletion strategy: default" file="job.go:111"
time="2025-01-10 18:13:00" level=info msg="0/3 iterations completed" file="create.go:117"
time="2025-01-10 18:13:00" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:167"
time="2025-01-10 18:13:01" level=info msg="Actions in namespace node-density-0 completed" file="waiters.go:76"
time="2025-01-10 18:13:01" level=info msg="Verifying created objects" file="utils.go:92"
time="2025-01-10 18:13:01" level=info msg="Churning through iterations: 0 to 1 in namespace: node-density-0" file="create.go:357"
time="2025-01-10 18:13:01" level=info msg="Deleting Pods labeled with kube-burner-job=node-density,kube-burner.io/job-iteration=0 in node-density-0" file="namespaces.go:55"
time="2025-01-10 18:13:05" level=info msg="Re-creating deleted objects" file="create.go:365"
time="2025-01-10 18:13:05" level=info msg="0/1 iterations completed" file="create.go:117"
time="2025-01-10 18:13:05" level=info msg="Namespace node-density-0 already exists" file="namespaces.go:43"
time="2025-01-10 18:13:05" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:167"
time="2025-01-10 18:13:06" level=info msg="Actions in namespace node-density-0 completed" file="waiters.go:76"
time="2025-01-10 18:13:06" level=info msg="Sleeping for 5s" file="create.go:368"
time="2025-01-10 18:13:11" level=info msg="Churning through iterations: 0 to 1 in namespace: node-density-0" file="create.go:357"
time="2025-01-10 18:13:11" level=info msg="Deleting Pods labeled with kube-burner-job=node-density,kube-burner.io/job-iteration=0 in node-density-0" file="namespaces.go:55"
time="2025-01-10 18:13:12" level=info msg="Re-creating deleted objects" file="create.go:365"
time="2025-01-10 18:13:12" level=info msg="0/1 iterations completed" file="create.go:117"
time="2025-01-10 18:13:12" level=info msg="Namespace node-density-0 already exists" file="namespaces.go:43"
time="2025-01-10 18:13:12" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:167"
time="2025-01-10 18:13:15" level=info msg="Actions in namespace node-density-0 completed" file="waiters.go:76"
time="2025-01-10 18:13:15" level=info msg="Sleeping for 5s" file="create.go:368"
time="2025-01-10 18:13:20" level=info msg="Churning through iterations: 1 to 2 in namespace: node-density-0" file="create.go:357"
time="2025-01-10 18:13:20" level=info msg="Deleting Pods labeled with kube-burner-job=node-density,kube-burner.io/job-iteration=1 in node-density-0" file="namespaces.go:55"
time="2025-01-10 18:13:21" level=info msg="Re-creating deleted objects" file="create.go:365"
time="2025-01-10 18:13:21" level=info msg="0/1 iterations completed" file="create.go:117"
time="2025-01-10 18:13:21" level=info msg="Namespace node-density-0 already exists" file="namespaces.go:43"
time="2025-01-10 18:13:21" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:167"
time="2025-01-10 18:13:22" level=info msg="Actions in namespace node-density-0 completed" file="waiters.go:76"
time="2025-01-10 18:13:22" level=info msg="Sleeping for 5s" file="create.go:368"
time="2025-01-10 18:13:27" level=info msg="Reached specified number of churn cycles (3), stopping churn job" file="create.go:326"
time="2025-01-10 18:13:27" level=info msg="Job node-density took 28s" file="job.go:159"
time="2025-01-10 18:13:27" level=info msg="Stopping measurement: podLatency" file="factory.go:129"
time="2025-01-10 18:13:27" level=info msg="Evaluating latency thresholds" file="metrics.go:48"
time="2025-01-10 18:13:27" level=info msg="node-density: PodReadyToStartContainers 99th: 0 max: 0 avg: 0" file="pod_latency.go:250"
time="2025-01-10 18:13:27" level=info msg="node-density: PodScheduled 99th: 0 max: 0 avg: 0" file="pod_latency.go:250"
time="2025-01-10 18:13:27" level=info msg="node-density: ContainersReady 99th: 1500 max: 2000 avg: 1000" file="pod_latency.go:250"
time="2025-01-10 18:13:27" level=info msg="node-density: Initialized 99th: 0 max: 0 avg: 0" file="pod_latency.go:250"
time="2025-01-10 18:13:27" level=info msg="node-density: Ready 99th: 1500 max: 2000 avg: 1000" file="pod_latency.go:250"
time="2025-01-10 18:13:27" level=info msg="Finished execution with UUID: d787cc75-c9f6-45c3-be2e-23e3f0ac9430" file="job.go:220"
time="2025-01-10 18:13:27" level=info msg="Garbage collecting jobs" file="job.go:241"
time="2025-01-10 18:13:28" level=info msg="Deleting 1 namespaces with label: kube-burner-job=node-density" file="namespaces.go:67"
time="2025-01-10 18:13:40" level=info msg="👋 kube-burner run completed with rc 0 for UUID d787cc75-c9f6-45c3-be2e-23e3f0ac9430" file="helpers.go:82"
```