### PR TITLE
fix: guard nil exponential and linear config in NewIterationCalculator

### DIFF
--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -53,24 +53,30 @@ func NewIterationCalculator(ex JobExecutor) IterationCalculator {
 	}
 	if cfg.Pattern.Type == config.ExponentialPattern {
 		base := 2.0
-		maxInc := cfg.Pattern.Exponential.MaxIncrease
-		warmup := cfg.Pattern.Exponential.WarmupSteps
-		if cfg.Pattern.Exponential != nil && cfg.Pattern.Exponential.Base > 0 {
-			base = cfg.Pattern.Exponential.Base
+		maxInc := 0
+		warmup := 0
+		if cfg.Pattern.Exponential != nil {
+			if cfg.Pattern.Exponential.Base > 0 {
+				base = cfg.Pattern.Exponential.Base
+			}
+			maxInc = cfg.Pattern.Exponential.MaxIncrease
+			warmup = cfg.Pattern.Exponential.WarmupSteps
 		}
 		return &exponentialCalculator{start: startIt, total: totalIt, base: base, maxIncrease: maxInc, warmup: warmup, stepNo: 0}
 	} else {
 		step := 1
 		if cfg.Pattern.Linear != nil {
-			step = cfg.Pattern.Linear.StepSize
-		}
-		totalSteps := int(math.Ceil(float64(totalIt-startIt) / float64(step)))
-		if cfg.Pattern.Linear.MinSteps > 0 && totalSteps < cfg.Pattern.Linear.MinSteps {
-			remaining := totalIt - startIt
-			if remaining <= 0 {
-				step = totalIt
-			} else {
-				step = int(math.Ceil(float64(remaining) / float64(cfg.Pattern.Linear.MinSteps)))
+			if cfg.Pattern.Linear.StepSize > 0 {
+				step = cfg.Pattern.Linear.StepSize
+			}
+			totalSteps := int(math.Ceil(float64(totalIt-startIt) / float64(step)))
+			if cfg.Pattern.Linear.MinSteps > 0 && totalSteps < cfg.Pattern.Linear.MinSteps {
+				remaining := totalIt - startIt
+				if remaining <= 0 {
+					step = totalIt
+				} else {
+					step = int(math.Ceil(float64(remaining) / float64(cfg.Pattern.Linear.MinSteps)))
+				}
 			}
 		}
 		if step <= 0 {

--- a/pkg/burner/incremental_test.go
+++ b/pkg/burner/incremental_test.go
@@ -1,0 +1,178 @@
+// Copyright 2024 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+)
+
+func TestBurner(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Burner Suite")
+}
+
+func newTestExecutor(il config.IncrementalLoad) JobExecutor {
+	return JobExecutor{
+		Job: config.Job{
+			JobIterations:   10,
+			IncrementalLoad: &il,
+		},
+	}
+}
+
+var _ = Describe("NewIterationCalculator", func() {
+	Describe("exponential pattern", func() {
+		Context("when exponential config block is missing", func() {
+			It("should not panic and use safe defaults", func() {
+				ex := newTestExecutor(config.IncrementalLoad{
+					StartIterations: 10,
+					TotalIterations: 100,
+					Pattern: config.LoadPattern{
+						Type:        config.ExponentialPattern,
+						Exponential: nil,
+					},
+				})
+				calc := NewIterationCalculator(ex)
+				Expect(calc).NotTo(BeNil())
+
+				ec, ok := calc.(*exponentialCalculator)
+				Expect(ok).To(BeTrue(), "expected *exponentialCalculator")
+				Expect(ec.base).To(Equal(2.0))
+				Expect(ec.maxIncrease).To(Equal(0))
+				Expect(ec.warmup).To(Equal(0))
+			})
+		})
+
+		Context("when exponential config block is provided", func() {
+			It("should use values from config", func() {
+				ex := newTestExecutor(config.IncrementalLoad{
+					StartIterations: 10,
+					TotalIterations: 100,
+					Pattern: config.LoadPattern{
+						Type: config.ExponentialPattern,
+						Exponential: &config.ExponentialLoadConfig{
+							Base:        3.0,
+							MaxIncrease: 50,
+							WarmupSteps: 2,
+						},
+					},
+				})
+				calc := NewIterationCalculator(ex)
+				ec, ok := calc.(*exponentialCalculator)
+				Expect(ok).To(BeTrue(), "expected *exponentialCalculator")
+				Expect(ec.base).To(Equal(3.0))
+				Expect(ec.maxIncrease).To(Equal(50))
+				Expect(ec.warmup).To(Equal(2))
+			})
+
+			It("should fall back to base=2.0 when Base is zero", func() {
+				ex := newTestExecutor(config.IncrementalLoad{
+					StartIterations: 10,
+					TotalIterations: 100,
+					Pattern: config.LoadPattern{
+						Type: config.ExponentialPattern,
+						Exponential: &config.ExponentialLoadConfig{
+							Base:        0,
+							MaxIncrease: 20,
+							WarmupSteps: 1,
+						},
+					},
+				})
+				calc := NewIterationCalculator(ex)
+				ec, ok := calc.(*exponentialCalculator)
+				Expect(ok).To(BeTrue(), "expected *exponentialCalculator")
+				Expect(ec.base).To(Equal(2.0))
+			})
+		})
+	})
+
+	Describe("linear pattern", func() {
+		Context("when linear config block is missing", func() {
+			It("should not panic and default to step=1", func() {
+				ex := newTestExecutor(config.IncrementalLoad{
+					StartIterations: 10,
+					TotalIterations: 100,
+					Pattern: config.LoadPattern{
+						Type:   config.LinearPattern,
+						Linear: nil,
+					},
+				})
+				calc := NewIterationCalculator(ex)
+				Expect(calc).NotTo(BeNil())
+
+				lc, ok := calc.(*linearCalculator)
+				Expect(ok).To(BeTrue(), "expected *linearCalculator")
+				Expect(lc.step).To(Equal(1))
+			})
+		})
+
+		Context("when linear config block is provided", func() {
+			It("should use StepSize from config", func() {
+				ex := newTestExecutor(config.IncrementalLoad{
+					StartIterations: 10,
+					TotalIterations: 100,
+					Pattern: config.LoadPattern{
+						Type: config.LinearPattern,
+						Linear: &config.LinearLoadConfig{
+							StepSize: 15,
+						},
+					},
+				})
+				calc := NewIterationCalculator(ex)
+				lc, ok := calc.(*linearCalculator)
+				Expect(ok).To(BeTrue(), "expected *linearCalculator")
+				Expect(lc.step).To(Equal(15))
+			})
+
+			It("should adjust step when MinSteps requires more steps", func() {
+				// startIt=10, totalIt=100 → range=90
+				// StepSize=90 → totalSteps=1, MinSteps=5 → recalculate: step=ceil(90/5)=18
+				ex := newTestExecutor(config.IncrementalLoad{
+					StartIterations: 10,
+					TotalIterations: 100,
+					Pattern: config.LoadPattern{
+						Type: config.LinearPattern,
+						Linear: &config.LinearLoadConfig{
+							StepSize: 90,
+							MinSteps: 5,
+						},
+					},
+				})
+				calc := NewIterationCalculator(ex)
+				lc, ok := calc.(*linearCalculator)
+				Expect(ok).To(BeTrue(), "expected *linearCalculator")
+				Expect(lc.step).To(Equal(18))
+			})
+		})
+	})
+
+	Describe("no pattern type set", func() {
+		It("should default to linear behavior without panicking", func() {
+			ex := newTestExecutor(config.IncrementalLoad{
+				StartIterations: 5,
+				TotalIterations: 50,
+				Pattern:         config.LoadPattern{},
+			})
+			calc := NewIterationCalculator(ex)
+			_, ok := calc.(*linearCalculator)
+			Expect(ok).To(BeTrue(), "expected *linearCalculator for empty pattern type")
+		})
+	})
+})


### PR DESCRIPTION
Fixes #1217

## Type of change

- Bug fix

## Description

`NewIterationCalculator` in `pkg/burner/incremental.go` had two nil pointer dereference panics:

1. **Exponential branch** - `cfg.Pattern.Exponential.MaxIncrease` and `.WarmupSteps` were read before the nil check, so setting `pattern.type: exponential` without an `exponential:` sub-block caused an immediate runtime panic.

2. **Linear branch** - `cfg.Pattern.Linear.MinSteps` was accessed outside the `if cfg.Pattern.Linear != nil` guard, triggering the same panic when the `linear:` sub-block was absent.

Both are fixed by setting safe defaults (`base=2.0`, `maxIncrease=0`, `warmup=0`, `step=1`) and reading all config fields only inside their respective nil guards. Unit tests are added using Ginkgo/Gomega covering nil configs, full configs, zero-base fallback, MinSteps adjustment, and empty pattern type.

## Related Tickets & Documents

- Closes #1217
