### PR TITLE
Fix(cli): Clarify default UUID behavior with help

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -91,6 +91,11 @@ func initCmd() *cobra.Command {
 			os.Exit(rc)
 		},
 		Args: cobra.NoArgs,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if uuid == "" {
+				uuid = uid.NewString()
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if configMap != "" {
 				metricsProfile, alertProfile, err = config.FetchConfigMap(configMap, namespace)
@@ -137,7 +142,7 @@ func initCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&uuid, "uuid", uid.NewString(), "Benchmark UUID")
+	cmd.Flags().StringVar(&uuid, "uuid", "", "Benchmark UUID (generated automatically if not provided)")
 	cmd.Flags().StringVarP(&metricsEndpoint, "metrics-endpoint", "e", "", "YAML file with a list of metric endpoints")
 	cmd.Flags().BoolVar(&skipTLSVerify, "skip-tls-verify", true, "Verify prometheus TLS certificate")
 	cmd.Flags().DurationVarP(&timeout, "timeout", "", 4*time.Hour, "Benchmark timeout")
@@ -311,6 +316,11 @@ func indexCmd() *cobra.Command {
 		PostRun: func(cmd *cobra.Command, args []string) {
 			log.Info("👋 Exiting kube-burner ", uuid)
 		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if uuid == "" {
+				uuid = uid.NewString()
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			util.SetupFileLogging(uuid)
 			configSpec.GlobalConfig.UUID = uuid
@@ -364,7 +374,7 @@ func indexCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&uuid, "uuid", uid.NewString(), "Benchmark UUID")
+	cmd.Flags().StringVar(&uuid, "uuid", "", "Benchmark UUID (generated automatically if not provided)")
 	cmd.Flags().StringVarP(&url, "prometheus-url", "u", "", "Prometheus URL")
 	cmd.Flags().StringVarP(&token, "token", "t", "", "Prometheus Bearer token")
 	cmd.Flags().StringVar(&username, "username", "", "Prometheus username for authentication")
@@ -439,6 +449,11 @@ func alertCmd() *cobra.Command {
 		Use:   "check-alerts",
 		Short: "Evaluate alerts for the given time range",
 		Args:  cobra.NoArgs,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if uuid == "" {
+				uuid = uid.NewString()
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			configSpec.GlobalConfig.UUID = uuid
 			if esServer != "" && esIndex != "" {
@@ -484,7 +499,7 @@ func alertCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&uuid, "uuid", uid.NewString(), "Benchmark UUID")
+	cmd.Flags().StringVar(&uuid, "uuid", "", "Benchmark UUID (generated automatically if not provided)")
 	cmd.Flags().StringVarP(&url, "prometheus-url", "u", "", "Prometheus URL")
 	cmd.Flags().StringVarP(&token, "token", "t", "", "Prometheus Bearer token")
 	cmd.Flags().StringVar(&username, "username", "", "Prometheus username for authentication")


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

The --uuid flag for the `init`, `check-alerts`, `index` commands displayed a randomly-generated UUID as its default value in the help text. This was misleading to users, suggesting the value was hardcoded or that they needed to override a specific default.

This commit addresses the issue in two ways:

1.  The default value for the flag definition is changed to an empty string. This provides a clean and predictable --help output.

2.  Logic is added to the beginning of each command's execution to generate a new UUID if one was not provided by the user.

This approach results in a more intuitive user experience while ensuring that a unique benchmark UUID is always present at runtime, preserving the original functionality.

Old behavior:-
~~~
$kube-burner init --help
Launch benchmark

Usage:
  kube-burner init [flags]

Flags:
      --uuid string               Benchmark UUID (default "a22992bc-e0f4-4301-8340-25b5ef4be94b")
~~~

New behavior:-
~~~
$kube-burner init --help
Launch benchmark

Usage:
  kube-burner init [flags]

Flags:
      --uuid string               Benchmark UUID (generated automatically if not provided)
~~~


## Related Tickets & Documents

- Closes #905 
