### PR TITLE
feat: report measurements even when job times out

### DIFF
--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"time"
 
@@ -65,21 +66,24 @@ var (
 	}
 )
 
-func (ex *JobExecutor) waitForObjects(ns string) {
+func (ex *JobExecutor) waitForObjects(ns string) []error {
+	var errs []error
 	for _, obj := range ex.objects {
-		ex.waitForObject(ns, obj)
-
+		if err := ex.waitForObject(ns, obj); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if ns != "" {
 		log.Infof("Actions in namespace %v completed", ns)
 	} else {
 		log.Info("Actions completed")
 	}
+	return errs
 }
 
-func (ex *JobExecutor) waitForObject(ns string, obj *object) {
+func (ex *JobExecutor) waitForObject(ns string, obj *object) error {
 	if !obj.Wait || obj.ready {
-		return
+		return nil
 	}
 	// When the object has defined its own namespace, we use it
 	if obj.namespace != "" {
@@ -119,14 +123,15 @@ func (ex *JobExecutor) waitForObject(ns string, obj *object) {
 	}
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.Fatalf("Timeout occurred while waiting for objects in namespace %s: %v", ns, err)
+			return fmt.Errorf("timeout occurred while waiting for objects in namespace %s: %v", ns, err)
 		} else {
-			log.Fatalf("Error waiting for objects in namespace %s: %v", ns, err)
+			return fmt.Errorf("error waiting for objects in namespace %s: %v", ns, err)
 		}
 	}
 	if obj.namespace != "" || obj.RunOnce {
 		obj.ready = true
 	}
+	return nil
 }
 
 func (ex *JobExecutor) waitForReplicas(ns string, obj *object, waitPath statusPath, labelSelector string) error {


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Refactor
- New feature

## Description

Instead of using fatal logs in wait methods, errors are now returned to the caller

<!--- Describe your changes in detail -->

## Related Tickets & Documents

Issue #742 
