### PR TITLE
Add validate command to check valid config

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -518,6 +518,61 @@ func alertCmd() *cobra.Command {
 	return cmd
 }
 
+func validateCmd() *cobra.Command {
+	var uuid string
+	var cfgFile string
+	var userDataFile string
+	var allowMissingKeys bool
+	var timeout time.Duration
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate kube-burner configuration file",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if uuid == "" {
+				uuid = uid.NewString()
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cfgFile == "" {
+				log.Fatalf("please provide a config file with -c")
+			}
+
+			configFileReader, err := fileutils.GetWorkloadReader(cfgFile, nil)
+			if err != nil {
+				log.Fatalf("error reading configuration file %s: %w", cfgFile, err)
+			}
+
+			var userDataFileReader io.Reader
+			if userDataFile != "" {
+				userDataFileReader, err = fileutils.GetWorkloadReader(userDataFile, nil)
+				if err != nil {
+					log.Fatalf("error reading user data file %s: %w", userDataFile, err)
+				}
+			}
+
+			_, err = config.ParseWithUserdata(uuid, timeout, configFileReader, userDataFileReader, allowMissingKeys, nil)
+			if err != nil { // graceful error handling
+				errs := strings.Split(err.Error(), ";")
+				log.Error("config validation failed with following issues:")
+				for _, e := range errs {
+					log.Errorf("-%s", strings.TrimSpace(e))
+				}
+				os.Exit(1)
+			}
+
+			fmt.Println("Config file is valid!")
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&cfgFile, "config", "c", "", "Config file path or URL")
+	cmd.Flags().StringVar(&uuid, "uuid", "", "Benchmark UUID (generated automatically if not provided)")
+	cmd.Flags().StringVar(&userDataFile, "user-data", "", "User provided data file for rendering the configuration file, in JSON or YAML format")
+	cmd.Flags().BoolVar(&allowMissingKeys, "allow-missing", false, "Do not fail on missing values in the config file")
+	cmd.Flags().DurationVar(&timeout, "timeout", 4*time.Hour, "Validation timeout (same as benchmark timeout)")
+	return cmd
+}
+
 // executes rootCmd
 func main() {
 	util.SetupCmd(rootCmd)
@@ -529,6 +584,7 @@ func main() {
 		indexCmd(),
 		alertCmd(),
 		importCmd(),
+		validateCmd(),
 		completionCmd,
 	)
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
## Type of change

- New feature

## Description
Added a new command for checking the validity of `config.yaml` file before running `init` command. Utilizes already existing logic of `ParseWithUserdata` used in init command.
For valid file:
<img width="1000" height="43" alt="image" src="https://github.com/user-attachments/assets/8068220e-4b51-4301-9d02-da2189c20869" />
For invalid file:
<img width="1673" height="88" alt="image" src="https://github.com/user-attachments/assets/2bc8ba10-0029-4361-adbb-52e467280a35" />

## Related Tickets & Documents

- Related Issue #962
- Closes #962
