### PR TITLE
Kubevirt ops migrate - wait on migrationState of VMI

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -154,7 +154,7 @@ Examples of valid configuration files can be found in the [examples folder](http
 
 We have watchers support during the benchmark workload. It is at a job level and will be usefull in scenarios where we want to monitor overhead created by watchers on a cluster.
 
-!!! note 
+!!! note
     This feature doesn't effect the overall QPS/Burst as it uses its own client instance.
 
 | Option            | Description                                             | Type    | Default |
@@ -209,6 +209,7 @@ If you want to override the default waiter behaviors, you can specify wait optio
 
 | Option       | Description                                             | Type    | Default |
 |--------------|---------------------------------------------------------|---------|---------|
+| `apiVersion` | Object apiVersion to consider for wait | String | "" |
 | `kind` | Object kind to consider for wait | String | "" |
 | `labelSelector` | Objects with these labels will be considered for wait | Object | {} |
 | `customStatusPaths` | list of jq path/values to verify readiness of the object | Object  | [] |

--- a/pkg/burner/object.go
+++ b/pkg/burner/object.go
@@ -28,6 +28,7 @@ import (
 type object struct {
 	config.Object
 	gvr        schema.GroupVersionResource
+	waitGVR    *schema.GroupVersionResource
 	objectSpec []byte
 	namespace  string
 	namespaced bool
@@ -49,9 +50,23 @@ func newObject(obj config.Object, mapper meta.RESTMapper, defaultAPIVersion stri
 		log.Fatal(err)
 	}
 
+	var waitGVR *schema.GroupVersionResource
+	if obj.WaitOptions.Kind != "" {
+		if obj.WaitOptions.APIVersion == "" {
+			obj.WaitOptions.APIVersion = obj.APIVersion
+		}
+		gvk = schema.FromAPIVersionAndKind(obj.WaitOptions.APIVersion, obj.WaitOptions.Kind)
+		mapping, err = mapper.RESTMapping(gvk.GroupKind())
+		if err != nil {
+			log.Fatal(err)
+		}
+		waitGVR = &mapping.Resource
+	}
+
 	o := object{
 		Object:     obj,
 		gvr:        mapping.Resource,
+		waitGVR:    waitGVR,
 		namespaced: mapping.Scope.Name() == meta.RESTScopeNameNamespace,
 	}
 

--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -242,15 +242,19 @@ func (ex *JobExecutor) waitForBuild(ns string, obj object) error {
 }
 
 func (ex *JobExecutor) verifyCondition(ns string, obj object) error {
+	gvr := obj.gvr
+	if obj.waitGVR != nil {
+		gvr = *obj.waitGVR
+	}
 	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, ex.MaxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		var objs *unstructured.UnstructuredList
 		ex.limiter.Wait(context.TODO())
 		if obj.namespaced {
-			objs, err = ex.dynamicClient.Resource(obj.gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{
+			objs, err = ex.dynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: labels.Set(obj.WaitOptions.LabelSelector).String(),
 			})
 		} else {
-			objs, err = ex.dynamicClient.Resource(obj.gvr).List(context.TODO(), metav1.ListOptions{
+			objs, err = ex.dynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: labels.Set(obj.WaitOptions.LabelSelector).String(),
 			})
 		}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -211,6 +211,8 @@ type Job struct {
 }
 
 type WaitOptions struct {
+	// APIVersion apiVersion to consider for wait
+	APIVersion string `yaml:"apiVersion" json:"apiVersion,omitempty"`
 	// Kind object kind to consider for wait
 	Kind string `yaml:"kind" json:"kind,omitempty"`
 	// LabelSelector objects with these labels will be considered


### PR DESCRIPTION
## Type of change

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation

## Description
The state of the Ready condition is not guarantied to change during migration. Instead monitor the migrationState of the VMI
Support waiting on a gvr different from the original object gvr 
Add apiVersion to wait object

