### PR TITLE
Add back logic to detect config file in CWD

### DIFF
--- a/pkg/util/fileutils/file_reader.go
+++ b/pkg/util/fileutils/file_reader.go
@@ -73,13 +73,18 @@ func GetScriptsReader(location string, embedCfg *EmbedConfiguration) (io.Reader,
 }
 
 func getEmbedReader(location string, embedFS *embed.FS, embedDir string) (io.Reader, error) {
-	log.Debugf("Looking for file %s in embed fs", location)
-	f, err := embedFS.Open(filepath.Join(embedDir, location))
-	if err != nil {
-		log.Infof("File %s not found in the embedded filesystem. Falling back to original path", location)
+	if _, err := os.Stat(location); err == nil {
+		log.Infof("Config file %v available in the current directory, using it", location)
 		return getReader(location)
+	} else {
+		log.Debugf("Looking for file %s in embed fs", location)
+		f, err := embedFS.Open(filepath.Join(embedDir, location))
+		if err != nil {
+			log.Infof("File %s not found in the embedded filesystem. Falling back to original path", location)
+			return getReader(location)
+		}
+		return f, nil
 	}
-	return f, nil
 }
 
 func getReader(location string) (io.Reader, error) {


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

This logic was mistakenly deleted in #868, it works great now, as it allows to combine local and embedded configuration files in the same run, including alerts and metrics files too.

## Related Tickets & Documents

- Related Issue #
- Closes #
