### PR TITLE
USHIFT-6963: Add MicroShift support

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kube-burner/kube-burner/v2/pkg/measurements"
 	"github.com/kube-burner/kube-burner/v2/pkg/prometheus"
 	"github.com/kube-burner/kube-burner/v2/pkg/util"
+	"github.com/kube-burner/kube-burner/v2/pkg/util/cluster"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/fileutils"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/metrics"
 	log "github.com/sirupsen/logrus"
@@ -297,12 +298,21 @@ func measureCmd() *cobra.Command {
 					log.Fatalf("Error reading provided user metadata: %v", err)
 				}
 			}
+			kubeClientProvider := config.NewKubeClientProvider(kubeConfig, kubeContext)
+			clientSet, _ := kubeClientProvider.DefaultClientSet()
+			probeCtx, probeCancel := context.WithTimeout(cmd.Context(), configSpec.GlobalConfig.RequestTimeout)
+			clusterInfo, err := cluster.Probe(probeCtx, clientSet)
+			probeCancel()
+			if err != nil {
+				log.Warnf("Cluster probe partially failed: %v", err)
+			}
+			metadata = clusterInfo.ApplyMetadata(metadata)
 			measurementsInstance := measurements.NewMeasurementsFactory(configSpec, metadata, nil).NewMeasurements(
 				&config.Job{
 					Name:    jobName,
 					JobType: config.CreationJob,
 				},
-				config.NewKubeClientProvider(kubeConfig, kubeContext),
+				kubeClientProvider,
 				nil,
 				selector,
 			)

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -110,14 +110,14 @@ func (ex *JobExecutor) gcGroupObjects(ctx context.Context, grp objectGroupEntry)
 				if !created {
 					continue
 				}
-				CleanupNamespaceResourcesByLabel(ctx, *ex, obj, ns, labelSelector)
+				CleanupNamespacedResourcesByLabel(ctx, *ex, obj, ns, labelSelector)
 			}
 			// Also clean up objects with a fixed namespace
 			if obj.namespace != "" {
-				CleanupNamespaceResourcesByLabel(ctx, *ex, obj, obj.namespace, labelSelector)
+				CleanupNamespacedResourcesByLabel(ctx, *ex, obj, obj.namespace, labelSelector)
 			}
 		} else {
-			CleanupNonNamespacedResourcesByLabel(ctx, *ex, obj, labelSelector)
+			CleanupClusterScopedResourcesByLabel(ctx, *ex, obj, labelSelector)
 		}
 	}
 	// Wait for deletion to complete
@@ -184,7 +184,7 @@ func (ex *JobExecutor) preloadClusterScopedObjects(ctx context.Context) []cluste
 }
 
 // deleteClusterScopedObjects marks cluster-scoped objects in the given iteration range
-// with a deletion label, deletes them using CleanupNonNamespacedResourcesByLabel,
+// with a deletion label, deletes them using CleanupClusterScopedResourcesByLabel,
 // and returns the list of deleted objects for verification.
 func (ex *JobExecutor) deleteClusterScopedObjects(ctx context.Context, caches []clusterScopedObjectCache, iterationStart, iterationEnd int) []churnDeletedObject {
 	delPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":""}}}`, config.KubeBurnerLabelChurnDelete))
@@ -214,7 +214,7 @@ func (ex *JobExecutor) deleteClusterScopedObjects(ctx context.Context, caches []
 			}
 		}
 
-		CleanupNonNamespacedResourcesByLabel(ctx, *ex, cache.obj, config.KubeBurnerLabelChurnDelete)
+		CleanupClusterScopedResourcesByLabel(ctx, *ex, cache.obj, config.KubeBurnerLabelChurnDelete)
 	}
 	return deletedObjects
 }

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kube-burner/kube-burner/v2/pkg/measurements"
 	"github.com/kube-burner/kube-burner/v2/pkg/prometheus"
 	"github.com/kube-burner/kube-burner/v2/pkg/util"
