### PR TITLE
 fix: standardize objectTemplate path in kubelet-density-crio.yml

### DIFF
--- a/examples/workloads/kubelet-density/kubelet-density-crio.yml
+++ b/examples/workloads/kubelet-density/kubelet-density-crio.yml
@@ -37,7 +37,7 @@ jobs:
     waitWhenFinished: true
     podWait: false
     objects:
-      - objectTemplate: ./examples/workloads/kubelet-density/templates/pod.yml
+      - objectTemplate: templates/pod.yml
         replicas: 1
         inputVars:
           containerImage: registry.k8s.io/pause:3.1


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

This PR fixes an inconsistency between the `kubelet-density` config examples. `kubelet-density-crio.yml` has been updated to use the relative path `templates/pod.yml` (matching `kubelet-density.yml`). 

Previously, `kubelet-density-crio.yml` used an absolute path relative to the project root (`./examples/workloads/kubelet-density/templates/pod.yml`), causing "file not found" errors when executed from within the workload directory. This standardizes the behavior across the density configurations.

## Related Tickets & Documents

- Closes #1215 