### PR TITLE
Expect items from a single iteration when RunOnce is set

### DIFF
--- a/pkg/burner/utils.go
+++ b/pkg/burner/utils.go
@@ -144,7 +144,12 @@ func (ex *Executor) Verify() bool {
 			success = false
 			continue
 		}
-		objectsExpected := ex.JobIterations * obj.Replicas
+		var objectsExpected int
+		if obj.RunOnce {
+			objectsExpected = obj.Replicas
+		} else {
+			objectsExpected = obj.Replicas * ex.JobIterations
+		}
 		if replicas != objectsExpected {
 			log.Errorf("%s found: %d Expected: %d", obj.gvr.Resource, replicas, objectsExpected)
 			success = false

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -79,3 +79,7 @@ jobs:
 
     - objectTemplate: objectTemplates/service.yml
       replicas: 1
+
+    - objectTemplate: objectTemplates/secret.yml
+      replicas: 1
+      runOnce: true

--- a/test/k8s/objectTemplates/secret.yml
+++ b/test/k8s/objectTemplates/secret.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-{{.Iteration}}-{{.Replica}}
+data:
+  info: {{ randAlphaNum 16 | b64enc  }}


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

When `runOnce` is set the number of created items is the number is in `replicas` without multiplying it be the number of iterations.

## Related Tickets & Documents

- Closes #821