+	"github.com/kube-burner/kube-burner/v2/pkg/util/cluster"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/fileutils"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/metrics"
 	"github.com/kube-burner/kube-burner/v2/pkg/watchers"
@@ -84,9 +85,17 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	log.Infof("🔥 Starting kube-burner (%s@%s) with UUID %s", version.Version, version.GitCommit, uuid)
 	ctx, cancel := context.WithTimeout(context.Background(), configSpec.GlobalConfig.Timeout)
 	defer cancel()
+	clientSet, restConfig := kubeClientProvider.DefaultClientSet()
+	probeCtx, probeCancel := context.WithTimeout(ctx, configSpec.GlobalConfig.RequestTimeout)
+	clusterInfo, err := cluster.Probe(probeCtx, clientSet)
+	probeCancel()
+	if err != nil {
+		log.Warnf("Cluster probe partially failed: %v", err)
+	}
+	metricsScraper.SummaryMetadata = clusterInfo.ApplyMetadata(metricsScraper.SummaryMetadata)
+	metricsScraper.MetricsMetadata = clusterInfo.ApplyMetadata(metricsScraper.MetricsMetadata)
 	go func() {
 		var innerRC int
-		_, restConfig := kubeClientProvider.DefaultClientSet()
 		measurementsFactory := measurements.NewMeasurementsFactory(configSpec, metricsScraper.MetricsMetadata, additionalMeasurementFactoryMap)
 		jobExecutors = newExecutorList(configSpec, kubeClientProvider, embedCfg)
 		if err := handlePreloadImages(ctx, jobExecutors, kubeClientProvider); err != nil {

--- a/pkg/measurements/datavolume_latency.go
+++ b/pkg/measurements/datavolume_latency.go
@@ -241,6 +241,7 @@ func (dv *dvLatency) Collect(measurementWg *sync.WaitGroup) {
 			dvRunning:  running,
 			dvReady:    ready,
 			JobName:    dv.JobConfig.Name,
+			Metadata:   dv.Metadata,
 		})
 	}
 }

--- a/pkg/measurements/job_latency.go
+++ b/pkg/measurements/job_latency.go
@@ -196,6 +196,7 @@ func (j *jobLatency) Collect(measurementWg *sync.WaitGroup) {
 			jobComplete: completed,
 			startTime:   startTime,
 			JobName:     j.JobConfig.Name,
+			Metadata:    j.Metadata,
 		})
 	}
 }

--- a/pkg/measurements/node_latency.go
+++ b/pkg/measurements/node_latency.go
@@ -205,6 +205,7 @@ func (n *nodeLatency) Collect(measurementWg *sync.WaitGroup) {
 			NodeReady:          nodeReady,
 			JobName:            n.JobConfig.Name,
 			Labels:             util.NormalizeLabels(node.Labels),
+			Metadata:           n.Metadata,
 		})
 	}
 }

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -319,6 +319,7 @@ func (p *podLatency) Collect(measurementWg *sync.WaitGroup) {
 			containersReady:        containersReady,
 			podReady:               podReady,
 			JobName:                p.JobConfig.Name,
+			Metadata:               p.Metadata,
 		})
 	}
 }

--- a/pkg/measurements/snapshot_latency.go
+++ b/pkg/measurements/snapshot_latency.go
@@ -201,6 +201,7 @@ func (vsl *volumeSnapshotLatency) Collect(measurementWg *sync.WaitGroup) {
 			UUID:       vsl.Uuid,
 			vsReady:    volumeSnapshot.Status.CreationTime.Time,
 			JobName:    vsl.JobConfig.Name,
+			Metadata:   vsl.Metadata,
 		})
 	}
 }

