### PR TITLE
fix(measurements): gracefully ignore uninitialized timestamps to avoid false 0ms latency ingestion

### DIFF
--- a/pkg/measurements/datavolume_latency.go
+++ b/pkg/measurements/datavolume_latency.go
@@ -264,26 +264,38 @@ func (dv *dvLatency) normalizeMetrics() float64 {
 		// v2 latencies are currently under AB testing which blindly trust kubernetes as source of
 		// truth and will prevent us from those over 1s delays as well as <0 cases.
 		errorFlag := 0
-		m.DVBoundLatency = int(m.dvBound.Sub(m.Timestamp).Milliseconds())
-		if m.DVBoundLatency < 0 {
-			log.Tracef("DVBoundLatency for DataVolume %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.DVBoundLatency = 0
+		if m.dvBound.IsZero() {
+			m.DVBoundLatency = -1
+		} else {
+			m.DVBoundLatency = int(m.dvBound.Sub(m.Timestamp).Milliseconds())
+			if m.DVBoundLatency < 0 {
+				log.Tracef("DVBoundLatency for DataVolume %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.DVBoundLatency = 0
+			}
 		}
 
-		m.DVRunningLatency = int(m.dvRunning.Sub(m.Timestamp).Milliseconds())
-		if m.DVRunningLatency < 0 {
-			// Running condition may be missed when creating empty volumes.
-			// Since we validated that the volume is Ready, assume the Running latency is 0 and don't report an error
-			log.Tracef("DVRunningLatency for DataVolume %v falling under negative case. So explicitly setting it to 0", m.Name)
-			m.DVRunningLatency = 0
+		if m.dvRunning.IsZero() {
+			m.DVRunningLatency = -1
+		} else {
+			m.DVRunningLatency = int(m.dvRunning.Sub(m.Timestamp).Milliseconds())
+			if m.DVRunningLatency < 0 {
+				// Running condition may be missed when creating empty volumes.
+				// Since we validated that the volume is Ready, assume the Running latency is 0 and don't report an error
+				log.Tracef("DVRunningLatency for DataVolume %v falling under negative case. So explicitly setting it to 0", m.Name)
+				m.DVRunningLatency = 0
+			}
 		}
 
-		m.DVReadyLatency = int(m.dvReady.Sub(m.Timestamp).Milliseconds())
-		if m.DVReadyLatency < 0 {
-			log.Tracef("DVReadyLatency for DataVolume %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.DVReadyLatency = 0
+		if m.dvReady.IsZero() {
+			m.DVReadyLatency = -1
+		} else {
+			m.DVReadyLatency = int(m.dvReady.Sub(m.Timestamp).Milliseconds())
+			if m.DVReadyLatency < 0 {
+				log.Tracef("DVReadyLatency for DataVolume %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.DVReadyLatency = 0
+			}
 		}
 		m.ChurnMetric = dv.IsChurnMetric(m.Timestamp)
 		dataVolumeCount++
@@ -299,11 +311,17 @@ func (dv *dvLatency) normalizeMetrics() float64 {
 
 func (dv *dvLatency) getLatency(normLatency any) map[string]float64 {
 	dataVolumeMetric := normLatency.(dvMetric)
-	return map[string]float64{
-		string(cdiv1beta1.DataVolumeBound):   float64(dataVolumeMetric.DVBoundLatency),
-		string(cdiv1beta1.DataVolumeRunning): float64(dataVolumeMetric.DVRunningLatency),
-		string(cdiv1beta1.DataVolumeReady):   float64(dataVolumeMetric.DVReadyLatency),
+	res := make(map[string]float64)
+	if dataVolumeMetric.DVBoundLatency != -1 {
+		res[string(cdiv1beta1.DataVolumeBound)] = float64(dataVolumeMetric.DVBoundLatency)
 	}
+	if dataVolumeMetric.DVRunningLatency != -1 {
+		res[string(cdiv1beta1.DataVolumeRunning)] = float64(dataVolumeMetric.DVRunningLatency)
+	}
+	if dataVolumeMetric.DVReadyLatency != -1 {
+		res[string(cdiv1beta1.DataVolumeReady)] = float64(dataVolumeMetric.DVReadyLatency)
+	}
+	return res
 }
 
 func (dv *dvLatency) IsCompatible() bool {

--- a/pkg/measurements/job_latency.go
+++ b/pkg/measurements/job_latency.go
@@ -217,10 +217,14 @@ func (j *jobLatency) normalizeMetrics() float64 {
 			log.Tracef("Job %v latency ignored as it did not reach Ready state", m.Name)
 			return true
 		}
-		m.StartTimeLatency = int(m.startTime.Sub(m.Timestamp).Milliseconds())
-		if m.StartTimeLatency < 0 {
-			log.Tracef("StartTimeLatency for job %v falling under negative case. So explicitly setting it to 0", m.Name)
-			m.StartTimeLatency = 0
+		if m.startTime.IsZero() {
+			m.StartTimeLatency = -1
+		} else {
+			m.StartTimeLatency = int(m.startTime.Sub(m.Timestamp).Milliseconds())
+			if m.StartTimeLatency < 0 {
+				log.Tracef("StartTimeLatency for job %v falling under negative case. So explicitly setting it to 0", m.Name)
+				m.StartTimeLatency = 0
+			}
 		}
 		m.CompletionLatency = int(m.jobComplete.Sub(m.Timestamp).Milliseconds())
 		m.ChurnMetric = j.IsChurnMetric(m.Timestamp)
@@ -232,10 +236,12 @@ func (j *jobLatency) normalizeMetrics() float64 {
 
 func (j *jobLatency) getLatency(normLatency any) map[string]float64 {
 	jobMetric := normLatency.(jobMetric)
-	return map[string]float64{
-		jobStartTimeMeasurement:     float64(jobMetric.StartTimeLatency),
-		string(batchv1.JobComplete): float64(jobMetric.CompletionLatency),
+	res := make(map[string]float64)
+	if jobMetric.StartTimeLatency != -1 {
+		res[jobStartTimeMeasurement] = float64(jobMetric.StartTimeLatency)
 	}
+	res[string(batchv1.JobComplete)] = float64(jobMetric.CompletionLatency)
+	return res
 }
 
 func (j *jobLatency) IsCompatible() bool {

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -345,46 +345,70 @@ func (p *podLatency) normalizeMetrics() float64 {
 		// negative value due to the precision of timestamp can only get to the level of second
 		errorFlag := 0
 		warningFlag := 0
-		m.ContainersReadyLatency = int(m.containersReady.Sub(m.Timestamp).Milliseconds())
-		if m.ContainersReadyLatency < 0 {
-			log.Tracef("ContainersReadyLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.ContainersReadyLatency = 0
+		if m.containersReady.IsZero() {
+			m.ContainersReadyLatency = -1
+		} else {
+			m.ContainersReadyLatency = int(m.containersReady.Sub(m.Timestamp).Milliseconds())
+			if m.ContainersReadyLatency < 0 {
+				log.Tracef("ContainersReadyLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.ContainersReadyLatency = 0
+			}
 		}
 
-		m.ReadyToStartContainersLatency = int(m.readyToStartContainers.Sub(m.Timestamp).Milliseconds())
-		if m.ReadyToStartContainersLatency < 0 {
-			log.Tracef("ReadyToStartContainersLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.ReadyToStartContainersLatency = 0
+		if m.readyToStartContainers.IsZero() {
+			m.ReadyToStartContainersLatency = -1
+		} else {
+			m.ReadyToStartContainersLatency = int(m.readyToStartContainers.Sub(m.Timestamp).Milliseconds())
+			if m.ReadyToStartContainersLatency < 0 {
+				log.Tracef("ReadyToStartContainersLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.ReadyToStartContainersLatency = 0
+			}
 		}
 
-		m.InitializedLatency = int(m.initialized.Sub(m.Timestamp).Milliseconds())
-		if m.InitializedLatency < 0 {
-			log.Tracef("InitializedLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.InitializedLatency = 0
+		if m.initialized.IsZero() {
+			m.InitializedLatency = -1
+		} else {
+			m.InitializedLatency = int(m.initialized.Sub(m.Timestamp).Milliseconds())
+			if m.InitializedLatency < 0 {
+				log.Tracef("InitializedLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.InitializedLatency = 0
+			}
 		}
 
-		m.PodReadyLatency = int(m.podReady.Sub(m.Timestamp).Milliseconds())
-		if m.PodReadyLatency < 0 {
-			log.Tracef("PodReadyLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.PodReadyLatency = 0
+		if m.podReady.IsZero() {
+			m.PodReadyLatency = -1
+		} else {
+			m.PodReadyLatency = int(m.podReady.Sub(m.Timestamp).Milliseconds())
+			if m.PodReadyLatency < 0 {
+				log.Tracef("PodReadyLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.PodReadyLatency = 0
+			}
 		}
 		// Both scheduling and containersStarted latencies are calculated from the event time, in high load scenarios,
 		// there might be a delay in the event time, so we print a warning message flag rather than returning an error
-		m.SchedulingLatency = int(m.scheduled.Sub(m.Timestamp).Milliseconds())
-		if m.SchedulingLatency < 0 {
-			log.Tracef("SchedulingLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
-			warningFlag = 1
-			m.SchedulingLatency = 0
+		if m.scheduled.IsZero() {
+			m.SchedulingLatency = -1
+		} else {
+			m.SchedulingLatency = int(m.scheduled.Sub(m.Timestamp).Milliseconds())
+			if m.SchedulingLatency < 0 {
+				log.Tracef("SchedulingLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
+				warningFlag = 1
+				m.SchedulingLatency = 0
+			}
 		}
-		m.ContainersStartedLatency = int(m.containersStarted.Sub(m.Timestamp).Milliseconds())
-		if m.ContainersStartedLatency < 0 {
-			log.Tracef("ContainersStartedLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
-			warningFlag = 1
-			m.ContainersStartedLatency = 0
+		if m.containersStarted.IsZero() {
+			m.ContainersStartedLatency = -1
+		} else {
+			m.ContainersStartedLatency = int(m.containersStarted.Sub(m.Timestamp).Milliseconds())
+			if m.ContainersStartedLatency < 0 {
+				log.Tracef("ContainersStartedLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
+				warningFlag = 1
+				m.ContainersStartedLatency = 0
+			}
 		}
 		m.ChurnMetric = p.IsChurnMetric(m.Timestamp)
 		totalPods++
@@ -404,14 +428,26 @@ func (p *podLatency) normalizeMetrics() float64 {
 
 func (p *podLatency) getLatency(normLatency any) map[string]float64 {
 	podMetric := normLatency.(podMetric)
-	return map[string]float64{
-		string(corev1.PodScheduled):              float64(podMetric.SchedulingLatency),
-		string(corev1.ContainersReady):           float64(podMetric.ContainersReadyLatency),
-		string(corev1.PodInitialized):            float64(podMetric.InitializedLatency),
-		string(corev1.PodReady):                  float64(podMetric.PodReadyLatency),
-		string(corev1.PodReadyToStartContainers): float64(podMetric.ReadyToStartContainersLatency),
-		containersStarted:                        float64(podMetric.ContainersStartedLatency),
+	res := make(map[string]float64)
+	if podMetric.SchedulingLatency != -1 {
+		res[string(corev1.PodScheduled)] = float64(podMetric.SchedulingLatency)
 	}
+	if podMetric.ContainersReadyLatency != -1 {
+		res[string(corev1.ContainersReady)] = float64(podMetric.ContainersReadyLatency)
+	}
+	if podMetric.InitializedLatency != -1 {
+		res[string(corev1.PodInitialized)] = float64(podMetric.InitializedLatency)
+	}
+	if podMetric.PodReadyLatency != -1 {
+		res[string(corev1.PodReady)] = float64(podMetric.PodReadyLatency)
+	}
+	if podMetric.ReadyToStartContainersLatency != -1 {
+		res[string(corev1.PodReadyToStartContainers)] = float64(podMetric.ReadyToStartContainersLatency)
+	}
+	if podMetric.ContainersStartedLatency != -1 {
+		res[containersStarted] = float64(podMetric.ContainersStartedLatency)
+	}
+	return res
 }
 
 func (p *podLatency) IsCompatible() bool {

--- a/pkg/measurements/pvc_latency.go
+++ b/pkg/measurements/pvc_latency.go
@@ -294,9 +294,7 @@ func (p *pvcLatency) normalizeMetrics() float64 {
 		}
 
 		// ResizeLatency is already calculated in handleUpdatePVC, just validate
-		if m.ResizedCapacity == "" {
-			m.ResizeLatency = -1
-		} else if m.ResizeLatency < 0 {
+		if m.ResizeLatency < 0 {
 			log.Tracef("ResizeLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.ResizeLatency = 0
 		}
@@ -325,9 +323,7 @@ func (p *pvcLatency) getLatency(normLatency any) map[string]float64 {
 	if pvcMetric.LostLatency != -1 {
 		res[string(corev1.ClaimLost)] = float64(pvcMetric.LostLatency)
 	}
-	if pvcMetric.ResizeLatency != -1 {
-		res["Resize"] = float64(pvcMetric.ResizeLatency)
-	}
+	res["Resize"] = float64(pvcMetric.ResizeLatency)
 	return res
 }
 

--- a/pkg/measurements/pvc_latency.go
+++ b/pkg/measurements/pvc_latency.go
@@ -261,15 +261,21 @@ func (p *pvcLatency) normalizeMetrics() float64 {
 			return true
 		}
 		errorFlag := 0
-		m.PendingLatency = int(m.pending - m.Timestamp.UnixMilli())
-		if m.PendingLatency < 0 {
-			log.Tracef("PendingLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
-			if m.pending < 0 {
-				errorFlag = 1
+		if m.pending == 0 {
+			m.PendingLatency = -1
+		} else {
+			m.PendingLatency = int(m.pending - m.Timestamp.UnixMilli())
+			if m.PendingLatency < 0 {
+				log.Tracef("PendingLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
+				if m.pending < 0 {
+					errorFlag = 1
+				}
+				m.PendingLatency = 0
 			}
-			m.PendingLatency = 0
 		}
-		if m.bound > 0 {
+		if m.bound == 0 {
+			m.BindingLatency = -1
+		} else {
 			m.BindingLatency = int(m.bound - m.Timestamp.UnixMilli())
 			if m.BindingLatency < 0 {
 				log.Tracef("BindingLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
@@ -277,7 +283,9 @@ func (p *pvcLatency) normalizeMetrics() float64 {
 				m.BindingLatency = 0
 			}
 		}
-		if m.lost > 0 {
+		if m.lost == 0 {
+			m.LostLatency = -1
+		} else {
 			m.LostLatency = int(m.lost - m.Timestamp.UnixMilli())
 			if m.LostLatency < 0 {
 				log.Tracef("LostLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
@@ -286,7 +294,9 @@ func (p *pvcLatency) normalizeMetrics() float64 {
 		}
 
 		// ResizeLatency is already calculated in handleUpdatePVC, just validate
-		if m.ResizeLatency < 0 {
+		if m.ResizedCapacity == "" {
+			m.ResizeLatency = -1
+		} else if m.ResizeLatency < 0 {
 			log.Tracef("ResizeLatency for pvc %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.ResizeLatency = 0
 		}
@@ -305,12 +315,20 @@ func (p *pvcLatency) normalizeMetrics() float64 {
 
 func (p *pvcLatency) getLatency(normLatency any) map[string]float64 {
 	pvcMetric := normLatency.(pvcMetric)
-	return map[string]float64{
-		string(corev1.ClaimPending): float64(pvcMetric.PendingLatency),
-		string(corev1.ClaimBound):   float64(pvcMetric.BindingLatency),
-		string(corev1.ClaimLost):    float64(pvcMetric.LostLatency),
-		"Resize":                    float64(pvcMetric.ResizeLatency),
+	res := make(map[string]float64)
+	if pvcMetric.PendingLatency != -1 {
+		res[string(corev1.ClaimPending)] = float64(pvcMetric.PendingLatency)
 	}
+	if pvcMetric.BindingLatency != -1 {
+		res[string(corev1.ClaimBound)] = float64(pvcMetric.BindingLatency)
+	}
+	if pvcMetric.LostLatency != -1 {
+		res[string(corev1.ClaimLost)] = float64(pvcMetric.LostLatency)
+	}
+	if pvcMetric.ResizeLatency != -1 {
+		res["Resize"] = float64(pvcMetric.ResizeLatency)
+	}
+	return res
 }
 
 func (p *pvcLatency) IsCompatible() bool {

--- a/pkg/measurements/vmim_latency.go
+++ b/pkg/measurements/vmim_latency.go
@@ -286,46 +286,70 @@ func (vmiml *vmimLatency) normalizeMetrics() float64 {
 
 		errorFlag := 0
 		// Calculate latencies from the timestamp (creation time)
-		m.PendingLatency = int(m.pendingTime.Sub(m.Timestamp).Milliseconds())
-		if m.PendingLatency < 0 {
-			log.Tracef("PendingLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.PendingLatency = 0
+		if m.pendingTime.IsZero() {
+			m.PendingLatency = -1
+		} else {
+			m.PendingLatency = int(m.pendingTime.Sub(m.Timestamp).Milliseconds())
+			if m.PendingLatency < 0 {
+				log.Tracef("PendingLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.PendingLatency = 0
+			}
 		}
 
-		m.SchedulingLatency = int(m.schedulingTime.Sub(m.Timestamp).Milliseconds())
-		if m.SchedulingLatency < 0 {
-			log.Tracef("SchedulingLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.SchedulingLatency = 0
+		if m.schedulingTime.IsZero() {
+			m.SchedulingLatency = -1
+		} else {
+			m.SchedulingLatency = int(m.schedulingTime.Sub(m.Timestamp).Milliseconds())
+			if m.SchedulingLatency < 0 {
+				log.Tracef("SchedulingLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.SchedulingLatency = 0
+			}
 		}
 
-		m.ScheduledLatency = int(m.scheduledTime.Sub(m.Timestamp).Milliseconds())
-		if m.ScheduledLatency < 0 {
-			log.Tracef("ScheduledLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.ScheduledLatency = 0
+		if m.scheduledTime.IsZero() {
+			m.ScheduledLatency = -1
+		} else {
+			m.ScheduledLatency = int(m.scheduledTime.Sub(m.Timestamp).Milliseconds())
+			if m.ScheduledLatency < 0 {
+				log.Tracef("ScheduledLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.ScheduledLatency = 0
+			}
 		}
 
-		m.PreparingTargetLatency = int(m.preparingTargetTime.Sub(m.Timestamp).Milliseconds())
-		if m.PreparingTargetLatency < 0 {
-			log.Tracef("PreparingTargetLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.PreparingTargetLatency = 0
+		if m.preparingTargetTime.IsZero() {
+			m.PreparingTargetLatency = -1
+		} else {
+			m.PreparingTargetLatency = int(m.preparingTargetTime.Sub(m.Timestamp).Milliseconds())
+			if m.PreparingTargetLatency < 0 {
+				log.Tracef("PreparingTargetLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.PreparingTargetLatency = 0
+			}
 		}
 
-		m.TargetReadyLatency = int(m.targetReadyTime.Sub(m.Timestamp).Milliseconds())
-		if m.TargetReadyLatency < 0 {
-			log.Tracef("TargetReadyLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.TargetReadyLatency = 0
+		if m.targetReadyTime.IsZero() {
+			m.TargetReadyLatency = -1
+		} else {
+			m.TargetReadyLatency = int(m.targetReadyTime.Sub(m.Timestamp).Milliseconds())
+			if m.TargetReadyLatency < 0 {
+				log.Tracef("TargetReadyLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.TargetReadyLatency = 0
+			}
 		}
 
-		m.RunningLatency = int(m.runningTime.Sub(m.Timestamp).Milliseconds())
-		if m.RunningLatency < 0 {
-			log.Tracef("RunningLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.RunningLatency = 0
+		if m.runningTime.IsZero() {
+			m.RunningLatency = -1
+		} else {
+			m.RunningLatency = int(m.runningTime.Sub(m.Timestamp).Milliseconds())
+			if m.RunningLatency < 0 {
+				log.Tracef("RunningLatency for VirtualMachineInstanceMigration %v falling under negative case. So explicitly setting it to 0", m.Name)
+				errorFlag = 1
+				m.RunningLatency = 0
+			}
 		}
 
 		m.SucceededLatency = int(m.succeededTime.Sub(m.Timestamp).Milliseconds())
@@ -350,15 +374,29 @@ func (vmiml *vmimLatency) normalizeMetrics() float64 {
 
 func (vmiml *vmimLatency) getLatency(normLatency any) map[string]float64 {
 	vmimMetric := normLatency.(vmimMetric)
-	return map[string]float64{
-		string(kvv1.MigrationPending):         float64(vmimMetric.PendingLatency),
-		string(kvv1.MigrationScheduling):      float64(vmimMetric.SchedulingLatency),
-		string(kvv1.MigrationScheduled):       float64(vmimMetric.ScheduledLatency),
-		string(kvv1.MigrationPreparingTarget): float64(vmimMetric.PreparingTargetLatency),
-		string(kvv1.MigrationTargetReady):     float64(vmimMetric.TargetReadyLatency),
-		string(kvv1.MigrationRunning):         float64(vmimMetric.RunningLatency),
-		string(kvv1.MigrationSucceeded):       float64(vmimMetric.SucceededLatency),
+	res := make(map[string]float64)
+
+	if vmimMetric.PendingLatency != -1 {
+		res[string(kvv1.MigrationPending)] = float64(vmimMetric.PendingLatency)
 	}
+	if vmimMetric.SchedulingLatency != -1 {
+		res[string(kvv1.MigrationScheduling)] = float64(vmimMetric.SchedulingLatency)
+	}
+	if vmimMetric.ScheduledLatency != -1 {
+		res[string(kvv1.MigrationScheduled)] = float64(vmimMetric.ScheduledLatency)
+	}
+	if vmimMetric.PreparingTargetLatency != -1 {
+		res[string(kvv1.MigrationPreparingTarget)] = float64(vmimMetric.PreparingTargetLatency)
+	}
+	if vmimMetric.TargetReadyLatency != -1 {
+		res[string(kvv1.MigrationTargetReady)] = float64(vmimMetric.TargetReadyLatency)
+	}
+	if vmimMetric.RunningLatency != -1 {
+		res[string(kvv1.MigrationRunning)] = float64(vmimMetric.RunningLatency)
+	}
+	res[string(kvv1.MigrationSucceeded)] = float64(vmimMetric.SucceededLatency)
+
+	return res
 }
 
 func (vmiml *vmimLatency) IsCompatible() bool {


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Fixes a silent mathematical underflow vulnerability across the `pkg/measurements/` metric suite that was inadvertently ingesting `0ms` metrics for unused/untracked workflow phases.

**Why it's needed:**
When a Kube-burner test suite runs through phases (such as `ContainersReady`, `DVBound`, `Scheduling`, etc.), if a phase completes instantaneously or if an underlying volume/pod condition is bypassed, the phase's tracking timestamps remain uninitialized (`0001-01-01`).

When evaluating metric generation, `.Sub(m.Timestamp)` is called against these uninitialized phases, which previously resulted in a massive negative number underflow. The existing handler caught this `<0` logic and explicitly clamped the result to exactly `0ms`. This ultimately forced downstream reporting logic (such as Elasticsearch) to skew heavily by treating completely absent deployment routines as having taken `0ms`. 

**Implementation Details:**
- Checks `m.[timestamp].IsZero()` (or explicit `0` int64 structures) globally inside `normalizeMetrics()`.
- Uninitialized phases are now cleanly bypassed to a discrete `-1` value.
- `getLatency()` metric mappings explicitly strip `-1` latency phases, ensuring they are entirely ignored during Elasticsearch dictionary indexing rather than outputting false `0ms` fields.

**Modified Components:**
- `vmim_latency.go`
- `pod_latency.go`
- `datavolume_latency.go`
- `pvc_latency.go`
- `job_latency.go`

