### PR TITLE
fix(ci): fix deploy-docs CI job failing on mike delete with substring matching

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,9 +33,9 @@ jobs:
           tags_to_keep=$(echo "$all_tags" | head -n 3)
           for tag in $all_tags; do
             if [[ $tags_to_keep != *"$tag"* ]]; then
-              if mike list | grep -q "$tag"; then
+              if mike list | grep -q "^$tag$"; then
                 echo "Deleting documentation for tag: $tag"
-                mike delete "$tag"
+                mike delete "$tag" || echo "Failed to delete documentation for tag: $tag"
               else
                 echo "Documentation for tag $tag not found. Skipping deletion."
               fi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,8 +89,8 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.keys


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- CI

## Description

the deploy-docs workflow was failing when trying to delete old documentation versions due to a grep pattern matching issue. the script used substring matching (`grep -q "$tag"`) which would incorrectly match partial version strings - for example, checking for "v1.2" would match "v1.20.6" and assume the documentation existed

this caused the workflow to attempt deleting non-existent versions like "v1.2" when only "v1.20.6" actually existed, resulting in: "error: unable to delete nonexistant identifier 'v1.2'"

the fix changes the grep pattern to use exact line matching (`grep -q "^$tag$"`) and updates mkdocs.yml to use the new material emoji extensions instead of the deprecated materialx.emoji extensions

also added error handling to prevent individual delete failures from breaking the entire ci workflow

<!--- Describe your changes in detail -->

## Related Tickets & Documents
- Closes: #901 
- Component: ci/docs

