### PR TITLE
Waiters - do not fail if query jq failed

### DIFF
--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -265,8 +265,8 @@ func (ex *Executor) verifyCondition(ns string, obj object) error {
 							break
 						}
 						if err, ok := v.(error); ok {
-							log.Errorf("Error evaluating jq path: %s", err)
-							return false, err
+							log.Warnf("Error evaluating jq path: [%s]: %s", statusPath.Key, err)
+							break
 						}
 						if v == statusPath.Value {
 							isStatusValid = true


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

Fix race condition in which the waiter checks for a field in the status that does not yet exist.
For example, waiting on a condition before there are any
