### PR TITLE
Fix : validate QPS and Burst to prevent panic and improve logging

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -336,14 +336,19 @@ func verifyJobTimeout(job *config.Job, defaultTimeout time.Duration) {
 }
 
 func verifyQPSBurst(job *config.Job) {
-	if job.QPS == 0 || job.Burst == 0 {
-		log.Infof("QPS or Burst rates not set, using default client-go values: %v %v", rest.DefaultQPS, rest.DefaultBurst)
-		job.QPS = rest.DefaultQPS
-		job.Burst = rest.DefaultBurst
-	} else {
-		log.Infof("QPS: %v", job.QPS)
-		log.Infof("Burst: %v", job.Burst)
-	}
+    if job.QPS <= 0 {
+        log.Warnf("Invalid QPS (%v); using default: %v", job.QPS, rest.DefaultQPS)
+        job.QPS = rest.DefaultQPS
+    } else {
+        log.Infof("QPS: %v", job.QPS)
+    }
+
+    if job.Burst <= 0 {
+        log.Warnf("Invalid Burst (%v); using default: %v", job.Burst, rest.DefaultBurst)
+        job.Burst = rest.DefaultBurst
+    } else {
+        log.Infof("Burst: %v", job.Burst)
+    }
 }
 
 func verifyJobDefaults(job *config.Job, defaultTimeout time.Duration) {


### PR DESCRIPTION



## Description

This change ensures the application handles these situations gracefully.

---

### Before (example failure cases)

**Case: QPS invalid → panic**

![Image](https://github.com/user-attachments/assets/2d324391-4433-4fdf-b869-b4fe26fdfe6c)

**Case: QPS valid, Burst negative → panic**

![Image](https://github.com/user-attachments/assets/4f6dc33f-c80e-4e24-a694-f5ab2b572564)

---

### After (example with fix applied)

**No panic, invalid values are corrected at runtime** ![Image](https://github.com/user-attachments/assets/f3656557-4336-4e6a-a289-8663618e9a5a)

