### PR TITLE
Bump default jobIterations and object replicas to 1

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -100,7 +100,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|----------|----------|
 | `name`                       | Job name                                                                                                                              | String   | ""       |
 | `jobType`                    | Type of job to execute. More details at [job types](#job-types)                                                                       | String   | create   |
-| `jobIterations`              | How many times to execute the job                                                                                                     | Integer  | 0        |
+| `jobIterations`              | How many times to execute the job                                                                                                     | Integer  | 1        |
 | `namespace`                  | Namespace base name to use                                                                                                            | String   | ""       |
 | `namespacedIterations`       | Whether to create a namespace per job iteration                                                                                       | Boolean  | true     |
 | `iterationsPerNamespace`     | The maximum number of `jobIterations` to create in a single namespace. Important for node-density workloads that create Services.     | Integer  | 1        |
@@ -162,7 +162,7 @@ We have watchers support during the benchmark workload. It is at a job level and
 | `kind`            | Object kind to consider for watch                       | String  |    ""   |
 | `apiVersion`      | Object apiVersion to consider for watch                 | String  |    ""   |
 | `labelSelector`   | Objects with these labels will be considered for watch  | Object  |    {}   |
-| `replicas`        | Number of watcher replicas to create                    | Integer |     0   |
+| `replicas`        | Number of watcher replicas to create                    | Integer |    1    |
 
 ### Objects
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,7 +80,8 @@ func (i *MetricsEndpoint) UnmarshalYAML(unmarshal func(any) error) error {
 func (o *Object) UnmarshalYAML(unmarshal func(any) error) error {
 	type rawObject Object
 	object := rawObject{
-		Wait: true,
+		Wait:     true,
+		Replicas: 1,
 	}
 	if err := unmarshal(&object); err != nil {
 		return err
@@ -109,6 +110,7 @@ func (j *Job) UnmarshalYAML(unmarshal func(any) error) error {
 		Cleanup:                true,
 		NamespacedIterations:   true,
 		IterationsPerNamespace: 1,
+		JobIterations:          1,
 		PodWait:                false,
 		WaitWhenFinished:       true,
 		VerifyObjects:          true,

--- a/test/k8s/kube-burner-virt.yml
+++ b/test/k8s/kube-burner-virt.yml
@@ -39,7 +39,6 @@ jobs:
   # create the VMs
   - name: kubevirt-density
     jobType: create
-    jobIterations: 1
     qps: 20
     burst: 20
     namespacedIterations: false

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -93,7 +93,6 @@ jobs:
       {{- end }}
 
     - objectTemplate: objectTemplates/pod.yml
-      replicas: 1
 
     - objectTemplate: objectTemplates/job.yml
       replicas: 1


### PR DESCRIPTION
## Type of change

- Optimization
- Documentation

## Description

Increasing the number of default replicas and jobIterations to 1 helps to reduce complexity in configuration files, as these parameters won't be mandatory anymore.

