### PR TITLE
fail on HTTP errors when collecting pprofs

### DIFF
--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -155,11 +155,11 @@ func (p *pprof) getPProf(wg *sync.WaitGroup, first bool) {
 					}
 				}
 				if target.BearerToken != "" {
-					command = []string{"curl", "-sSLkH", fmt.Sprintf("Authorization: Bearer %s", target.BearerToken), target.URL}
+					command = []string{"curl", "-fsSLkH", fmt.Sprintf("Authorization: Bearer %s", target.BearerToken), target.URL}
 				} else if target.Cert != "" && target.Key != "" {
-					command = []string{"curl", "-sSLk", "--cert", "/tmp/pprof.crt", "--key", "/tmp/pprof.key", target.URL}
+					command = []string{"curl", "-fsSLk", "--cert", "/tmp/pprof.crt", "--key", "/tmp/pprof.key", target.URL}
 				} else {
-					command = []string{"curl", "-sSLk", target.URL}
+					command = []string{"curl", "-fsSLk", target.URL}
 				}
 				req := p.ClientSet.CoreV1().
 					RESTClient().


### PR DESCRIPTION
- Added `-f` flag to curl commands to avoid writing HTTP error responses (like 404) to .pprof files.
- Ensures pprof collection fails fast per pod while keeping remaining pods unaffected.
- Prevents invalid profiles from being saved and logged.