### PR TITLE
fix(burner): prevent panic in churnObjects with empty object list

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -524,6 +524,10 @@ func (ex *JobExecutor) churnObjects(ctx context.Context) {
 					return timeI.Before(&timeJ)
 				})
 				log.Debugf("Total %s listed: %d, churning %d%%", obj.gvr.Resource, len(objectList.Items), ex.ChurnConfig.Percent)
+				if len(objectList.Items) == 0 {
+					log.Warnf("No %s found with label selector %s, skipping churn cycle", obj.gvr.Resource, labels.FormatLabels(labelSelector))
+					continue
+				}
 				percent := int(math.Max(float64(ex.ChurnConfig.Percent*len(objectList.Items)/100), 1))
 				objectsToDelete := objectList.Items[:percent]
 				log.Infof("Deleting %d %s", len(objectsToDelete), obj.gvr.Resource)

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -529,6 +529,12 @@ func (ex *JobExecutor) churnObjects(ctx context.Context) {
 					continue
 				}
 				percent := int(math.Max(float64(ex.ChurnConfig.Percent*len(objectList.Items)/100), 1))
+				if percent < 0 {
+					percent = 0
+				}
+				if percent > len(objectList.Items) {
+					percent = len(objectList.Items)
+				}
 				objectsToDelete := objectList.Items[:percent]
 				log.Infof("Deleting %d %s", len(objectsToDelete), obj.gvr.Resource)
 				for _, objToDelete := range objectsToDelete {


### PR DESCRIPTION
## Type of change
- Bug fix

## Description
When namespace deletion is blocked by admission webhooks (e.g., Kyverno policies), leftover objects from previous runs may not match the expected label selector. This causes churnObjects to receive an empty object list, leading to a slice bounds out of range panic when calculating deletion percentages with the formula `math.Max(percent*0/100, 1)`.

This change adds a guard clause to check if the object list is empty before attempting any slice operations. When no objects are found matching the label selector, the churn cycle is gracefully skipped with a warning log instead of panicking.

