### PR TITLE
fix(burner): nil-check Pattern.Exponential / Pattern.Linear before dereferencing in NewIterationCalculator

### DIFF
--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -53,24 +53,29 @@ func NewIterationCalculator(ex JobExecutor) IterationCalculator {
 	}
 	if cfg.Pattern.Type == config.ExponentialPattern {
 		base := 2.0
-		maxInc := cfg.Pattern.Exponential.MaxIncrease
-		warmup := cfg.Pattern.Exponential.WarmupSteps
-		if cfg.Pattern.Exponential != nil && cfg.Pattern.Exponential.Base > 0 {
-			base = cfg.Pattern.Exponential.Base
+		var maxInc, warmup int
+		if cfg.Pattern.Exponential != nil {
+			maxInc = cfg.Pattern.Exponential.MaxIncrease
+			warmup = cfg.Pattern.Exponential.WarmupSteps
+			if cfg.Pattern.Exponential.Base > 0 {
+				base = cfg.Pattern.Exponential.Base
+			}
 		}
 		return &exponentialCalculator{start: startIt, total: totalIt, base: base, maxIncrease: maxInc, warmup: warmup, stepNo: 0}
 	} else {
 		step := 1
+		var minSteps int
 		if cfg.Pattern.Linear != nil {
 			step = cfg.Pattern.Linear.StepSize
+			minSteps = cfg.Pattern.Linear.MinSteps
 		}
 		totalSteps := int(math.Ceil(float64(totalIt-startIt) / float64(step)))
-		if cfg.Pattern.Linear.MinSteps > 0 && totalSteps < cfg.Pattern.Linear.MinSteps {
+		if minSteps > 0 && totalSteps < minSteps {
 			remaining := totalIt - startIt
 			if remaining <= 0 {
 				step = totalIt
 			} else {
-				step = int(math.Ceil(float64(remaining) / float64(cfg.Pattern.Linear.MinSteps)))
+				step = int(math.Ceil(float64(remaining) / float64(minSteps)))
 			}
 		}
 		if step <= 0 {


### PR DESCRIPTION
## What

`NewIterationCalculator` in `pkg/burner/incremental.go` dereferences `cfg.Pattern.Exponential` (and `cfg.Pattern.Linear.MinSteps`) before checking whether those sub-blocks are nil. Per #1217, a config with `pattern.type: exponential` but no `exponential:` sub-block panics at startup:

```go
// lines 54-61
if cfg.Pattern.Type == config.ExponentialPattern {
    base := 2.0
    maxInc := cfg.Pattern.Exponential.MaxIncrease      // panics here if nil
    warmup := cfg.Pattern.Exponential.WarmupSteps      // and here
    if cfg.Pattern.Exponential != nil && cfg.Pattern.Exponential.Base > 0 {
        base = cfg.Pattern.Exponential.Base            // guard is already too late
    }
    ...
}
```

The linear branch has the mirror-image version of the bug: `Pattern.Linear` is nil-checked before reading `StepSize`, but the following reads of `cfg.Pattern.Linear.MinSteps` (and the later division using it) are not. A `pattern.type: linear` with no `linear:` sub-block takes the `step = 1` default and then panics on the `MinSteps` dereference.

## Fix

Read each sub-block through a single nil-checked branch, defaulting the integer fields to `0` when the block is absent:

```go
if cfg.Pattern.Type == config.ExponentialPattern {
    base := 2.0
    var maxInc, warmup int
    if cfg.Pattern.Exponential != nil {
        maxInc = cfg.Pattern.Exponential.MaxIncrease
        warmup = cfg.Pattern.Exponential.WarmupSteps
        if cfg.Pattern.Exponential.Base > 0 {
            base = cfg.Pattern.Exponential.Base
        }
    }
    return &exponentialCalculator{start: startIt, total: totalIt, base: base,
        maxIncrease: maxInc, warmup: warmup, stepNo: 0}
}
step := 1
var minSteps int
if cfg.Pattern.Linear != nil {
    step = cfg.Pattern.Linear.StepSize
    minSteps = cfg.Pattern.Linear.MinSteps
}
totalSteps := int(math.Ceil(float64(totalIt-startIt) / float64(step)))
if minSteps > 0 && totalSteps < minSteps {
    ...
}
```

The surrounding logic is already tolerant of the zero defaults:

- `exponentialCalculator` treats `maxIncrease == 0` as "no cap" and `warmup == 0` as "no warmup".
- `if minSteps > 0` gates the min-step reshaping path; when the Linear block is missing we skip it, matching the existing "default step = 1" fallback.

Behaviour is unchanged for any config that populates the sub-block. Only the two nil-config paths stop panicking.

## Test plan

- Reproduce the panic on `main` with the config in the bug report (`pattern.type: exponential` with no `exponential:` block) — kube-burner crashes at startup with `runtime error: invalid memory address or nil pointer dereference` inside `NewIterationCalculator`.
- Apply this patch and rerun — kube-burner starts, uses `base=2.0`, `maxIncrease=0`, `warmup=0`, and runs the incremental load with the safe defaults.
- Same for `pattern.type: linear` with no `linear:` block.

Fixes #1217