### PR TITLE
Allow waiting for status between objects in the same job iteration

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -91,6 +91,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | `defaultMissingKeysWithZero` | Stops templates from exiting with an error when a missing key is found, meaning users will have to ensure templates hand missing keys | Boolean  | false    |
 | `executionMode`              | Job execution mode. More details at [execution modes](#execution-modes)                                                               | String   | parallel |
 | `objectDelay`                | How long to wait between each object in a job                                                                                         | Duration | 0s       |
+| `objectWait`                 | Wait for each object to complete before processing the next one - not for Create jobs                                                 | Boolean  | 0s       |
 
 !!! note
     Both `churnCycles` and `churnDuration` serve as termination conditions, with the churn process halting when either condition is met first. If someone wishes to exclusively utilize `churnDuration` to control churn, they can achieve this by setting `churnCycles` to `0`. Conversely, to prioritize `churnCycles`, one should set a longer `churnDuration` accordingly.

--- a/pkg/burner/utils.go
+++ b/pkg/burner/utils.go
@@ -225,7 +225,11 @@ func (ex *Executor) runSequential(ctx context.Context) {
 			}
 			// Wait for all items in the object
 			wg.Wait()
-			ex.waitForObjects("")
+
+			// If requested, wait for the completion of the specific object
+			if ex.ObjectWait {
+				ex.waitForObject("", &obj)
+			}
 
 			if ex.objectFinalizer != nil {
 				ex.objectFinalizer(ex, obj)
@@ -235,6 +239,9 @@ func (ex *Executor) runSequential(ctx context.Context) {
 				log.Infof("Sleeping between objects for %v", ex.ObjectDelay)
 				time.Sleep(ex.ObjectDelay)
 			}
+		}
+		if ex.WaitWhenFinished {
+			ex.waitForObjects("")
 		}
 		// Wait between job iterations
 		if ex.JobIterationDelay > 0 {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -201,6 +201,8 @@ type Job struct {
 	ExecutionMode ExecutionMode `yaml:"executionMode" json:"executionMode,omitempty"`
 	// ObjectDelay how much time to wait between objects processing in patch jobs
 	ObjectDelay time.Duration `yaml:"objectDelay" json:"objectDelay,omitempty"`
+	// ObjectWait wait for each object to complete before processing the next one
+	ObjectWait bool `yaml:"objectWait" json:"objectWait,omitempty"`
 }
 
 type WaitOptions struct {

--- a/test/k8s/kube-burner-virt-operations.yml
+++ b/test/k8s/kube-burner-virt-operations.yml
@@ -31,29 +31,88 @@ jobs:
     burst: 20
     jobIterations: 2
     objectDelay: 1m
+    objectWait: true
+    waitWhenFinished: false
     objects:
     - kubeVirtOp: stop
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
+      waitOptions:
+        labelSelector:
+          kube-burner-job: kubevirt-ops
+        customStatusPaths:
+        - key:   "(.conditions.[] | select(.type == \"Ready\")).status"
+          value: "False"
     - kubeVirtOp: start
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
+      waitOptions:
+        labelSelector:
+          kube-burner-job: kubevirt-ops
+        customStatusPaths:
+        - key:   "(.conditions.[] | select(.type == \"Ready\")).status"
+          value: "True"
     - kubeVirtOp: restart
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
+      # Do not wait for the completion as there is currently no way to check it
+      wait: false
     - kubeVirtOp: pause
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
+      waitOptions:
+        labelSelector:
+          kube-burner-job: kubevirt-ops
+        customStatusPaths:
+        - key:   "(.conditions.[] | select(.type == \"Paused\")).status"
+          value: "True"
     - kubeVirtOp: unpause
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
+      waitOptions:
+        labelSelector:
+          kube-burner-job: kubevirt-ops
+        customStatusPaths:
+        - key:   "(.conditions.[] | select(.type == \"Ready\")).status"
+          value: "True"
     - kubeVirtOp: stop
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
       inputVars:
         force: true
+      waitOptions:
+        labelSelector:
+          kube-burner-job: kubevirt-ops
+        customStatusPaths:
+        - key:   "(.conditions.[] | select(.type == \"Ready\")).status"
+          value: "False"
     - kubeVirtOp: start
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
       inputVars:
         startPaused: true
+      waitOptions:
+        labelSelector:
+          kube-burner-job: kubevirt-ops
+        customStatusPaths:
+        - key:   "(.conditions.[] | select(.type == \"Paused\")).status"
+          value: "True"
     - kubeVirtOp: unpause
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
+      inputVars:
+        force: true
+      waitOptions:
+        labelSelector:
+          kube-burner-job: kubevirt-ops
+        customStatusPaths:
+        - key:   "(.conditions.[] | select(.type == \"Ready\")).status"
+          value: "True"
     - kubeVirtOp: migrate
-      labelSelector: {kube-burner-job: kubevirt-ops}
+      labelSelector:
+        kube-burner-job: kubevirt-ops
+      # Do not wait for the completion as there is currently no way to check it
+      wait: false
 
   # cleanup the experiment
   - name: delete-vms
@@ -68,4 +127,4 @@ jobs:
       apiVersion: kubevirt.io/v1
 
     - kind: Namespace
-      labelSelector: {kube-burner-job: ops}
+      labelSelector: {kube-burner-job: kubevirt-ops}


### PR DESCRIPTION
## Type of change

- New feature
- Bug fix

## Description

Add a new job parameter to wait between objects
In Sequential run check and wait at the object and at the job iteration level
Adjust testing
Add to doc
