### PR TITLE
Decrease info logging

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -81,7 +81,7 @@ func (ex *JobExecutor) setupCreateJob(mapper meta.RESTMapper) {
 		if obj.namespaced && obj.namespace == "" {
 			ex.nsRequired = true
 		}
-		log.Infof("Job %s: %d iterations with %d %s replicas", ex.Name, ex.JobIterations, obj.Replicas, gvk.Kind)
+		log.Debugf("Job %s: %d iterations with %d %s replicas", ex.Name, ex.JobIterations, obj.Replicas, gvk.Kind)
 		ex.objects = append(ex.objects, obj)
 	}
 }
@@ -116,7 +116,7 @@ func (ex *JobExecutor) RunCreateJob(ctx context.Context, iterationStart, iterati
 			return
 		}
 		if i == iterationStart+iterationProgress*percent {
-			log.Infof("%v/%v iterations completed", i-iterationStart, iterationEnd-iterationStart)
+			log.Debugf("%v/%v iterations completed", i-iterationStart, iterationEnd-iterationStart)
 			percent++
 		}
 		log.Debugf("Creating object replicas from iteration %d", i)

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -188,7 +188,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 			}
 			if !globalConfig.WaitWhenFinished {
 				elapsedTime := jobEnd.Sub(executedJobs[len(executedJobs)-1].Start).Round(time.Second)
-				log.Infof("Job %s took %v", jobExecutor.Name, elapsedTime)
+				log.Debugf("Job %s took %v", jobExecutor.Name, elapsedTime)
 			}
 			if !jobExecutor.MetricsAggregate {
 				// We stop and index measurements per job
@@ -358,24 +358,23 @@ func indexMetrics(uuid string, executedJobs []prometheus.Job, returnMap map[stri
 
 func verifyJobTimeout(job *config.Job, defaultTimeout time.Duration) {
 	if job.MaxWaitTimeout == 0 {
-		log.Debugf("job.MaxWaitTimeout is zero in %s, override by timeout: %s", job.Name, defaultTimeout)
+		log.Debugf("%s: job.MaxWaitTimeout is zero, override by timeout: %s", job.Name, defaultTimeout)
 		job.MaxWaitTimeout = defaultTimeout
 	}
 }
 
 func verifyQPSBurst(job *config.Job) {
 	if job.QPS <= 0 {
-		log.Warnf("Invalid QPS (%v); using default: %v", job.QPS, rest.DefaultQPS)
+		log.Warnf("%s: Invalid QPS (%v); using default: %v", job.Name, job.QPS, rest.DefaultQPS)
 		job.QPS = rest.DefaultQPS
 	} else {
-		log.Infof("QPS: %v", job.QPS)
+		log.Infof("%s: QPS: %v", job.Name, job.QPS)
 	}
-
 	if job.Burst <= 0 {
-		log.Warnf("Invalid Burst (%v); using default: %v", job.Burst, rest.DefaultBurst)
+		log.Warnf("%s: Invalid Burst (%v); using default: %v", job.Name, job.Burst, rest.DefaultBurst)
 		job.Burst = rest.DefaultBurst
 	} else {
-		log.Infof("Burst: %v", job.Burst)
+		log.Infof("%s: Burst: %v", job.Name, job.Burst)
 	}
 }
 

--- a/pkg/burner/utils.go
+++ b/pkg/burner/utils.go
@@ -116,7 +116,7 @@ func (ex *JobExecutor) Verify() bool {
 	var objList *unstructured.UnstructuredList
 	var replicas int
 	success := true
-	log.Info("Verifying created objects")
+	log.Debug("Verifying created objects")
 	for objectIndex, obj := range ex.objects {
 		listOptions := metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("kube-burner-uuid=%s,kube-burner-runid=%s,kube-burner-job=%s,kube-burner-index=%d", ex.uuid, ex.runid, ex.Name, objectIndex),

--- a/pkg/util/namespaces.go
+++ b/pkg/util/namespaces.go
@@ -38,10 +38,9 @@ func CreateNamespace(clientSet kubernetes.Interface, name string, nsLabels map[s
 		_, err = clientSet.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
 		if errors.IsForbidden(err) {
 			log.Fatalf("authorization error creating namespace %s: %s", ns.Name, err)
-			return false, err
 		}
 		if errors.IsAlreadyExists(err) {
-			log.Infof("Namespace %s already exists", ns.Name)
+			log.Debugf("Namespace %s already exists", ns.Name)
 			nsSpec, _ := clientSet.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
 			if nsSpec.Status.Phase == corev1.NamespaceTerminating {
 				log.Warnf("Namespace %s is in %v state, retrying", name, corev1.NamespaceTerminating)


### PR DESCRIPTION
## Type of change

- Optimization

## Description

The current INFO logging level is too verbose, and makes the output difficult to read. Decreasing the logging level of some messages helps on that. Also adding job name prefixes to some log messages improve their readability.


## Related Tickets & Documents

- Related Issue #
- Closes #
