### PR TITLE
Prevent execution error on high measurement error rate

### DIFF
--- a/pkg/measurements/base_measurement.go
+++ b/pkg/measurements/base_measurement.go
@@ -125,7 +125,7 @@ func (bm *BaseMeasurement) StopMeasurement(normalizeMetrics func() float64, getL
 		log.Infof("%s: %v 99th: %v ms max: %v ms avg: %v ms", bm.JobConfig.Name, pq.QuantileName, pq.P99, pq.Max, pq.Avg)
 	}
 	if errorRate > 10.00 {
-		return fmt.Errorf("something is wrong with system under test. %v latencies error rate was: %.2f", bm.MeasurementName, errorRate)
+		log.Warnf("%v latencies error rate was: %.2f", bm.MeasurementName, errorRate)
 	} else if errorRate > 0 {
 		log.Infof("%v error rate was: %.2f", bm.MeasurementName, errorRate)
 	}


### PR DESCRIPTION
## Type of change

- Optimization

## Description

The user can debug latency errors afterwards, kube-burner shouldn't fail the execution when observing them as is not a tool issue.

This behavior can prevent the execution of other subsequent steps like additional tests or regression checking.

## Related Tickets & Documents

- Related Issue #
- Closes #
