### PR TITLE
Add iterationStart support and job-scoped measurement selectors

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -167,7 +167,7 @@ func (ex *JobExecutor) RunCreateJob(ctx context.Context, iterationStart, iterati
 			}
 			ex.objects[objectIndex].LabelSelector = kbLabels
 			if obj.RunOnce {
-				if i == 0 {
+				if i == iterationStart {
 					// this executes only once during the first iteration of an object
 					log.Debugf("RunOnce set to %s, so creating object once", obj.ObjectTemplate)
 					ex.replicaHandler(ctx, kbLabels, obj, ns, i, &wg)

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -132,7 +132,11 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				measurementsJobName = jobExecutor.Name
 				// For incremental jobs we create runtime measurements per-step inside the incremental runner
 				if jobExecutor.IncrementalLoad == nil {
-					measurementsInstance = measurementsFactory.NewMeasurements(&jobExecutor.Job, kubeClientProvider, embedCfg, fmt.Sprintf("%s=%s", config.KubeBurnerLabelRunID, globalConfig.RUNID))
+					labelSelector := fmt.Sprintf("%s=%s", config.KubeBurnerLabelRunID, globalConfig.RUNID)
+					if !jobExecutor.MetricsAggregate && jobExecutor.JobType == config.CreationJob {
+						labelSelector = fmt.Sprintf("%s,%s=%s", labelSelector, config.KubeBurnerLabelJob, jobExecutor.Name)
+					}
+					measurementsInstance = measurementsFactory.NewMeasurements(&jobExecutor.Job, kubeClientProvider, embedCfg, labelSelector)
 					measurementsInstance.Start()
 				}
 			}
@@ -371,7 +375,7 @@ func runCreateOrIncremental(ctx context.Context, jobExecutor JobExecutor, measur
 		calculator := NewIterationCalculator(jobExecutor)
 		return jobExecutor.RunIncrementalCreateJob(ctx, calculator, measurementsFactory, kubeClientProvider, embedCfg, measurementsJobName, metricsScraper, configSpec)
 	}
-	return jobExecutor.RunCreateJob(ctx, 0, jobExecutor.JobIterations), nil
+	return jobExecutor.RunCreateJob(ctx, jobExecutor.IterationStart, jobExecutor.IterationStart+jobExecutor.JobIterations), nil
 }
 
 // If requests, preload the images used in the test into the node

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -309,6 +309,12 @@ func ParseWithUserdata(uuid string, timeout time.Duration, configFileReader, use
 		if job.JobIterations < 1 && (job.JobType == CreationJob || job.JobType == ReadJob) {
 			log.Fatalf("Job %s has < 1 iterations", job.Name)
 		}
+		if job.IterationStart < 0 {
+			log.Fatalf("Job %s has negative iterationStart: %d", job.Name, job.IterationStart)
+		}
+		if job.IterationStart > 0 && job.IncrementalLoad != nil {
+			log.Fatalf("Job %s: iterationStart is not supported with incrementalLoad", job.Name)
+		}
 		if _, ok := metricsClosing[job.MetricsClosing]; !ok {
 			log.Fatalf("Invalid value for metricsClosing: %s", job.MetricsClosing)
 		}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -150,6 +150,8 @@ type Object struct {
 type Job struct {
 	// IterationCount how many times to execute the job
 	JobIterations int `yaml:"jobIterations" json:"jobIterations,omitempty"`
+	// IterationStart offsets iteration numbering so namespaces and templates start from this value instead of 0
+	IterationStart int `yaml:"iterationStart" json:"iterationStart,omitempty"`
 	// IterationDelay how much time to wait between each job iteration
 	JobIterationDelay time.Duration `yaml:"jobIterationDelay" json:"jobIterationDelay,omitempty"`
 	// JobPause how much time to pause after finishing the job


### PR DESCRIPTION
Add iterationStart field to Job config that offsets iteration numbering so namespaces and templates start from this value instead of 0. This enables YAML-driven jobs to recreate resources at specific indices (e.g., cudn-density-45 instead of cudn-density-0) without custom Go code.


 When measurements are per-job (the default), add the job name to the pod watcher's label selector so it only captures pods created by that job. Without this, a job like cudn-churn-workload would also pick up the 1800 existing pods from 
cudn-density-workload because they share the same runid, resulting in duplicate latency entries in ES.

Fix RunOnce guard to use iterationStart instead of hardcoded 0.
