### PR TITLE
Fix UUID template substitution for TSDB indexer

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -407,7 +407,7 @@ func indexCmd() *cobra.Command {
 					log.Fatal(err)
 				}
 			}
-			if (configSpec.MetricsEndpoints[0].Type == indexers.LocalIndexer || configSpec.MetricsEndpoints[0].Type == indexers.TSDBIndexer) && tarballName != "" {
+			if util.IsLocalIndexer(configSpec.MetricsEndpoints[0].Type) && tarballName != "" {
 				if err := metrics.CreateTarball(configSpec.MetricsEndpoints[0].IndexerConfig); err != nil {
 					log.Fatal(err)
 				}

--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -306,7 +306,7 @@ func splitIndexersByType(configSpec config.Spec, indexerList map[string]indexers
 			alias = fmt.Sprintf("indexer-%d", i)
 		}
 		if indexer, exists := indexerList[alias]; exists {
-			if endpoint.Type == indexers.LocalIndexer {
+			if util.IsLocalIndexer(endpoint.Type) {
 				localIndexers["collected-metrics"] = indexer
 			} else {
 				remoteIndexers[alias] = indexer

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cloud-bulldozer/go-commons/v2/indexers"
 	"github.com/cloud-bulldozer/go-commons/v2/version"
 	"github.com/kube-burner/kube-burner/v2/pkg/config"
 	"github.com/kube-burner/kube-burner/v2/pkg/measurements"
@@ -431,7 +430,7 @@ func indexMetrics(uuid string, executedJobs []prometheus.Job, returnMap map[stri
 		prometheusClient.ScrapeJobsMetrics(executedJobs...)
 	}
 	for _, indexer := range configSpec.MetricsEndpoints {
-		if (indexer.Type == indexers.LocalIndexer || indexer.Type == indexers.TSDBIndexer) && indexer.CreateTarball {
+		if util.IsLocalIndexer(indexer.Type) && indexer.CreateTarball {
 			metrics.CreateTarball(indexer.IndexerConfig)
 		}
 	}

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -69,7 +69,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 			} else {
 				indexerAlias = metricsEndpoint.Alias
 			}
-			if metricsEndpoint.Type == indexers.LocalIndexer || metricsEndpoint.Type == indexers.TSDBIndexer {
+			if util.IsLocalIndexer(metricsEndpoint.Type) {
 				if metricsEndpoint.MetricsDirectory == "collected-metrics-{{.UUID}}" {
 					if metricsDirectoryFlag != "" && metricsDirectoryFlag != "collected-metrics-{{.UUID}}" {
 						metricsEndpoint.MetricsDirectory = metricsDirectoryFlag

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -69,7 +69,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 			} else {
 				indexerAlias = metricsEndpoint.Alias
 			}
-			if metricsEndpoint.Type == indexers.LocalIndexer {
+			if metricsEndpoint.Type == indexers.LocalIndexer || metricsEndpoint.Type == indexers.TSDBIndexer {
 				if metricsEndpoint.MetricsDirectory == "collected-metrics-{{.UUID}}" {
 					if metricsDirectoryFlag != "" && metricsDirectoryFlag != "collected-metrics-{{.UUID}}" {
 						metricsEndpoint.MetricsDirectory = metricsDirectoryFlag

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -178,4 +179,13 @@ func NormalizeLabels(labels map[string]string) map[string]string {
 		out[strings.ReplaceAll(k, ".", "_")] = v
 	}
 	return out
+}
+
+func IsLocalIndexer(indexer indexers.IndexerType) bool {
+	switch indexer {
+	case indexers.LocalIndexer, indexers.TSDBIndexer:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -181,6 +181,7 @@ func NormalizeLabels(labels map[string]string) map[string]string {
 	return out
 }
 
+// IsLocalIndexer checks if the given indexer is a local indexer
 func IsLocalIndexer(indexer indexers.IndexerType) bool {
 	switch indexer {
 	case indexers.LocalIndexer, indexers.TSDBIndexer:


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->


- Bug fix
- Optimization


## Description

<!--- Describe your changes in detail -->

The {{.UUID}} placeholder in the metrics directory path was only being substituted for the LocalIndexer type. When using --indexer-type tsdb, the directory was created with the literal name "collected-metrics-{{.UUID}}" instead of "collected-metrics-<actual-uuid>".

Extend the condition in ProcessMetricsScraperConfig to also match TSDBIndexer so both indexer types get the UUID properly substituted.

## Related Tickets & Documents

- Related Issue #
- Closes #1245 
