### PR TITLE
Add captureMetricsPerStep option for incremental load

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -113,14 +113,14 @@ func (ex *JobExecutor) gcGroupObjects(ctx context.Context, grp objectGroupEntry)
 				if !created {
 					continue
 				}
-				CleanupNamespaceResourcesByLabel(ctx, *ex, obj, ns, labelSelector)
+				CleanupNamespacedResourcesByLabel(ctx, *ex, obj, ns, labelSelector)
 			}
 			// Also clean up objects with a fixed namespace
 			if obj.namespace != "" {
-				CleanupNamespaceResourcesByLabel(ctx, *ex, obj, obj.namespace, labelSelector)
+				CleanupNamespacedResourcesByLabel(ctx, *ex, obj, obj.namespace, labelSelector)
 			}
 		} else {
-			CleanupNonNamespacedResourcesByLabel(ctx, *ex, obj, labelSelector)
+			CleanupClusterScopedResourcesByLabel(ctx, *ex, obj, labelSelector)
 		}
 	}
 	// Wait for deletion to complete
@@ -187,7 +187,7 @@ func (ex *JobExecutor) preloadClusterScopedObjects(ctx context.Context) []cluste
 }
 
 // deleteClusterScopedObjects marks cluster-scoped objects in the given iteration range
-// with a deletion label, deletes them using CleanupNonNamespacedResourcesByLabel,
+// with a deletion label, deletes them using CleanupClusterScopedResourcesByLabel,
 // and returns the list of deleted objects for verification.
 func (ex *JobExecutor) deleteClusterScopedObjects(ctx context.Context, caches []clusterScopedObjectCache, iterationStart, iterationEnd int) []churnDeletedObject {
 	delPatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":""}}}`, config.KubeBurnerLabelChurnDelete))
@@ -217,7 +217,7 @@ func (ex *JobExecutor) deleteClusterScopedObjects(ctx context.Context, caches []
 			}
 		}
 
-		CleanupNonNamespacedResourcesByLabel(ctx, *ex, cache.obj, config.KubeBurnerLabelChurnDelete)
+		CleanupClusterScopedResourcesByLabel(ctx, *ex, cache.obj, config.KubeBurnerLabelChurnDelete)
 	}
 	return deletedObjects
 }

--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -282,6 +282,45 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 			IncrementalLoadUUID: stepRunID,
 		})
 
+		// Capture Prometheus metrics and job summary after each step if configured
+		if ex.IncrementalLoad.CaptureMetricsPerStep {
+			log.Infof("Capturing metrics for incremental step (total iterations: %d)", end)
+			stepJob := stepJobs[len(stepJobs)-1]
+
+			elapsedTime := stepJob.End.Sub(stepJob.Start).Round(time.Second).Seconds()
+
+			stepSummaryMetadata := make(map[string]any)
+			for k, v := range metricsScraper.SummaryMetadata {
+				stepSummaryMetadata[k] = v
+			}
+			stepSummaryMetadata["incrementalLoadUUID"] = stepRunID
+
+			jobSummary := JobSummary{
+				UUID:                originalUUID,
+				IncrementalLoadUUID: stepRunID,
+				Timestamp:           stepJob.Start,
+				EndTimestamp:        stepJob.End,
+				ElapsedTime:         elapsedTime,
+				JobConfig:           ex.Job,
+				Metadata:            stepSummaryMetadata,
+				Passed:              true,
+				MetricName:          jobSummaryMetric,
+			}
+			if len(metricsScraper.IndexerList) > 0 {
+				for _, indexer := range metricsScraper.IndexerList {
+					IndexJobSummary([]JobSummary{jobSummary}, indexer)
+				}
+			}
+
+			if len(metricsScraper.PrometheusClients) > 0 {
+				for _, prometheusClient := range metricsScraper.PrometheusClients {
+					if err := prometheusClient.ScrapeJobsMetrics(stepJob); err != nil {
+						log.Errorf("Error scraping metrics for incremental step: %v", err)
+					}
+				}
+			}
+		}
+
 		if stepDelay > 0 {
 			log.Infof("Sleeping %v before next step", stepDelay)
 			time.Sleep(stepDelay)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -277,6 +277,8 @@ type IncrementalLoad struct {
 	Pattern LoadPattern `yaml:"pattern" json:"pattern,omitempty"`
 	// HealthCheckScript optional shell script to run as a health check between steps
 	HealthCheckScript string `yaml:"healthCheckScript" json:"healthCheckScript,omitempty"`
+	// CaptureMetricsPerStep captures Prometheus metrics after each incremental step completes
+	CaptureMetricsPerStep bool `yaml:"captureMetricsPerStep" json:"captureMetricsPerStep,omitempty"`
 }
 
 type LoadPattern struct {


### PR DESCRIPTION
When incremental load is configured with captureMetricsPerStep: true, kube-burner now captures Prometheus metrics and indexes job summaries after each incremental step completes, rather than waiting until all steps are finished. This prevents data loss when a cluster breaks before the final totalIterations is reached.

## Type of change

<!-- Choose a type of change -->

- New feature
- Optimization


## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes  #1244
