### PR TITLE
feat(pod_latency): Add high-precision metrics support for pod latency

### DIFF
--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -13,6 +13,34 @@ Collects latencies from the different pod startup phases, these **latency metric
   - name: podLatency
 ```
 
+### High-Precision Pod Latency
+
+By default, pod latency measurements are limited to second-precision due to Kubernetes API timestamp constraints. For sub-second pod operations and more accurate measurements, you can enable high-precision mode:
+
+```yaml
+measurements:
+  - name: podLatency
+    highPrecisionMetrics: true
+```
+
+When enabled, this feature provides:
+
+- **Sub-millisecond accuracy**: Float64 values in milliseconds with decimal precision (e.g., 123.456ms)
+- **Client-side timestamps**: Captures exact moment events are observed by kube-burner, not API timestamps
+- **Dual measurement system**: Provides both standard (API-based) and high-precision (client-based) metrics
+- **Backward compatibility**: Existing measurements remain unchanged
+
+High-precision metrics are prefixed with "Client" and include:
+
+- `ClientPodScheduled`: Client-side scheduling latency
+- `ClientPodInitialized`: Client-side initialization latency
+- `ClientContainersReady`: Client-side containers ready latency
+- `ClientPodReady`: Client-side pod ready latency
+- `ClientPodReadyToStartContainers`: Client-side ready to start containers latency
+
+!!! note
+High-precision metrics are only available for real-time measurements during workload execution. They are not available when collecting metrics from existing pods using the `Collect` method, as client-side timestamps cannot be captured retroactively.
+
 ### Metrics
 
 The metrics collected are pod latency timeseries (`podLatencyMeasurement`) and four documents holding a summary with different pod latency quantiles of each pod condition (`podLatencyQuantilesMeasurement`).

--- a/pkg/measurements/types/types.go
+++ b/pkg/measurements/types/types.go
@@ -54,6 +54,8 @@ type Measurement struct {
 	QuantilesIndexer string `yaml:"quantilesIndexer"`
 	// Defines the indexer for timeseries
 	TimeseriesIndexer string `yaml:"timeseriesIndexer"`
+	// Enable high-precision timestamps for sub-millisecond accuracy
+	HighPrecisionMetrics bool `yaml:"highPrecisionMetrics"`
 }
 
 // LatencyThreshold holds the thresholds configuration

--- a/test/k8s/kube-burner-high-precision.yaml
+++ b/test/k8s/kube-burner-high-precision.yaml
@@ -1,0 +1,28 @@
+---
+global:
+  measurements:
+    - name: podLatency
+      highPrecisionMetrics: true
+      thresholds:
+        - conditionType: PodScheduled
+          metric: P99
+          threshold: 500ms
+        - conditionType: Ready
+          metric: P99
+          threshold: 2s
+
+metricsEndpoints:
+  - indexer:
+      type: local
+      metricsDirectory: metrics
+
+jobs:
+  - name: test-high-precision
+    jobIterations: 1
+    namespace: test-high-precision
+    namespacedIterations: true
+    podWait: false
+    cleanup: true
+    objects:
+      - objectTemplate: objectTemplates/pod.yml
+        replicas: 2


### PR DESCRIPTION
# Add High-Precision Pod Latency Measurements

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Description

This PR introduces **high-precision pod latency measurements** to address timing precision limitations in Kubernetes API timestamps.

### Problem

Current pod latency measurements suffer from second-only precision due to Kubernetes API constraints:

- API server only supports RFC3339 format (second precision), not RFC3339NANO
- Kubelet purposely discards microseconds/nanoseconds due to API limitations
- Fast pod operations (< 1 second) result in zero or negative latencies
- Sub-second pod startup scenarios cannot be measured accurately

### Solution

Implements client-side timestamp capture using `time.Now().UTC()` with nanosecond precision when kube-burner observes pod events in real-time.

### Key Features

- **Dual measurement system**: Provides both standard (API-based) and high-precision (client-based) metrics
- **Sub-millisecond accuracy**: Float64 values in milliseconds with decimal precision (e.g., `123.456ms`)
- **Client-side timestamps**: Captures exact moment events are observed, not API timestamps
- **Backward compatibility**: Existing measurements remain unchanged

### Configuration

```yaml
global:
  measurements:
    - name: podLatency
      highPrecisionMetrics: true # Enable high-precision mode
```

### Output Metrics

When enabled, adds high-precision metrics with "Client" prefix:

- `ClientPodScheduled`: 123.456ms
- `ClientPodReady`: 456.789ms
- `ClientPodInitialized`: 234.567ms
- `ClientContainersReady`: 345.678ms

### Implementation

- Added `HighPrecisionMetrics bool` field to Measurement struct
- Enhanced `podMetric` with client-side timestamp and latency fields
- Updated event handlers to capture client-side timestamps
- Modified metric calculation to include high-precision measurements
- Uses nanosecond resolution converted to milliseconds with float64

### Benefits

- Accurate SLO/SLA tracking for pod startup performance
- Better bottleneck identification for sub-second operations
- Improved granularity with microsecond-level timing
- Eliminates negative latency measurement errors
- Enhanced Kubernetes cluster performance observability

## Related Tickets & Documents

- Related Issue: Pod latency measurements limited to second precision
- Addresses: Inaccurate measurements due to Kubernetes API timestamp constraints
- Closes #930