### PR TITLE
Add embedded filesystem support for hook scripts

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -440,6 +440,26 @@ The `when` field specifies at which stage the hook should execute:
 2. Foreground hooks execute sequentially after background hooks start
 3. Background hooks are waited on before proceeding to the next major phase
 
+#### Embedded Script Support
+
+When using kube-burner-ocp or any application with an embedded filesystem, hooks can reference scripts stored in the embedded `scripts` directory. When a hook command invokes `bash` or `sh` with a script file (e.g., `["bash", "my-script.sh", "arg1"]`), kube-burner will:
+
+1. If the script path is absolute, execute it directly
+2. If the script exists in the current working directory, execute it directly
+3. If not found locally, look for it in the embedded filesystem's scripts directory
+
+This allows workload authors to bundle scripts with their configurations without requiring users to manually extract or copy them. Local scripts always take precedence over embedded scripts.
+
+Example using an embedded script:
+
+```yaml
+jobs:
+  - name: my-workload
+    hooks:
+      - cmd: ["bash", "setup-environment.sh", "--config", "production"]
+        when: beforeJobExecution
+```
+
 #### Example Configuration
 
 ```yaml

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -539,6 +539,26 @@ The `when` field specifies at which stage the hook should execute:
 2. Foreground hooks execute sequentially after background hooks start
 3. Background hooks are waited on before proceeding to the next major phase
 
+#### Embedded Script Support
+
+When using kube-burner-ocp or any application with an embedded filesystem, hooks can reference scripts stored in the embedded `scripts` directory. When a hook command invokes `bash` or `sh` with a script file (e.g., `["bash", "my-script.sh", "arg1"]`), kube-burner will:
+
+1. If the script path is absolute, execute it directly
+2. If the script exists in the current working directory, execute it directly
+3. If not found locally, look for it in the embedded filesystem's scripts directory
+
+This allows workload authors to bundle scripts with their configurations without requiring users to manually extract or copy them. Local scripts always take precedence over embedded scripts.
+
+Example using an embedded script:
+
+```yaml
+jobs:
+  - name: my-workload
+    hooks:
+      - cmd: ["bash", "setup-environment.sh", "--config", "production"]
+        when: beforeJobExecution
+```
+
 #### Example Configuration
 
 ```yaml

--- a/pkg/burner/executor.go
+++ b/pkg/burner/executor.go
@@ -74,7 +74,7 @@ func newExecutor(configSpec config.Spec, kubeClientProvider *config.KubeClientPr
 		embedCfg:          embedCfg,
 		deletionStrategy:  configSpec.GlobalConfig.DeletionStrategy,
 		objectOperations:  0,
-		hookManager:       NewHookManager(context.Background(), len(job.Hooks)),
+		hookManager:       NewHookManager(context.Background(), len(job.Hooks), embedCfg),
 	}
 
 	clientSet, runtimeRestConfig := kubeClientProvider.ClientSet(job.QPS, job.Burst)

--- a/pkg/burner/executor.go
+++ b/pkg/burner/executor.go
@@ -72,7 +72,7 @@ func newExecutor(configSpec config.Spec, kubeClientProvider *config.KubeClientPr
 		functionTemplates: configSpec.GlobalConfig.FunctionTemplates,
 		embedCfg:          embedCfg,
 		deletionStrategy:  configSpec.GlobalConfig.DeletionStrategy,
-		hookManager:       NewHookManager(context.Background(), len(job.Hooks)),
+		hookManager:       NewHookManager(context.Background(), len(job.Hooks), embedCfg),
 	}
 
 	clientSet, runtimeRestConfig := kubeClientProvider.ClientSet(job.QPS, job.Burst)

--- a/pkg/burner/hooks.go
+++ b/pkg/burner/hooks.go
@@ -19,11 +19,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/kube-burner/kube-burner/v2/pkg/util/fileutils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -37,16 +41,18 @@ type HookManager struct {
 	cancel      context.CancelFunc
 	resultChan  chan hookResult
 	backgrounWg sync.WaitGroup
+	embedCfg    *fileutils.EmbedConfiguration
 }
 
 // NewHookManager creates a new HookManager
-func NewHookManager(ctx context.Context, hookCount int) *HookManager {
+func NewHookManager(ctx context.Context, hookCount int, embedCfg *fileutils.EmbedConfiguration) *HookManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &HookManager{
 		ctx:         ctx,
 		cancel:      cancel,
 		resultChan:  make(chan hookResult, hookCount),
 		backgrounWg: sync.WaitGroup{},
+		embedCfg:    embedCfg,
 	}
 }
 
@@ -83,9 +89,83 @@ func (hm *HookManager) executeHooks(hooks []config.Hook, when config.JobHook) er
 	return nil
 }
 
