### PR TITLE
Fix logic to sort tags based on creation date

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Delete docs for older tags
         run: |
           echo "Keeping documentation for latest tags"
-          all_tags=$(git tag --sort=-v:refname)
+          all_tags=$(git for-each-ref --sort=-creatordate --format '%(refname:short)' refs/tags)
           tags_to_keep=$(echo "$all_tags" | head -n 3)
           for tag in $all_tags; do
             if [[ $tags_to_keep != *"$tag"* ]]; then


### PR DESCRIPTION
## Type of change

- Bug fix
- Documentation
- CI

## Description
Previous logic to fetch all the tags used to sort them in descending order lexicographically, which wasn't what we wanted in reality. So fixing that logic to fetch the logs and sort them solely based on creation times so that we fetch and keep only 3 latest version of them and delete the rest.

## Related Tickets & Documents
There have been failures in deploying docs in the past due to this issue.

## Testing
Tested and verified these changes locally in a hacky way.
### Previous command
```
v1.15.1
v1.15.0
v1.14.3
v1.14.2
v1.14.1
v1.14.0
v1.13.0
v1.12.1
v1.12.0
v1.11.3
v1.11.2
v1.11.1
v1.11.0
v1.10.9
v1.10.8
v1.10.7
v1.10.6
v1.10.5
v1.10.4
v1.10.3
v1.10.1
v1.10.0
v1.9.8
v1.9.7
v1.9.5
v1.9.4
v1.9.3
v1.9.2
v1.9.1
v1.9.0
v1.8.1
v1.8.0
v1.7.13
v1.7.12
v1.7.11
v1.7.10
v1.7.9
v1.7.8
v1.7.7
v1.7.6
v1.7.5
v1.7.4
v1.7.3
v1.7.2
v1.7.1
v1.7.0
v1.6
v1.5
v1.4.4
v1.4.3
v1.4.2
v1.4.1
v1.4
v1.3
v1.2
v1.1
v1.0
v0.17.3
v0.17.2
v0.17.1
v0.17.0
v0.16.3
v0.16.2
v0.16.1
v0.16
v0.15.5
v0.15.4
v0.15.3
v0.15.2
v0.15.1
v0.15
v0.14.3
v0.14.2
v0.14.1
v0.14
v0.13.2
v0.13.1
v0.13
v0.12
v0.11
v0.10.1
v0.10
v0.9.1
v0.9
v0.8
v0.7
v0.6
v0.5
v0.4.1
v0.4
v0.3
```
Current logic
```
v1.15.1
v1.15.0
v1.14.3
v1.14.2
v1.14.1
v1.14.0
v1.13.0
v1.12.1
v1.12.0
v1.11.3
v1.11.2
v1.11.1
v1.11.0
v1.10.9
v1.10.8
v1.10.7
v1.10.6
v1.10.5
v1.10.4
v1.10.3
v1.10.1
v1.10.0
v1.9.8
v1.9.7
v1.9.5
v1.9.4
v1.9.3
v1.9.2
v1.9.1
v1.9.0
v1.8.1
v1.8.0
v1.7.13
v1.7.12
v1.7.11
v1.7.10
v1.7.9
v1.7.8
v1.7.7
v1.7.6
v1.7.5
v1.7.4
v1.7.3
v1.7.2
v1.7.1
v1.7.0
v1.6
v1.5
v1.4.4
v1.4.3
v1.4.2
v1.4.1
v0.17.3
v1.4
v1.3
v1.2
v1.1
v1.0
v0.17.2
v0.17.1
v0.17.0
v0.16.3
v0.16.2
v0.16.1
v0.16
v0.15.5
v0.15.4
v0.15.3
v0.15.2
v0.15.1
v0.15
v0.14.3
v0.14.2
v0.14.1
v0.14
v0.13.2
v0.13.1
v0.13
v0.12
v0.11
v0.10.1
v0.10
v0.9.1
v0.9
v0.8
v0.7
v0.6
v0.5
v0.4.1
v0.4
v0.3
```
In both the above sorted list see how `v0.17.3` was placed.