### PR TITLE
Fix measurements regression

### DIFF
--- a/pkg/measurements/job_latency.go
+++ b/pkg/measurements/job_latency.go
@@ -94,7 +94,7 @@ func (j *jobLatency) handleCreateJob(obj any) {
 		return
 	}
 	jobLabels := job.GetLabels()
-	j.metrics.LoadOrStore(string(job.UID), jobMetric{
+	j.Metrics.LoadOrStore(string(job.UID), jobMetric{
 		Timestamp:    job.CreationTimestamp.UTC(),
 		Namespace:    job.Namespace,
 		Name:         job.Name,
@@ -113,7 +113,7 @@ func (j *jobLatency) handleUpdateJob(obj any) {
 		log.Errorf("failed to convert to Job: %v", err)
 		return
 	}
-	if value, exists := j.metrics.Load(string(job.UID)); exists {
+	if value, exists := j.Metrics.Load(string(job.UID)); exists {
 		jm := value.(jobMetric)
 		if jm.jobComplete.IsZero() {
 			for _, c := range job.Status.Conditions {
@@ -125,7 +125,7 @@ func (j *jobLatency) handleUpdateJob(obj any) {
 					}
 				}
 			}
-			j.metrics.Store(string(job.UID), jm)
+			j.Metrics.Store(string(job.UID), jm)
 		}
 	}
 }
@@ -172,7 +172,7 @@ func (j *jobLatency) Collect(measurementWg *sync.WaitGroup) {
 		}
 		jobs = append(jobs, jobList.Items...)
 	}
-	j.metrics = sync.Map{}
+	j.Metrics = sync.Map{}
 	for _, job := range jobs {
 		var startTime, completed time.Time
 		for _, c := range job.Status.Conditions {
@@ -182,7 +182,7 @@ func (j *jobLatency) Collect(measurementWg *sync.WaitGroup) {
 				completed = c.LastTransitionTime.UTC()
 			}
 		}
-		j.metrics.Store(string(job.UID), jobMetric{
+		j.Metrics.Store(string(job.UID), jobMetric{
 			Timestamp:   job.Status.StartTime.UTC(),
 			Namespace:   job.Namespace,
 			Name:        job.Name,
@@ -201,11 +201,11 @@ func (j *jobLatency) Stop() error {
 }
 
 func (j *jobLatency) GetMetrics() *sync.Map {
-	return &j.metrics
+	return &j.Metrics
 }
 
 func (j *jobLatency) normalizeMetrics() float64 {
-	j.metrics.Range(func(key, value any) bool {
+	j.Metrics.Range(func(key, value any) bool {
 		m := value.(jobMetric)
 		// If a job does not reach the Complete state (this timestamp isn't set), we skip that job
 		if m.jobComplete.IsZero() {
@@ -218,7 +218,7 @@ func (j *jobLatency) normalizeMetrics() float64 {
 			m.StartTimeLatency = 0
 		}
 		m.CompletionLatency = int(m.jobComplete.Sub(m.Timestamp).Milliseconds())
-		j.normLatencies = append(j.normLatencies, m)
+		j.NormLatencies = append(j.NormLatencies, m)
 		return true
 	})
 	return 0

--- a/pkg/measurements/netpol_latency.go
+++ b/pkg/measurements/netpol_latency.go
@@ -424,7 +424,7 @@ func (n *netpolLatency) processResults() {
 
 		// Use minVal for reporting as ping test tool might have delayed initiating ping tests from some remote addresses.
 		// This can happen when remote pod was busy pinging other pods before trying our network policy pod
-		n.metrics.Store(name, netpolMetric{
+		n.Metrics.Store(name, netpolMetric{
 			Name:            name,
 			Timestamp:       npCreationTime[name],
 			MetricName:      netpolLatencyMeasurement,
@@ -532,7 +532,7 @@ func (n *netpolLatency) Stop() error {
 	}()
 	kutil.CleanupNamespaces(ctx, n.ClientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", networkPolicyProxy))
 	n.normalizeMetrics()
-	for _, q := range n.latencyQuantiles {
+	for _, q := range n.LatencyQuantiles {
 		pq := q.(metrics.LatencyQuantiles)
 		// Divide nanoseconds by 1e6 to get milliseconds
 		log.Infof("%s: %s 50th: %d 99th: %d max: %d avg: %d", n.JobConfig.Name, pq.QuantileName, pq.P50, pq.P99, pq.Max, pq.Avg)
@@ -545,12 +545,12 @@ func (n *netpolLatency) normalizeMetrics() {
 	var latencies []float64
 	var minLatencies []float64
 	sLen := 0
-	n.metrics.Range(func(key, value any) bool {
+	n.Metrics.Range(func(key, value any) bool {
 		sLen++
 		metric := value.(netpolMetric)
 		latencies = append(latencies, float64(metric.ReadyLatency))
 		minLatencies = append(minLatencies, float64(metric.MinReadyLatency))
-		n.normLatencies = append(n.normLatencies, metric)
+		n.NormLatencies = append(n.NormLatencies, metric)
 		return true
 	})
 	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
@@ -563,8 +563,8 @@ func (n *netpolLatency) normalizeMetrics() {
 		return latencySummary
 	}
 	if sLen > 0 {
-		n.latencyQuantiles = append(n.latencyQuantiles, calcSummary("Ready", latencies))
-		n.latencyQuantiles = append(n.latencyQuantiles, calcSummary("minReady", minLatencies))
+		n.LatencyQuantiles = append(n.LatencyQuantiles, calcSummary("Ready", latencies))
+		n.LatencyQuantiles = append(n.LatencyQuantiles, calcSummary("minReady", minLatencies))
 	}
 }
 


### PR DESCRIPTION
RouteAdvertisement latency measurement code in kube-burner-ocp is impacted by the kube-burner measurements refactoring PR #278 Exported some variables to fix this regression.

