### PR TITLE
Allow repeatEveryNIterations with object churn for non-churnable objects

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -473,10 +473,11 @@ func validateGC() error {
 
 // validateRepeatEveryNIterations checks that:
 // 1. All objects in a job have consistent RepeatEveryNIterations values (all =1 or all same non-1 value)
-// 2. RepeatEveryNIterations > 1 is not used with object-based churn mode
+// 2. RepeatEveryNIterations > 1 is not used with object-based churn on churnable objects
 func validateRepeatEveryNIterations() error {
 	for _, job := range configSpec.Jobs {
 		var nonDefaultValue int
+		hasChurnableRepeat := false
 		for _, obj := range job.Objects {
 			if obj.RepeatEveryNIterations > 1 {
 				if nonDefaultValue == 0 {
@@ -485,11 +486,13 @@ func validateRepeatEveryNIterations() error {
 					return fmt.Errorf("job %s: inconsistent RepeatEveryNIterations values. Found both %d and %d. All objects must have RepeatEveryNIterations=1 or the same non-1 value",
 						job.Name, nonDefaultValue, obj.RepeatEveryNIterations)
 				}
+				if obj.Churn {
+					hasChurnableRepeat = true
+				}
 			}
 		}
-		// Check that RepeatEveryNIterations > 1 is not used with object-based churn
-		if nonDefaultValue > 1 && IsChurnEnabled(job) && job.ChurnConfig.Mode == ChurnObjects {
-			return fmt.Errorf("job %s: repeatEveryNIterations > 1 cannot be used with churn mode 'objects'. Use churn mode 'namespaces' instead",
+		if hasChurnableRepeat && IsChurnEnabled(job) && job.ChurnConfig.Mode == ChurnObjects {
+			return fmt.Errorf("job %s: repeatEveryNIterations > 1 cannot be used with churn mode 'objects' on churnable objects. Set churn: false on objects with repeatEveryNIterations or use churn mode 'namespaces' instead",
 				job.Name)
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -472,13 +472,18 @@ func validateGC() error {
 }
 
 // validateRepeatEveryNIterations checks that:
-// 1. All objects in a job have consistent RepeatEveryNIterations values (all =1 or all same non-1 value)
-// 2. RepeatEveryNIterations > 1 is not used with object-based churn on churnable objects
+// 1. RepeatEveryNIterations must be >= 1 (0 or negative would cause divide-by-zero)
+// 2. All objects in a job have consistent RepeatEveryNIterations values (all =1 or all same non-1 value)
+// 3. RepeatEveryNIterations > 1 is not used with object-based churn on churnable objects
 func validateRepeatEveryNIterations() error {
 	for _, job := range configSpec.Jobs {
 		var nonDefaultValue int
 		hasChurnableRepeat := false
 		for _, obj := range job.Objects {
+			if obj.RepeatEveryNIterations < 1 {
+				return fmt.Errorf("job %s: repeatEveryNIterations must be >= 1, got %d",
+					job.Name, obj.RepeatEveryNIterations)
+			}
 			if obj.RepeatEveryNIterations > 1 {
 				if nonDefaultValue == 0 {
 					nonDefaultValue = obj.RepeatEveryNIterations


### PR DESCRIPTION
## Summary

- Skip the `repeatEveryNIterations > 1` validation for objects that have `churn: false`
- Previously, any object with `repeatEveryNIterations > 1` in a job with object-mode churn was rejected, even if the object was explicitly excluded from churning
- This allows grouped execution configs (e.g., CUDNs with `repeatEveryNIterations` and `churn: false`) to coexist with object churn on other objects (e.g., deployments) in a single job

## Test plan

- Tested with kube-burner-ocp cudn-density workload using a single grouped job:
  - Group 1: CUDNs with `repeatEveryNIterations: 5` and `churn: false`
  - Group 2: Workload objects (deployments churnable, infra objects `churn: false`)
  - No churn: rc 0
  - 50% pod churn (mode: objects): rc 0, CUDNs untouched, deployments churned
  - 10% CUDN churn (mode: namespaces): rc 0, entire CUDN groups churned

🤖 Generated with [Claude Code](https://claude.com/claude-code)