### PR TITLE
feat(build): add missing security hardening flags for binary releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: build lint clean test help images push manifest manifest-build all
+.PHONY: build build-release build-hardened build-hardened-cgo lint clean test help images push manifest manifest-build all
 
 
 ARCH ?= $(shell uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
@@ -8,6 +8,13 @@ BIN_DIR = bin
 BIN_PATH = $(BIN_DIR)/$(ARCH)/$(BIN_NAME)
 CGO = 0
 TEST_BINARY ?= $(CURDIR)/$(BIN_PATH)
+# Security hardening flags for static builds
+HARDENED_FLAGS = -buildmode=pie -tags=netgo,osusergo,static_build
+HARDENED_LDFLAGS = -extldflags '-static'
+
+# Full security hardening flags with CGO
+HARDENED_CGO_FLAGS = -buildmode=pie
+HARDENED_CGO_LDFLAGS = -linkmode=external -extldflags "-Wl,-z,relro,-z,now"
 
 GIT_COMMIT = $(shell git rev-parse HEAD)
 VERSION ?= $(shell hack/tag_name.sh)
@@ -29,15 +36,17 @@ help:
 	@echo "Commands for $(BIN_PATH):"
 	@echo
 	@echo 'Usage:'
-	@echo '    make lint                     	Install and execute pre-commit'
-	@echo '    make clean                    	Clean the compiled binaries'
-	@echo '    [ARCH=arch] make build        	Compile the project for arch, default amd64'
-	@echo '    [ARCH=arch] make build-release 	Compile hardened release binary, default amd64'
-	@echo '    [ARCH=arch] make install      	Installs kube-burner binary in the system, default amd64'
-	@echo '    [ARCH=arch] make images       	Build images for arch, default amd64'
-	@echo '    [ARCH=arch] make push         	Push images for arch, default amd64'
-	@echo '    make manifest                 	Create and push manifest for the different architectures supported'
-	@echo '    make help                     	Show this message'
+	@echo '    make lint                     		Install and execute pre-commit'
+	@echo '    make clean                    		Clean the compiled binaries'
+	@echo '    [ARCH=arch] make build        		Compile the project for arch, default amd64'
+	@echo '    [ARCH=arch] make build-release 		Compile release binary, default amd64'
+	@echo '    [ARCH=arch] make build-hardened 		Build with security hardening (static)'
+	@echo '    [ARCH=arch] make build-hardened-cgo 	Build with full security hardening (requires glibc)'
+	@echo '    [ARCH=arch] make install      		Installs kube-burner binary in the system, default amd64'
+	@echo '    [ARCH=arch] make images       		Build images for arch, default amd64'
+	@echo '    [ARCH=arch] make push         		Push images for arch, default amd64'
+	@echo '    make manifest                 		Create and push manifest for the different architectures supported'
+	@echo '    make help                     		Show this message'
 
 build: $(BIN_PATH)
 
@@ -51,10 +60,28 @@ $(BIN_PATH): $(SOURCES)
 		-o $(BIN_PATH) ./cmd/kube-burner
 
 build-release: $(SOURCES)
-	@echo -e "\033[2mBuilding hardened release binary $(BIN_PATH)\033[0m"
+	@echo -e "\033[2mBuilding secure release binary $(BIN_PATH)\033[0m"
 	@echo "GOPATH=$(GOPATH)"
-	GOARCH=$(ARCH) CGO_ENABLED=$(CGO) go build -v -trimpath \
-		-ldflags "-s -w -X $(KUBE_BURNER_VERSION).GitCommit=$(GIT_COMMIT) \
+	GOARCH=$(ARCH) CGO_ENABLED=$(CGO) go build -v -trimpath $(HARDENED_FLAGS) \
+		-ldflags "-s -w $(HARDENED_LDFLAGS) -X $(KUBE_BURNER_VERSION).GitCommit=$(GIT_COMMIT) \
+		-X $(KUBE_BURNER_VERSION).BuildDate=$(BUILD_DATE) \
+		-X $(KUBE_BURNER_VERSION).Version=$(VERSION)" \
+		-o $(BIN_PATH) ./cmd/kube-burner
+
+build-hardened: $(SOURCES)
+	@echo -e "\033[2mBuilding hardened static $(BIN_PATH)\033[0m"
+	@echo "GOPATH=$(GOPATH)"
+	GOARCH=$(ARCH) CGO_ENABLED=$(CGO) go build -v -trimpath $(HARDENED_FLAGS) \
+		-ldflags "-s -w $(HARDENED_LDFLAGS) -X $(KUBE_BURNER_VERSION).GitCommit=$(GIT_COMMIT) \
+		-X $(KUBE_BURNER_VERSION).BuildDate=$(BUILD_DATE) \
+		-X $(KUBE_BURNER_VERSION).Version=$(VERSION)" \
+		-o $(BIN_PATH) ./cmd/kube-burner
+
+build-hardened-cgo: $(SOURCES)
+	@echo -e "\033[2mBuilding fully hardened $(BIN_PATH) with CGO\033[0m"
+	@echo "GOPATH=$(GOPATH)"
+	GOARCH=$(ARCH) CGO_ENABLED=1 go build -v -trimpath $(HARDENED_CGO_FLAGS) \
+		-ldflags "-s -w $(HARDENED_CGO_LDFLAGS) -X $(KUBE_BURNER_VERSION).GitCommit=$(GIT_COMMIT) \
 		-X $(KUBE_BURNER_VERSION).BuildDate=$(BUILD_DATE) \
 		-X $(KUBE_BURNER_VERSION).Version=$(VERSION)" \
 		-o $(BIN_PATH) ./cmd/kube-burner

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ In case you want to start tinkering with Kube-burner now:
 - There's also a container image available at [quay](https://quay.io/repository/kube-burner/kube-burner?tab=tags).
 - Example configuration files can be found at the [examples directory](./examples).
 
+## Building from Source
+
+Kube-burner provides multiple build options:
+
+- `make build`              - Standard build for development
+- `make build-release`      - Optimized release build  
+- `make build-hardened`     - Security-hardened static binary
+- `make build-hardened-cgo` - Full security hardening with CGO (requires glibc)
+
+The default builds produce static binaries that work across all Linux distributions. The CGO-hardened build offers additional security features but requires glibc to be present on the target system.
+
 ## Contributing Guidelines, CI, and Code Style
 
 Please read the [Contributing section](https://kube-burner.github.io/kube-burner/latest/contributing/) before contributing to this project. It provides information on how to contribute, guidelines for setting an environment a CI checks to be done before commiting code.


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Optimization

## Description

<!--- Describe your changes in detail -->

following up on #880 I found a way to add the missing security hardening features elegantly:

**1. FULL RELRO (relocation read-only)**
**2. position independent executable (PIE)**
**3. binary stripping**
**4. reproducible builds**

- updated `.goreleaser.yml` to split builds into linux (with full hardening) and other platforms
- added `build-hardened` target to Makefile for local hardened builds
- maintained backward compatibility with existing `build` and `build-release` targets
- security flags only applied to Linux builds as other platforms have different requirements

Component: build

## Related Tickets & Documents

- Closes #851
