### PR TITLE
[GH#816] fix wrappers 404 in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ nav:
     - contributing/pullrequest.md
     - contributing/release.md
   - Tests: contributing/tests.md
-- Wrappers: wrappers/index.md
+- Wrappers: wrappers/wrappers.md
 site_name: Kube-burner
 plugins:
   - search


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Documentation

## Description

The nav item was pointing to `wrappers/index` instead of `wrappers/wrappers` resulting in a broken link.

## Related Tickets & Documents

- Closes #816
