### PR TITLE
fix: nil pointer dereference in NewIterationCalculator when pattern config is missing

### DIFF
--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -53,24 +53,30 @@ func NewIterationCalculator(ex JobExecutor) IterationCalculator {
 	}
 	if cfg.Pattern.Type == config.ExponentialPattern {
 		base := 2.0
-		maxInc := cfg.Pattern.Exponential.MaxIncrease
-		warmup := cfg.Pattern.Exponential.WarmupSteps
-		if cfg.Pattern.Exponential != nil && cfg.Pattern.Exponential.Base > 0 {
-			base = cfg.Pattern.Exponential.Base
+		maxInc := 0
+		warmup := 0
+		if cfg.Pattern.Exponential != nil {
+			if cfg.Pattern.Exponential.Base > 0 {
+				base = cfg.Pattern.Exponential.Base
+			}
+			maxInc = cfg.Pattern.Exponential.MaxIncrease
+			warmup = cfg.Pattern.Exponential.WarmupSteps
 		}
 		return &exponentialCalculator{start: startIt, total: totalIt, base: base, maxIncrease: maxInc, warmup: warmup, stepNo: 0}
 	} else {
 		step := 1
 		if cfg.Pattern.Linear != nil {
-			step = cfg.Pattern.Linear.StepSize
-		}
-		totalSteps := int(math.Ceil(float64(totalIt-startIt) / float64(step)))
-		if cfg.Pattern.Linear.MinSteps > 0 && totalSteps < cfg.Pattern.Linear.MinSteps {
-			remaining := totalIt - startIt
-			if remaining <= 0 {
-				step = totalIt
-			} else {
-				step = int(math.Ceil(float64(remaining) / float64(cfg.Pattern.Linear.MinSteps)))
+			if cfg.Pattern.Linear.StepSize > 0 {
+				step = cfg.Pattern.Linear.StepSize
+			}
+			totalSteps := int(math.Ceil(float64(totalIt-startIt) / float64(step)))
+			if cfg.Pattern.Linear.MinSteps > 0 && totalSteps < cfg.Pattern.Linear.MinSteps {
+				remaining := totalIt - startIt
+				if remaining <= 0 {
+					step = totalIt
+				} else {
+					step = int(math.Ceil(float64(remaining) / float64(cfg.Pattern.Linear.MinSteps)))
+				}
 			}
 		}
 		if step <= 0 {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -45,8 +45,9 @@ var _ = Describe("Error Enhancement", func() {
 				result := errors.EnhanceYAMLParseError("config.yml", yamlErr)
 
 				Expect(result).To(HaveOccurred())
-				Expect(result.Error()).Should(ContainSubstring("failed to parse config file config.yml"))
-				Expect(result.Error()).Should(ContainSubstring("line 5: invalid syntax; line 10: unknown field"))
+				Expect(result.Error()).Should(ContainSubstring("failed to parse config file: config.yml:"))
+				Expect(result.Error()).Should(ContainSubstring("line 5: invalid syntax"))
+				Expect(result.Error()).Should(ContainSubstring("line 10: unknown field"))
 			})
 		})
 


### PR DESCRIPTION
## Type of change
 
- [x] Bug fix

## Description

I was reading through the incremental load code and noticed that `NewIterationCalculator` in `pkg/burner/incremental.go` would panic at startup in two places if the pattern sub-block is missing from the config.

For the exponential pattern, `MaxIncrease` and `WarmupSteps` were being read from `cfg.Pattern.Exponential` before the nil check so if someone sets `pattern.type: exponential` without an `exponential:` block, kube-burner crashes immediately. Fixed by moving the nil check first and using safe defaults (`base=2.0`, `maxIncrease=0`, `warmupSteps=0`).

For the linear pattern, the nil guard only wrapped `StepSize` but `cfg.Pattern.Linear.MinSteps` was accessed just outside it, causing the same crash when the `linear:` block is absent. Extended the guard to cover the full calculation block.

Also fixed a stale test assertion in `pkg/errors/errors_test.go` that was already failing on `main` the format string in `EnhanceYAMLParseError` had been updated but the test expectation wasn't kept in sync with it.

## Related Tickets & Documents

- No upstream issue tracked for this yet discovered while reading the codebase.

