### PR TITLE
Waiters - limit resource list to ones created by the current run

### DIFF
--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -197,9 +197,13 @@ teardown_file() {
   export LABEL_VALUE_END="end"
   export REPLICAS=50
 
+  # Create a failing deployment to test that kube-burner is not waiting on it
+  run_cmd kubectl create deployment failing-up --image=quay.io/cloud-bulldozer/sampleapp:nonexistent --replicas=1
+
   run_cmd ${KUBE_BURNER} init -c  kube-burner-sequential-patch.yml --uuid="${UUID}" --log-level=debug
   check_deployment_count ${NAMESPACE} ${LABEL_KEY} ${LABEL_VALUE_END} ${REPLICAS}
-  kubectl delete ns ${NAMESPACE}
+  run_cmd kubectl delete ns ${NAMESPACE}
+  run_cmd kubectl delete deployment failing-up
 }
 
 @test "kube-burner init: jobType kubevirt" {


### PR DESCRIPTION
## Type of change

- Bug fix
- CI

## Description
When waiting for resources to reach the desired state, list calls did not limit the list to the resources created by the current execution causing wait to hang on unrelated resources.
Add the current runid to the label selector when listing resources for wait

## Related Tickets & Documents

- Related Issue https://github.com/kube-burner/kube-burner-ocp/issues/263
