### PR TITLE
fix(conditions): handle null conditions in JQ queries to prevent warnings

### DIFF
--- a/pkg/burner/conditions.go
+++ b/pkg/burner/conditions.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	jqQueryConditionStringFieldPattern        = "(.conditions.[] | select(.type == \"%s\")).%s"
-	jqQueryConditionLastTransitionTimePattern = "(.conditions.[] | select(.type == \"%s\")).lastTransitionTime | strptime(\"%%Y-%%m-%%dT%%H:%%M:%%SZ\") | mktime %s %d | tostring"
+	jqQueryConditionStringFieldPattern        = "((.conditions // []) | .[] | select(.type == \"%s\")).%s"
+	jqQueryConditionLastTransitionTimePattern = "((.conditions // []) | .[] | select(.type == \"%s\")).lastTransitionTime | strptime(\"%%Y-%%m-%%dT%%H:%%M:%%SZ\") | mktime %s %d | tostring"
 )
 
 type ConditionField string


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Bug fix

## Description

<!--- Describe your changes in detail -->
When kube-burner waits for Job completion, the JQ query would fail with `"cannot iterate over: null"` warnings when the Job's `status.conditions` field hasn't been populated yet by the Kubernetes controller.

This is a race condition between Job creation and status population that occurs during the initial phase of Job lifecycle. The warnings were harmless as the waiter would retry, but they created noise in the logs.

The fix updates the JQ query patterns to use the alternative operator (`//`) to provide an empty array default when conditions is `null`.

Component: conditions

## Related Tickets & Documents

- Closes #853
