### PR TITLE
Fix pre-load falsely reporting images as pulled

### DIFF
--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -153,7 +153,7 @@ func countPulledImages(ctx context.Context, clientSet kubernetes.Interface, seen
 				continue
 			}
 			pullCount++
-			if status.Image != "" {
+			if isImagePulled(status) {
 				seen[podName+"/"+status.Name] = struct{}{}
 				pulledCount++
 			}
@@ -163,6 +163,21 @@ func countPulledImages(ctx context.Context, clientSet kubernetes.Interface, seen
 		}
 	}
 	return nil
+}
+
+func isImagePulled(status corev1.ContainerStatus) bool {
+	if status.State.Running != nil || status.State.Terminated != nil || status.RestartCount > 0 {
+		return true
+	}
+	if status.State.Waiting != nil {
+		switch status.State.Waiting.Reason {
+		case "", "ContainerCreating", "ErrImagePull", "ImagePullBackOff":
+			return false
+		default:
+			return true
+		}
+	}
+	return false
 }
 
 func isOwnedByDaemonSet(ownerReferences []metav1.OwnerReference, daemonSetName string) bool {


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

The pre-load check used status.Image to determine whether a container image had been pulled. This field is populated by the kubelet as soon as the container status entry is created, even while the image is still being pulled (Waiting/ContainerCreating), causing pre-load to declare success within seconds for multi-GB images.

Replace the check with isImagePulled(), which inspects container state instead: Running, Terminated, or RestartCount > 0 means the image was pulled. For KubeVirt container disk images where the container command fails at create time (CreateContainerError), the Waiting reason itself proves the pull succeeded, distinguishing it from image-pull-related reasons (ContainerCreating, ErrImagePull, ImagePullBackOff).
