### PR TITLE
Add label-based skip for pod latency measurement

### DIFF
--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -142,6 +142,37 @@ WARN[2020-12-15 12:37:08] P99 Ready latency (2929ms) higher than configured thre
 
 In case of not meeting any of the configured thresholds, like the example above, **kube-burner return code will be 1**.
 
+### Skipping specific pods
+
+It is possible to exclude specific pods from pod latency tracking by adding the label `kube-burner.io/skip-pod-latency: "true"` to the pod template. This is useful when:
+
+- Pods are created temporarily and cleaned up before job completion (e.g., setup pods in staged execution)
+- Certain pods should not contribute to latency metrics (e.g., infrastructure pods, DaemonSet pods)
+
+Example pod template with skip label:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{.Name}}
+spec:
+  selector:
+    matchLabels:
+      app: {{.Name}}
+  template:
+    metadata:
+      labels:
+        app: {{.Name}}
+        kube-burner.io/skip-pod-latency: "true"
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+```
+
+Pods with this label will be excluded from latency measurement and will not cause verification failures if they are deleted before job completion.
+
 ## Job latency
 
 Collects latencies from the different job stages, these **latency metrics are in ms**. It can be enabled with:

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -349,6 +349,7 @@ const (
 	KubeBurnerLabelChurnDelete              = "kube-burner.io/churn-delete"
 	KubeBurnerLabelServiceLatency           = "kube-burner.io/service-latency"
 	KubeBurnerLabelSkipNetworkPolicyLatency = "kube-burner.io/skip-networkpolicy-latency"
+	KubeBurnerLabelSkipPodLatency           = "kube-burner.io/skip-pod-latency"
 )
 
 // MetricsCLosing strategy

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -115,6 +115,11 @@ func (p *podLatency) handleCreatePod(obj any) {
 		return
 	}
 	podLabels := pod.GetLabels()
+	// Skip pod latency tracking if the skip label is set
+	if value, ok := podLabels[config.KubeBurnerLabelSkipPodLatency]; ok && value == "true" {
+		log.Debugf("Skipping pod latency tracking for %s/%s (skip label set)", pod.Namespace, pod.Name)
+		return
+	}
 	p.Metrics.LoadOrStore(string(pod.UID), podMetric{
 		Timestamp:    pod.CreationTimestamp.UTC(),
 		Namespace:    pod.Namespace,


### PR DESCRIPTION
Introduce kube-burner.io/skip-pod-latency label to exclude specific pods from pod latency tracking. Pods with this label set to "true" will tracked by the podLatency measurement.

