### PR TITLE
Add generic role to all maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,10 +2,10 @@ The current Maintainers Group for the Kube-burner Project consists of:
 
 | Name                  | Employer | GitHub ID                                                 | Email                   | Responsibilities |
 |---------------------  | -------- | --------------------------------------------------------- | ----------------------- | ---------------- |
-| Raul Sevilla Canavate | Red Hat  | [rsevilla87](https://github.com/rsevilla87)               | rsevilla@redhat.com     |    [TODO]        |
-| Vishnu Challa         | Red Hat  | [vishnuchalla](https://github.com/vishnuchalla)           | vchalla@redhat.com      |    [TODO]        |
-| Sai Malleni           | Red Hat  | [smalleni](https://github.com/smalleni)                   | smalleni@redhat.com     |    [TODO]        |
-| Ygal Blum             | Red Hat  | [ygalblunm](https://github.com/ygalblum)                  | yblum@redhat.com        |    [TODO]        |
+| Raul Sevilla Canavate | Red Hat  | [rsevilla87](https://github.com/rsevilla87)               | rsevilla@redhat.com     |    Project Maintainer        |
+| Vishnu Challa         | Red Hat  | [vishnuchalla](https://github.com/vishnuchalla)           | vchalla@redhat.com      |    Project Maintainer        |
+| Sai Malleni           | Red Hat  | [smalleni](https://github.com/smalleni)                   | smalleni@redhat.com     |    Project Maintainer        |
+| Ygal Blum             | Red Hat  | [ygalblunm](https://github.com/ygalblum)                  | yblum@redhat.com        |    Project Maintainer        |
 
 See [the project Governance](GOVERNANCE.md) for how maintainers are selected and replaced.
 


### PR DESCRIPTION
## Type of change

- Documentation

## Description

Add generic role to all maintainers, as Project Maintainer, later if needed we can do more specific roles.

## Related Tickets & Documents

- Related Issue #
- Closes #
