### PR TITLE
Simplify stdout logginf format Logging format

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -51,9 +51,6 @@ var rootCmd = &cobra.Command{
 	Long: `Kube-burner 🔥
 
 Tool aimed at stressing a kubernetes cluster by creating or deleting lots of objects.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		util.ConfigureLogging(cmd)
-	},
 }
 
 var completionCmd = &cobra.Command{
@@ -105,7 +102,8 @@ func initCmd() *cobra.Command {
 				// We assume configFile is config.yml
 				configFile = "config.yml"
 			}
-			util.SetupFileLogging(uuid)
+			logLevel, _ := cmd.Flags().GetString("log-level")
+			util.ConfigureLogging(logLevel, uuid)
 			kubeClientProvider := config.NewKubeClientProvider(kubeConfig, kubeContext)
 			clientSet, _ = kubeClientProvider.DefaultClientSet()
 			configFileReader, err := fileutils.GetWorkloadReader(configFile, nil)
@@ -166,13 +164,13 @@ func healthCheck() *cobra.Command {
 		Use:   "health-check",
 		Short: "Check for Health Status of the cluster",
 		PostRun: func(cmd *cobra.Command, args []string) {
-			log.Info("👋 Exiting kube-burner ")
+			log.Info("👋 Exiting kube-burner")
 			os.Exit(rc)
 		},
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			var uuid = uid.NewString()
-			util.SetupFileLogging(uuid)
+			logLevel, _ := cmd.Flags().GetString("log-level")
+			util.ConfigureLogging(logLevel, "")
 			clientSet, _ := config.NewKubeClientProvider(kubeConfig, kubeContext).ClientSet(0, 0)
 			util.ClusterHealthCheck(clientSet)
 		},
@@ -196,7 +194,8 @@ func destroyCmd() *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			util.SetupFileLogging(uuid)
+			logLevel, _ := cmd.Flags().GetString("log-level")
+			util.ConfigureLogging(logLevel, uuid)
 			kubeClientProvider := config.NewKubeClientProvider(kubeConfig, kubeContext)
 			clientSet, restConfig := kubeClientProvider.ClientSet(0, 0)
 			dynamicClient := dynamic.NewForConfigOrDie(restConfig)
@@ -233,7 +232,8 @@ func measureCmd() *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			util.SetupFileLogging(uuid)
+			logLevel, _ := cmd.Flags().GetString("log-level")
+			util.ConfigureLogging(logLevel, uuid)
 			f, err := fileutils.GetWorkloadReader(configFile, nil)
 			if err != nil {
 				log.Fatalf("Error reading configuration file %s: %s", configFile, err)
@@ -322,7 +322,8 @@ func indexCmd() *cobra.Command {
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			util.SetupFileLogging(uuid)
+			logLevel, _ := cmd.Flags().GetString("log-level")
+			util.ConfigureLogging(logLevel, uuid)
 			configSpec.GlobalConfig.UUID = uuid
 			metricsProfiles := strings.FieldsFunc(metricsProfile, func(r rune) bool {
 				return r == ',' || r == ' '

--- a/pkg/util/cluster_health.go
+++ b/pkg/util/cluster_health.go
@@ -12,9 +12,9 @@ import (
 func ClusterHealthCheck(clientSet kubernetes.Interface) {
 	log.Infof("🏥 Checking for Cluster Health")
 	if ClusterHealthyVanillaK8s(clientSet) {
-		log.Infof("Cluster is healthy.")
+		log.Infof("Cluster is healthy")
 	} else {
-		log.Fatalf("Cluster is not healthy.")
+		log.Fatalf("Cluster is not healthy")
 	}
 }
 


### PR DESCRIPTION
## Type of change

Optimization

## Description

As part of the effort to make kube-burner output more friendly, I'm proposing to use a different logging format for stdout, which is more human friendly and removes full timestamp from it, making it more readable.

The log file format remains the same

```
rsevilla@fedora ~/labs/kube-burner (logging-format) $ ./bin/amd64/kube-burner init -c examples/workloads/kubelet-density/kubelet-density.yml 
INFO[0000]job.go:91 🔥 Starting kube-burner (logging-format@b322cd8b23af88a0779abec36f7b5bbad07e73e3) with UUID 170a4f65-8260-4d5f-969a-302c4e915b39 
INFO[0000]factory.go:112 📈 Registered measurement: podLatency         
FATA[0000]create.go:55 Error reading template templates/pod.yml: failed to open config file templates/pod.yml: open templates/pod.yml: no such file or directory 
rsevilla@fedora ~/labs/kube-burner (logging-format) $ cat kube-burner-170a4f65-8260-4d5f-969a-302c4e915b39.log

time="2025-10-01 16:59:22" level=info msg="🔥 Starting kube-burner (logging-format@b322cd8b23af88a0779abec36f7b5bbad07e73e3) with UUID 170a4f65-8260-4d5f-969a-302c4e915b39" file="job.go:91"
time="2025-10-01 16:59:22" level=info msg="📈 Registered measurement: podLatency" file="factory.go:112"
time="2025-10-01 16:59:23" level=fatal msg="Error reading template templates/pod.yml: failed to open config file templates/pod.yml: open templates/pod.yml: no such file or directory" file="create.go:55"
```

This change is relevant for external tools consuming/parsing kube-burner logs: cc @paigerube14 



## Related Tickets & Documents

- Related Issue #
- Closes #
