### PR TITLE
Fixing default for ClosingMetrics

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -589,4 +589,4 @@ This config defines when the metrics collection should stop. The option supports
 
 - `afterJob` - collect metrics after the job completes
 - `afterJobPause` - collect metrics after the jobPause duration ends
-- `afterMeasurements` - collect metrics after all measurements are finished
+- `afterMeasurements` - collect metrics after all measurements are finished (default)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -588,5 +588,5 @@ jobs:
 This config defines when the metrics collection should stop. The option supports three values:
 
 - `afterJob` - collect metrics after the job completes
-- `afterJobPause` - collect metrics after the jobPause duration ends
-- `afterMeasurements` - collect metrics after all measurements are finished (default)
+- `afterJobPause` - collect metrics after the jobPause duration ends (default)
+- `afterMeasurements` - collect metrics after all measurements are finished

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,7 +104,7 @@ func (j *Job) UnmarshalYAML(unmarshal func(any) error) error {
 		ChurnDuration:          1 * time.Hour,
 		ChurnDelay:             5 * time.Minute,
 		ChurnDeletionStrategy:  "default",
-		MetricsClosing:         "afterMeasurements",
+		MetricsClosing:         "afterJobPause",
 	}
 
 	if err := unmarshal(&raw); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,7 +104,7 @@ func (j *Job) UnmarshalYAML(unmarshal func(any) error) error {
 		ChurnDuration:          1 * time.Hour,
 		ChurnDelay:             5 * time.Minute,
 		ChurnDeletionStrategy:  "default",
-		MetricsClosing:         "afterJob",
+		MetricsClosing:         "afterMeasurements",
 	}
 
 	if err := unmarshal(&raw); err != nil {


### PR DESCRIPTION
## Type of change
- Bug fix
- Documentation

## Description
- Adding to our docs what our default `ClosingMetric` selection.
- Changing default to afterMeasurements to match previous workflow
