### PR TITLE
Fix broken CONTRIBUTING.md link in docs

### DIFF
--- a/docs/contributing/ai-policy.md
+++ b/docs/contributing/ai-policy.md
@@ -33,7 +33,7 @@ Using LLMs for coding is allowed, but responsibility remains with the contributo
 
 ### Requirements
 
-- Follow all project contribution guidance in [CONTRIBUTING.md](../../CONTRIBUTING.md)
+- Follow all project contribution guidance in [CONTRIBUTING.md](index.md)
 - Keep changes focused, minimal, and easy to review
 - Match existing style, formatting, and structure
 - Remove unnecessary noise (unused files, generated metadata, unrelated edits)


### PR DESCRIPTION
Fix broken CONTRIBUTING.md link in documentation

The previous relative path did not resolve correctly.
Updated the link to point to the correct file.

<img width="1915" height="399" alt="Screenshot 2026-04-14 at 10 40 29 PM" src="https://github.com/user-attachments/assets/ea1e23f0-6351-44ca-bdfb-734a8d7e95eb" />
