### PR TITLE
Delete job - always set waitWhenFinished to false

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -97,6 +97,12 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 !!! note
     Both `churnCycles` and `churnDuration` serve as termination conditions, with the churn process halting when either condition is met first. If someone wishes to exclusively utilize `churnDuration` to control churn, they can achieve this by setting `churnCycles` to `0`. Conversely, to prioritize `churnCycles`, one should set a longer `churnDuration` accordingly.
 
+!!! note
+    When `jobType` is set to [Delete](#delete) the following settings are forced:
+    `jobIterations` is set to `1`,
+    `waitWhenFinished` is set to `false`,
+    `executionMode` is set to `sequential`
+
 Our configuration files strictly follow YAML syntax. To clarify on List and Object types usage, they are nothing but the [`Lists and Dictionaries`](https://gettaurus.org/docs/YAMLTutorial/#Lists-and-Dictionaries) in YAML syntax.
 
 Examples of valid configuration files can be found in the [examples folder](https://github.com/kube-burner/kube-burner/tree/master/examples).

--- a/pkg/burner/delete.go
+++ b/pkg/burner/delete.go
@@ -38,6 +38,8 @@ func (ex *Executor) setupDeleteJob(configSpec config.Spec, mapper meta.RESTMappe
 	ex.JobIterations = 1
 	// Use the sequential mode
 	ex.ExecutionMode = config.ExecutionModeSequential
+	// WaitWhenFinished expects the resources to exists. For this reason wait is handled by WaitForDeletion
+	ex.WaitWhenFinished = false
 	for _, o := range ex.Objects {
 		log.Debugf("Job %s: %s %s with selector %s", ex.Name, ex.JobType, o.Kind, labels.Set(o.LabelSelector))
 		ex.objects = append(ex.objects, newObject(o, configSpec, mapper, APIVersionV1))


### PR DESCRIPTION
## Type of change

- Bug fix
- Documentation

## Description

waitWhenFinished searches for resources while a delete job removes them. As a result, waitWhenFinished should never be used. Instead WaitForDeletion should be used