+// isShellScript checks if the command is invoking a shell with a script file
+// Returns the script path if it should be read from embedded FS, empty string otherwise
+func isShellScript(cmd []string) string {
+	if len(cmd) < 2 {
+		return ""
+	}
+	shell := filepath.Base(cmd[0])
+	if shell != "bash" && shell != "sh" {
+		return ""
+	}
+	script := cmd[1]
+	// Check if it's a script file (not a flag like -c)
+	if len(script) > 0 && script[0] == '-' {
+		return ""
+	}
+	// Check for common script extensions or assume it's a script if no extension
+	ext := filepath.Ext(script)
+	if ext == ".sh" || ext == "" {
+		return script
+	}
+	return ""
+}
+
+// prepareCommand creates an exec.Cmd, potentially reading the script from embedded FS
+// It first checks if the script exists locally or is an absolute path, and only falls back
+// to embedded FS if the script is not found
+func (hm *HookManager) prepareCommand(hook config.Hook) (*exec.Cmd, io.ReadCloser, error) {
+	var scriptReader io.ReadCloser
+	var cmd *exec.Cmd
+
+	scriptPath := isShellScript(hook.Cmd)
+	if scriptPath != "" {
+		// Check if script exists locally or is an absolute path
+		useEmbedded := false
+		if !filepath.IsAbs(scriptPath) {
+			if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
+				// Script not found locally, try embedded FS
+				useEmbedded = true
+			}
+		}
+
+		if useEmbedded && hm.embedCfg != nil {
+			// Try to read script from embedded FS
+			reader, err := fileutils.GetScriptsReader(scriptPath, hm.embedCfg)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to read script %s: %w", scriptPath, err)
+			}
+			scriptReader = reader
+
+			// Build command: shell -s - <args>
+			// -s tells shell to read from stdin, - marks end of options
+			args := []string{"-s", "-"}
+			if len(hook.Cmd) > 2 {
+				args = append(args, hook.Cmd[2:]...)
+			}
+			cmd = exec.CommandContext(hm.ctx, hook.Cmd[0], args...)
+			cmd.Stdin = scriptReader
+			log.Debugf("Reading script %s from embedded filesystem", scriptPath)
+		} else {
+			// Execute command directly (script exists locally or is absolute path)
+			cmd = exec.CommandContext(hm.ctx, hook.Cmd[0], hook.Cmd[1:]...)
+		}
+	} else {
+		// Not a shell script invocation, execute command directly
+		cmd = exec.CommandContext(hm.ctx, hook.Cmd[0], hook.Cmd[1:]...)
+	}
+
+	return cmd, scriptReader, nil
+}
+
 func (hm *HookManager) executeBackgroundHook(hook config.Hook) error {
 	log.Infof("Starting Background hook at %s , %v", hook.When, hook.Cmd)
-	cmd := exec.CommandContext(hm.ctx, hook.Cmd[0], hook.Cmd[1:]...)
+
+	cmd, scriptReader, err := hm.prepareCommand(hook)
+	if err != nil {
+		return err
+	}
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -95,17 +175,25 @@ func (hm *HookManager) executeBackgroundHook(hook config.Hook) error {
 	setSysProcAttr(cmd)
 
 	if err := cmd.Start(); err != nil {
+		if scriptReader != nil {
+			scriptReader.Close()
+		}
 		return fmt.Errorf("failed to start background hook: %w", err)
 	}
 	hm.backgrounWg.Add(1)
-	go hm.monitorBackgroundHook(cmd, hook, time.Now(), &stdout, &stderr)
+	go hm.monitorBackgroundHook(cmd, hook, time.Now(), &stdout, &stderr, scriptReader)
 
 	return nil
 }
 
 // monitorBackgroundHook monitors a background hook with proper error handling
-func (hm *HookManager) monitorBackgroundHook(cmd *exec.Cmd, hook config.Hook, startTime time.Time, stdout, stderr *bytes.Buffer) {
+func (hm *HookManager) monitorBackgroundHook(cmd *exec.Cmd, hook config.Hook, startTime time.Time, stdout, stderr *bytes.Buffer, scriptReader io.ReadCloser) {
 	defer hm.backgrounWg.Done()
+	defer func() {
+		if scriptReader != nil {
+			scriptReader.Close()
+		}
+	}()
 	// Wait for process with timeout context
 	errChan := make(chan error, 1)
 	go func() {
@@ -145,14 +233,21 @@ func (hm *HookManager) monitorBackgroundHook(cmd *exec.Cmd, hook config.Hook, st
 
 func (hm *HookManager) executeForegroundHook(hook config.Hook) error {
 	log.Infof("Executing foreground hook: %v", hook.Cmd)
-	cmd := exec.CommandContext(hm.ctx, hook.Cmd[0], hook.Cmd[1:]...)
+
+	cmd, scriptReader, err := hm.prepareCommand(hook)
+	if err != nil {
+		return err
+	}
+	if scriptReader != nil {
+		defer scriptReader.Close()
+	}
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	start := time.Now()
-	err := cmd.Run()
+	err = cmd.Run()
 	duration := time.Since(start)
 
 	if stdout.Len() > 0 {

--- a/pkg/burner/hooks.go
+++ b/pkg/burner/hooks.go
@@ -89,8 +89,9 @@ func (hm *HookManager) executeHooks(hooks []config.Hook, when config.JobHook) er
 	return nil
 }
 
-// isShellScript checks if the command is invoking a shell with a script file
-// Returns the script path if it should be read from embedded FS, empty string otherwise
+// isShellScript checks whether the command invokes sh or bash with a script file argument.
+// It returns the script path for shell script invocations, or an empty string otherwise.
+// Whether that script should be read from the embedded FS is determined later in prepareCommand().
 func isShellScript(cmd []string) string {
 	if len(cmd) < 2 {
 		return ""

--- a/pkg/burner/hooks.go
+++ b/pkg/burner/hooks.go
@@ -89,74 +89,42 @@ func (hm *HookManager) executeHooks(hooks []config.Hook, when config.JobHook) er
 	return nil
 }
 
-// isShellScript checks whether the command invokes sh or bash with a script file argument.
-// It returns the script path for shell script invocations, or an empty string otherwise.
-// Whether that script should be read from the embedded FS is determined later in prepareCommand().
-func isShellScript(cmd []string) string {
-	if len(cmd) < 2 {
-		return ""
-	}
-	shell := filepath.Base(cmd[0])
-	if shell != "bash" && shell != "sh" {
-		return ""
-	}
-	script := cmd[1]
-	// Check if it's a script file (not a flag like -c)
-	if len(script) > 0 && script[0] == '-' {
-		return ""
-	}
-	// Check for common script extensions or assume it's a script if no extension
-	ext := filepath.Ext(script)
-	if ext == ".sh" || ext == "" {
-		return script
-	}
-	return ""
-}
-
 // prepareCommand creates an exec.Cmd, potentially reading the script from embedded FS
 // It first checks if the script exists locally or is an absolute path, and only falls back
 // to embedded FS if the script is not found
 func (hm *HookManager) prepareCommand(hook config.Hook) (*exec.Cmd, io.ReadCloser, error) {
 	var scriptReader io.ReadCloser
 	var cmd *exec.Cmd
-
-	scriptPath := isShellScript(hook.Cmd)
-	if scriptPath != "" {
-		// Check if script exists locally or is an absolute path
-		useEmbedded := false
-		if !filepath.IsAbs(scriptPath) {
-			if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
-				// Script not found locally, try embedded FS
-				useEmbedded = true
-			}
+	scriptPath := hook.Cmd[0]
+	useEmbedded := false
+	if !filepath.IsAbs(scriptPath) {
+		if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
+			// Script not found locally, try embedded FS
+			useEmbedded = true
 		}
-
-		if useEmbedded && hm.embedCfg != nil {
-			// Try to read script from embedded FS
-			reader, err := fileutils.GetScriptsReader(scriptPath, hm.embedCfg)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read script %s: %w", scriptPath, err)
-			}
-			scriptReader = reader
-
-			// Build command: shell -s - <args>
-			// -s tells shell to read from stdin, - marks end of options
-			args := []string{"-s", "-"}
-			if len(hook.Cmd) > 2 {
-				args = append(args, hook.Cmd[2:]...)
-			}
-			cmd = exec.CommandContext(hm.ctx, hook.Cmd[0], args...)
-			cmd.Stdin = scriptReader
-			log.Debugf("Reading script %s from embedded filesystem", scriptPath)
-		} else {
-			// Execute command directly (script exists locally or is absolute path)
-			cmd = exec.CommandContext(hm.ctx, hook.Cmd[0], hook.Cmd[1:]...)
-		}
-	} else {
-		// Not a shell script invocation, execute command directly
-		cmd = exec.CommandContext(hm.ctx, hook.Cmd[0], hook.Cmd[1:]...)
 	}
 
+	if useEmbedded && hm.embedCfg != nil {
+		// Try to read script from embedded FS
+		reader, err := fileutils.GetScriptsReader(scriptPath, hm.embedCfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read script %s: %w", scriptPath, err)
+		}
+		scriptReader = reader
+
+		// Build command: sh -s - <args...>
+		// Script is read from stdin; positional params start at hook.Cmd[1].
+		args := []string{"-s", "-"}
+		if len(hook.Cmd) > 1 {
+			args = append(args, hook.Cmd[1:]...)
+		}
+		cmd = exec.CommandContext(hm.ctx, "/bin/sh", args...)
+		cmd.Stdin = scriptReader
+		log.Debugf("Reading script %s from embedded filesystem", scriptPath)
+
+	} else {
+		cmd = exec.CommandContext(hm.ctx, hook.Cmd[0], hook.Cmd[1:]...)
+	}
 	return cmd, scriptReader, nil
 }
 


### PR DESCRIPTION
Hooks can now reference scripts stored in the embedded config/scripts directory when using kube-burner-ocp or any application with an embedded filesystem.

When a hook command invokes bash or sh with a script file, kube-burner will:
1. Execute directly if the script path is absolute
2. Execute directly if the script exists in the current directory
3. Fall back to reading from embedded filesystem if not found locally

This enables workload authors to bundle scripts with their configurations without requiring users to manually extract them.

The implementation reuses the existing GetScriptsReader() function that beforeCleanup and healthCheckScript already use.

