### PR TITLE
add /16 subnet, used for netpol test

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -573,7 +573,9 @@ On top of the default [golang template semantics](https://golang.org/pkg/text/te
 
 - `Binomial` - returns the binomial coefficient of (n,k)
 - `IndexToCombination` - returns the combination corresponding to the given index
-- `GetSubnet24`
+- `GetSubnet16` – returns a /16 CIDR block derived from the given subnet index (acts as the parent network).
+- `GetSubnet24` – returns a /24 CIDR block derived from the given subnet index (acts as the parent network).
+- `GetSubnet24In16` – returns a /24 CIDR block inside the /16 derived from the given subnet index and offset (acts as a child network carved from the parent).
 - `GetIPAddress` - returns number of addresses requested per iteration from the list of total provided addresses
 - `ReadFile` - returns the content of the file in the provided path
 

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -41,8 +41,21 @@ var funcMap = sprig.GenericFuncMap()
 func init() {
 	AddRenderingFunction("Binomial", combin.Binomial)
 	AddRenderingFunction("IndexToCombination", combin.IndexToCombination)
-	funcMap["GetSubnet24"] = func(subnetIdx int) string { // TODO Document this function
-		return netip.AddrFrom4([4]byte{byte(subnetIdx>>16 + 1), byte(subnetIdx >> 8), byte(subnetIdx), 0}).String() + "/24"
+	funcMap["GetSubnet24"] = func(subnetIdx int) string {
+	    return netip.AddrFrom4([4]byte{byte(subnetIdx>>16 + 1), byte(subnetIdx >> 8), byte(subnetIdx), 0}).String() + "/24"
+	}
+	// Parent /16 subnet
+	funcMap["GetSubnet16"] = func(subnetIdx int) string {
+	    first := byte((subnetIdx >> 8) + 1)
+	    second := byte(subnetIdx & 0xFF)
+	    return netip.AddrFrom4([4]byte{first, second, 0, 0}).String() + "/16"
+	}
+	// Child /24s that stay inside the parent /16
+	funcMap["GetSubnet24In16"] = func(subnetIdx, offset int) string {
+	    first := byte((subnetIdx >> 8) + 1)
+	    second := byte(subnetIdx & 0xFF)
+	    third := byte(offset) // carve /24s by varying the 3rd octet
+	    return netip.AddrFrom4([4]byte{first, second, third, 0}).String() + "/24"
 	}
 	// This function returns number of addresses requested per iteration from the list of total provided addresses
 	funcMap["GetIPAddress"] = func(Addresses string, iteration int, addressesPerIteration int) string { // TODO Move this function to kube-burner-ocp


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->
- Optimization


## Description
Add /16 subnet and a /24 subnet in the /16 subnet for netpol testing

## Related Tickets & Documents
https://github.com/kube-burner/kube-burner-ocp/pull/316 