--- a/pkg/measurements/vmim_latency.go
+++ b/pkg/measurements/vmim_latency.go
@@ -263,6 +263,7 @@ func (vmiml *vmimLatency) Collect(measurementWg *sync.WaitGroup) {
 			targetReadyTime:     targetReady,
 			runningTime:         running,
 			succeededTime:       succeeded,
+			Metadata:            vmiml.Metadata,
 		})
 	}
 }

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	MetadataKeyK8sVersion = "k8sVersion"
+	MetadataKeyTotalNodes = "totalNodes"
+)
+
+// Info contains generic Kubernetes cluster facts kube-burner core consumes.
+type Info struct {
+	K8sVersion string
+	TotalNodes *int
+}
+
+// AsMetadata returns the generic Kubernetes cluster metadata keys kube-burner
+// stamps onto indexed documents. Missing probe values are omitted so user
+// metadata is not overwritten with empty values.
+func (i Info) AsMetadata() map[string]any {
+	metadata := make(map[string]any)
+	if i.K8sVersion != "" {
+		metadata[MetadataKeyK8sVersion] = i.K8sVersion
+	}
+	if i.TotalNodes != nil {
+		metadata[MetadataKeyTotalNodes] = *i.TotalNodes
+	}
+	return metadata
+}
+
+// ApplyMetadata stamps discovered cluster metadata into m. A non-nil map is
+// always returned.
+func (i Info) ApplyMetadata(m map[string]any) map[string]any {
+	if m == nil {
+		m = make(map[string]any)
+	}
+	for k, v := range i.AsMetadata() {
+		m[k] = v
+	}
+	return m
+}
+
+// Probe collects generic Kubernetes cluster metadata. Partial data is returned
+// alongside an aggregate error when one or more discovery calls fail.
+func Probe(ctx context.Context, client kubernetes.Interface) (Info, error) {
+	var info Info
+	var errs []error
+	version, err := client.Discovery().ServerVersion()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("discovering Kubernetes server version: %w", err))
+	} else if version != nil {
+		info.K8sVersion = version.GitVersion
+	}
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		errs = append(errs, fmt.Errorf("listing nodes: %w", err))
+	} else if nodes == nil {
+		errs = append(errs, fmt.Errorf("listing nodes: empty response"))
+	} else {
+		totalNodes := len(nodes.Items)
+		info.TotalNodes = &totalNodes
+	}
+	return info, utilerrors.NewAggregate(errs)
+}

