### PR TITLE
fix: guard nil Linear/Exponential config in NewIterationCalculator

### DIFF
--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -53,24 +53,29 @@ func NewIterationCalculator(ex JobExecutor) IterationCalculator {
 	}
 	if cfg.Pattern.Type == config.ExponentialPattern {
 		base := 2.0
-		maxInc := cfg.Pattern.Exponential.MaxIncrease
-		warmup := cfg.Pattern.Exponential.WarmupSteps
-		if cfg.Pattern.Exponential != nil && cfg.Pattern.Exponential.Base > 0 {
-			base = cfg.Pattern.Exponential.Base
+		var maxInc, warmup int
+		if cfg.Pattern.Exponential != nil {
+			if cfg.Pattern.Exponential.Base > 0 {
+				base = cfg.Pattern.Exponential.Base
+			}
+			maxInc = cfg.Pattern.Exponential.MaxIncrease
+			warmup = cfg.Pattern.Exponential.WarmupSteps
 		}
 		return &exponentialCalculator{start: startIt, total: totalIt, base: base, maxIncrease: maxInc, warmup: warmup, stepNo: 0}
 	} else {
 		step := 1
 		if cfg.Pattern.Linear != nil {
-			step = cfg.Pattern.Linear.StepSize
-		}
-		totalSteps := int(math.Ceil(float64(totalIt-startIt) / float64(step)))
-		if cfg.Pattern.Linear.MinSteps > 0 && totalSteps < cfg.Pattern.Linear.MinSteps {
-			remaining := totalIt - startIt
-			if remaining <= 0 {
-				step = totalIt
-			} else {
-				step = int(math.Ceil(float64(remaining) / float64(cfg.Pattern.Linear.MinSteps)))
+			if cfg.Pattern.Linear.StepSize > 0 {
+				step = cfg.Pattern.Linear.StepSize
+			}
+			totalSteps := int(math.Ceil(float64(totalIt-startIt) / float64(step)))
+			if cfg.Pattern.Linear.MinSteps > 0 && totalSteps < cfg.Pattern.Linear.MinSteps {
+				remaining := totalIt - startIt
+				if remaining <= 0 {
+					step = totalIt
+				} else {
+					step = int(math.Ceil(float64(remaining) / float64(cfg.Pattern.Linear.MinSteps)))
+				}
 			}
 		}
 		if step <= 0 {

--- a/pkg/burner/incremental_test.go
+++ b/pkg/burner/incremental_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"testing"
+
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+)
+
+func makeExecutor(start, total int, pattern config.LoadPattern) JobExecutor {
+	return JobExecutor{
+		Job: config.Job{
+			JobIterations: start,
+			IncrementalLoad: &config.IncrementalLoad{
+				StartIterations: start,
+				TotalIterations: total,
+				Pattern:         pattern,
+			},
+		},
+	}
+}
+
+func TestLinearNilConfigNoPanic(t *testing.T) {
+	ex := makeExecutor(10, 100, config.LoadPattern{
+		Type:   config.LinearPattern,
+		Linear: nil,
+	})
+
+	calc := NewIterationCalculator(ex)
+	lc, ok := calc.(*linearCalculator)
+	if !ok {
+		t.Fatalf("expected *linearCalculator, got %T", calc)
+	}
+	if lc.step != 1 {
+		t.Errorf("expected step=1 when Linear config is nil, got %d", lc.step)
+	}
+}
+
+func TestLinearStepSize(t *testing.T) {
+	ex := makeExecutor(10, 100, config.LoadPattern{
+		Type: config.LinearPattern,
+		Linear: &config.LinearLoadConfig{
+			StepSize: 15,
+		},
+	})
+
+	calc := NewIterationCalculator(ex)
+	lc, ok := calc.(*linearCalculator)
+	if !ok {
+		t.Fatalf("expected *linearCalculator, got %T", calc)
+	}
+	if lc.step != 15 {
+		t.Errorf("expected step=15, got %d", lc.step)
+	}
+}
+
+func TestLinearStepSizeZeroDefaultsToOne(t *testing.T) {
+	ex := makeExecutor(10, 100, config.LoadPattern{
+		Type: config.LinearPattern,
+		Linear: &config.LinearLoadConfig{
+			StepSize: 0,
+		},
+	})
+
+	calc := NewIterationCalculator(ex)
+	lc, ok := calc.(*linearCalculator)
+	if !ok {
+		t.Fatalf("expected *linearCalculator, got %T", calc)
+	}
+	if lc.step != 1 {
+		t.Errorf("expected step=1 for StepSize=0, got %d", lc.step)
+	}
+}
+
+func TestLinearMinStepsRecalc(t *testing.T) {
+	// start=10, total=110, stepSize=100 → totalSteps=ceil(100/100)=1
+	// MinSteps=5 → 1 < 5 triggers recalc: step=ceil(100/5)=20
+	ex := makeExecutor(10, 110, config.LoadPattern{
+		Type: config.LinearPattern,
+		Linear: &config.LinearLoadConfig{
+			StepSize: 100,
+			MinSteps: 5,
+		},
+	})
+
+	calc := NewIterationCalculator(ex)
+	lc, ok := calc.(*linearCalculator)
+	if !ok {
+		t.Fatalf("expected *linearCalculator, got %T", calc)
+	}
+	if lc.step != 20 {
+		t.Errorf("expected step=20 after MinSteps recalc, got %d", lc.step)
+	}
+}
+
+func TestExponentialNilConfigNoPanic(t *testing.T) {
+	ex := makeExecutor(10, 100, config.LoadPattern{
+		Type:        config.ExponentialPattern,
+		Exponential: nil,
+	})
+
+	calc := NewIterationCalculator(ex)
+	ec, ok := calc.(*exponentialCalculator)
+	if !ok {
+		t.Fatalf("expected *exponentialCalculator, got %T", calc)
+	}
+	if ec.base != 2.0 {
+		t.Errorf("expected default base=2.0, got %f", ec.base)
+	}
+	if ec.maxIncrease != 0 || ec.warmup != 0 {
+		t.Errorf("expected maxIncrease=0 and warmup=0, got maxIncrease=%d warmup=%d", ec.maxIncrease, ec.warmup)
+	}
+}
+
+func TestExponentialWithConfig(t *testing.T) {
+	ex := makeExecutor(10, 100, config.LoadPattern{
+		Type: config.ExponentialPattern,
+		Exponential: &config.ExponentialLoadConfig{
+			Base:        3.0,
+			MaxIncrease: 50,
+			WarmupSteps: 2,
+		},
+	})
+
+	calc := NewIterationCalculator(ex)
+	ec, ok := calc.(*exponentialCalculator)
+	if !ok {
+		t.Fatalf("expected *exponentialCalculator, got %T", calc)
+	}
+	if ec.base != 3.0 {
+		t.Errorf("expected base=3.0, got %f", ec.base)
+	}
+	if ec.maxIncrease != 50 {
+		t.Errorf("expected maxIncrease=50, got %d", ec.maxIncrease)
+	}
+	if ec.warmup != 2 {
+		t.Errorf("expected warmup=2, got %d", ec.warmup)
+	}
+}
+
+func TestZeroTotalIterationsDone(t *testing.T) {
+	ex := makeExecutor(0, 0, config.LoadPattern{
+		Type: config.LinearPattern,
+	})
+
+	calc := NewIterationCalculator(ex)
+	lc, ok := calc.(*linearCalculator)
+	if !ok {
+		t.Fatalf("expected *linearCalculator, got %T", calc)
+	}
+	_, _, done := lc.Next(0)
+	if !done {
+		t.Error("expected calculator with total=0 to be done immediately")
+	}
+}


### PR DESCRIPTION
Fixes #1220

## Type of change
- [x] Bug fix

## Description

While reviewing the incremental load logic in `pkg/burner/incremental.go`, I noticed that `cfg.Pattern.Linear.MinSteps` was being accessed outside the nil guard that protects `StepSize`. If a user sets `pattern.type: linear` but omits the `linear` sub-block entirely, `cfg.Pattern.Linear` is nil and the code panics at the `MinSteps` dereference on startup.

The fix moves `totalSteps` and the `MinSteps` check inside the `cfg.Pattern.Linear != nil` block, so omitting the config safely falls back to `step=1` with no crash.

I also fixed the same ordering issue in the exponential branch, where `MaxIncrease` and `WarmupSteps` were read before the nil check as mentioned in the issue, it made sense to fix both in one PR.

Added unit tests covering nil config for both patterns, normal StepSize behaviour, MinSteps recalculation, and the zero-total edge case.

## Related Tickets & Documents

- Related issue #1220
- Closes #1220
