### PR TITLE
Replace `kube_deployment_labels` with `kube_deployment_spec_replicas`…

### DIFF
--- a/examples/metrics-profiles/kubevirt-metrics.yaml
+++ b/examples/metrics-profiles/kubevirt-metrics.yaml
@@ -191,7 +191,7 @@
 - query: count(kube_secret_info{}) > 0
   metricName: secretCount
 
-- query: count(kube_deployment_labels{}) > 0
+- query: count(kube_deployment_spec_replicas{}) > 0
   metricName: deploymentCount
 
 - query: count(kube_configmap_info{}) > 0

--- a/examples/metrics-profiles/metrics-aggregated.yaml
+++ b/examples/metrics-profiles/metrics-aggregated.yaml
@@ -148,7 +148,7 @@
 - query: count(kube_secret_info{})
   metricName: secretCount
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
 
 - query: count(kube_configmap_info{})

--- a/examples/metrics-profiles/metrics.yaml
+++ b/examples/metrics-profiles/metrics.yaml
@@ -95,7 +95,7 @@
 - query: count(kube_secret_info{})
   metricName: secretCount
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
 
 - query: count(kube_configmap_info{})


### PR DESCRIPTION
… in metrics profiles

## Type of change

- Bug fix

## Description

Fix metrics profiles in examples for deployment count