--- a/pkg/util/cluster/cluster_test.go
+++ b/pkg/util/cluster/cluster_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+const (
+	testK8sVersion   = "v1.35.3"
+	testDistribution = "microshift"
+)
+
+func TestAsMetadataEmitsOnlyDiscoveredValues(t *testing.T) {
+	metadata := Info{}.AsMetadata()
+	if len(metadata) != 0 {
+		t.Fatalf("expected empty metadata, got %v", metadata)
+	}
+
+	nodes := 0
+	metadata = Info{TotalNodes: &nodes}.AsMetadata()
+	if len(metadata) != 1 {
+		t.Fatalf("expected one metadata key, got %v", metadata)
+	}
+	if metadata[MetadataKeyTotalNodes] != 0 {
+		t.Fatalf("expected totalNodes=0, got %v", metadata[MetadataKeyTotalNodes])
+	}
+
+	nodes = 3
+	metadata = Info{K8sVersion: testK8sVersion, TotalNodes: &nodes}.AsMetadata()
+	expected := map[string]any{
+		MetadataKeyK8sVersion: testK8sVersion,
+		MetadataKeyTotalNodes: 3,
+	}
+	if len(metadata) != len(expected) {
+		t.Fatalf("expected %d metadata keys, got %d: %v", len(expected), len(metadata), metadata)
+	}
+	for key, want := range expected {
+		if metadata[key] != want {
+			t.Fatalf("expected %s=%v, got %v", key, want, metadata[key])
+		}
+	}
+	for _, absent := range []string{"distribution", "microshift", "microshiftVersion", "microshiftMajorVersion", "platform", "openshift", "ocpVersion"} {
+		if _, ok := metadata[absent]; ok {
+			t.Fatalf("did not expect %q in kube-burner core metadata", absent)
+		}
+	}
+}
+
+func TestApplyMetadata(t *testing.T) {
+	nodes := 2
+	input := map[string]any{
+		MetadataKeyK8sVersion: "stale",
+		MetadataKeyTotalNodes: 99,
+		"distribution":        testDistribution,
+		"customKey":           "preserve-me",
+	}
+
+	got := (Info{K8sVersion: testK8sVersion, TotalNodes: &nodes}).ApplyMetadata(input)
+	got["sentinel"] = "same-map"
+	if input["sentinel"] != "same-map" {
+		t.Fatal("expected ApplyMetadata to mutate the existing map instance")
+	}
+	if input[MetadataKeyK8sVersion] != testK8sVersion {
+		t.Fatalf("expected k8sVersion to be overwritten, got %v", input[MetadataKeyK8sVersion])
+	}
+	if input[MetadataKeyTotalNodes] != 2 {
+		t.Fatalf("expected totalNodes to be overwritten, got %v", input[MetadataKeyTotalNodes])
+	}
+	if input["distribution"] != testDistribution {
+		t.Fatalf("expected unrelated distribution metadata to be preserved, got %v", input["distribution"])
+	}
+	if input["customKey"] != "preserve-me" {
+		t.Fatalf("expected custom metadata to be preserved, got %v", input["customKey"])
+	}
+}
+
+func TestApplyMetadataNilInput(t *testing.T) {
+	nodes := 1
+	metadata := (Info{K8sVersion: testK8sVersion, TotalNodes: &nodes}).ApplyMetadata(nil)
+	if metadata == nil {
+		t.Fatal("expected ApplyMetadata to allocate a map for nil input")
+	}
+	if metadata[MetadataKeyK8sVersion] != testK8sVersion {
+		t.Fatalf("expected k8sVersion metadata, got %v", metadata[MetadataKeyK8sVersion])
+	}
+	if metadata[MetadataKeyTotalNodes] != 1 {
+		t.Fatalf("expected totalNodes metadata, got %v", metadata[MetadataKeyTotalNodes])
+	}
+}
+
+func TestApplyMetadataDoesNotOverwriteWithAbsentValues(t *testing.T) {
+	input := map[string]any{
+		MetadataKeyK8sVersion: "user-version",
+		MetadataKeyTotalNodes: 7,
+	}
+	got := (Info{}).ApplyMetadata(input)
+	if got[MetadataKeyK8sVersion] != "user-version" {
+		t.Fatalf("expected k8sVersion to be preserved, got %v", got[MetadataKeyK8sVersion])
+	}
+	if got[MetadataKeyTotalNodes] != 7 {
+		t.Fatalf("expected totalNodes to be preserved, got %v", got[MetadataKeyTotalNodes])
+	}
+}
+
+func TestProbe(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}},
+	)
+	discovery := fakeDiscovery(t, client)
+	discovery.FakedServerVersion = &version.Info{GitVersion: testK8sVersion}
+
+	info, err := Probe(context.Background(), client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.K8sVersion != testK8sVersion {
+		t.Fatalf("expected k8sVersion v1.35.3, got %q", info.K8sVersion)
+	}
+	if info.TotalNodes == nil {
+		t.Fatal("expected totalNodes to be discovered")
+	}
+	if *info.TotalNodes != 2 {
+		t.Fatalf("expected totalNodes=2, got %d", *info.TotalNodes)
+	}
+}
+
+func TestProbeReturnsPartialInfoWithAggregatedErrors(t *testing.T) {
+	client := k8sfake.NewSimpleClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+	)
+	discovery := fakeDiscovery(t, client)
+	versionErr := errors.New("version unavailable")
+	discovery.PrependReactor("get", "version", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		return true, nil, versionErr
+	})
+
+	info, err := Probe(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected partial probe error")
+	}
+	if !errors.Is(err, versionErr) {
+		t.Fatalf("expected aggregate to contain version error, got %v", err)
+	}
+	if info.K8sVersion != "" {
+		t.Fatalf("expected k8sVersion to be absent after version error, got %q", info.K8sVersion)
+	}
+	if info.TotalNodes == nil || *info.TotalNodes != 1 {
+		t.Fatalf("expected totalNodes=1 despite version error, got %v", info.TotalNodes)
+	}
+}
+
+func fakeDiscovery(t *testing.T, client *k8sfake.Clientset) *fakediscovery.FakeDiscovery {
+	t.Helper()
+	discovery, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
+	if !ok {
+		t.Fatal("unexpected discovery type")
+	}
+	return discovery
+}

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -26,9 +26,28 @@ import (
 
 // Processes common config and executes according to the caller
 func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
-	userMetadata := make(map[string]any)
+	if scraperConfig.SummaryMetadata == nil {
+		scraperConfig.SummaryMetadata = make(map[string]any)
+	}
+	if scraperConfig.MetricsMetadata == nil {
+		scraperConfig.MetricsMetadata = make(map[string]any)
+	}
+	if scraperConfig.UserMetaData != "" {
+		userMetadata, err := util.ReadUserMetadata(scraperConfig.UserMetaData)
+		if err != nil {
+			log.Fatalf("Error reading provided user metadata: %v", err)
+		}
+		// Combine users provided metadata with metrics and summary metadata
+		for k, v := range userMetadata {
+			scraperConfig.SummaryMetadata[k] = v
+			scraperConfig.MetricsMetadata[k] = v
+		}
+	}
 	if len(scraperConfig.ConfigSpec.MetricsEndpoints) == 0 && scraperConfig.MetricsEndpoint == "" {
-		return Scraper{}
+		return Scraper{
+			SummaryMetadata: scraperConfig.SummaryMetadata,
+			MetricsMetadata: scraperConfig.MetricsMetadata,
+		}
 	}
 	var err error
 	var indexer *indexers.Indexer
@@ -37,21 +56,6 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 	var prometheusClients []*prometheus.Prometheus
 	var alertM *alerting.AlertManager
 	var alertMs []*alerting.AlertManager
-	if scraperConfig.UserMetaData != "" {
-		userMetadata, err = util.ReadUserMetadata(scraperConfig.UserMetaData)
-		if err != nil {
-			log.Fatalf("Error reading provided user metadata: %v", err)
-		}
-	}
-	// Combine users provided metadata with metrics and summary metadata
-	for k, v := range userMetadata {
-		if scraperConfig.SummaryMetadata != nil {
-			scraperConfig.SummaryMetadata[k] = v
-		}
-		if scraperConfig.MetricsMetadata != nil {
-			scraperConfig.MetricsMetadata[k] = v
-		}
-	}
 	// MetricsEndpoint has preference over the configuration file
 	// if --metrics-directory is set, retain the value that is overwritten by UnmarshalYAML default
 	var metricsDirectoryFlag string

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -186,6 +186,19 @@ teardown_file() {
   run_cmd ${KUBE_BURNER} init -c kube-burner.yml --uuid=${UUID} --log-level=debug --kubeconfig="${TEST_KUBECONFIG}" --kube-context="${TEST_KUBECONTEXT}"
   check_metric_value jobSummary top2PrometheusCPU prometheusRSS podLatencyMeasurement podLatencyQuantilesMeasurement
   check_file_list ${METRICS_FOLDER}/jobSummary.json ${METRICS_FOLDER}/prometheusBuildInfo.json
+  jq -e '
+    length > 0 and
+    all(.[]; (has("distribution") | not)
+      and (has("microshift") | not)
+      and (has("platform") | not)
+      and (has("openshift") | not)
+      and (has("microshiftVersion") | not)
+      and (has("microshiftMajorVersion") | not)
+      and (.k8sVersion | type == "string")
+      and (.k8sVersion | length > 0)
+      and (.totalNodes | type == "number")
+      and (.totalNodes >= 1))
+  ' ${METRICS_FOLDER}/jobSummary.json
 }
 
 # bats test_tags=subsystem:health-check
@@ -360,4 +373,3 @@ teardown_file() {
   [ "$bindings" -eq 6 ]
   ${KUBE_BURNER} destroy -c kube-burner-repeat-every-n-iterations.yml
 }
-


### PR DESCRIPTION
Add a small, distribution-agnostic cluster probe to kube-burner core.

This is the kube-burner-core half of a two-part split. MicroShift support was originally proposed entirely in core; per maintainer feedback, kube-burner-core stays vanilla-Kubernetes and the OpenShift/MicroShift specifics move to the companion PR kube-burner/kube-burner-ocp#461.

Add a generic cluster probe (`pkg/util/cluster`) using plain client-go discovery — the Kubernetes server version and the node count. It does not import `go-commons/ocp-metadata` and performs no distribution detection.

Merge `--user-metadata` even when no metrics endpoints are configured, so it is honored on runs that do not scrape or index metrics.

## Type of change

- New feature

## Description

### Generic, distribution-agnostic cluster probe

`pkg/util/cluster.Probe(ctx, client)` uses plain client-go discovery only:

- `Discovery().ServerVersion()` → `k8sVersion`
- `CoreV1().Nodes().List()` → `totalNodes`

It does **not** import `go-commons/ocp-metadata` and performs **no** distribution detection. `Probe` is best-effort: each discovery call is attempted independently, and a partial `Info` is returned alongside an aggregate error when one or more calls fail, so callers stamp whatever was discovered.

`Info` is a narrow boundary type — `{ K8sVersion string; TotalNodes *int }`. `TotalNodes` is a pointer so "0 nodes" is distinguishable from "not discovered".

### Indexed metadata keys

Core stamps only generic Kubernetes facts, and only when discovered (absent values are omitted so user metadata is never overwritten with empties):

```yaml
k8sVersion: v1.xx.x
totalNodes: 1
```

Cluster metadata is applied after `--user-metadata`, so detected values stay authoritative over user-provided keys of the same name. Document shapes are unchanged: JobSummary flattens metadata at the top level; Prometheus and measurement documents nest it under `metadata`.

Distribution and OpenShift/MicroShift identity keys (`distribution`, `microshift`, `microshiftVersion`, …) are intentionally **not** stamped by core — they are owned by kube-burner-ocp (kube-burner/kube-burner-ocp#461).

### `--user-metadata` on non-scraping runs

`ProcessMetricsScraperConfig` now merges `--user-metadata` into the summary/metrics maps even when no metrics endpoints are configured; the early-return path previously dropped it.

### Measurement collection consistency

Several latency collectors already had a `Metadata` field for event-created docs but did not populate it on the `Collect()` path for existing objects. Fixed for the relevant collectors so standalone `measure` output is consistent. No new document schema.

### Coverage of `init` and `measure`

`kube-burner init` probes once at the start of `burner.Run` and applies metadata to the scraper's `SummaryMetadata`/`MetricsMetadata` maps in place. `kube-burner measure` performs its own probe after loading `--user-metadata`, since it bypasses `burner.Run`. `kube-burner index` is intentionally out of scope.

### Moved to kube-burner-ocp (kube-burner/kube-burner-ocp#461)

- OpenShift/MicroShift distribution detection and identity metadata (`distribution`, `microshift`, `microshiftVersion`, …) via go-commons `GetClusterInfo`.
- Capability-aware `cluster-density-ms` (gates ImageStream/Route on discovered APIs), MicroShift health-check handling, the MicroShift metrics profile, and MicroShift docs.

### Validation

- `go build ./...`, `go vet ./...`, `go test ./...` clean locally.
- Unit coverage in `pkg/util/cluster/cluster_test.go` for metadata overwrite, in-place mutation, nil-safe `ApplyMetadata()`, and the exact (`k8sVersion`/`totalNodes`) key whitelist.
- `test/test-k8s.bats` asserts JobSummary carries `k8sVersion`/`totalNodes` and that `distribution`/`microshift`/`platform`/`openshift` keys are absent.

## Related Tickets & Documents

- Jira: [USHIFT-6963](https://issues.redhat.com/browse/USHIFT-6963) — Add MicroShift support to kube-burner
- Companion PR (OpenShift/MicroShift specifics): kube-burner/kube-burner-ocp#461
