### PR TITLE
Iteration progress logs fix

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -471,6 +471,7 @@ func (ex *JobExecutor) runCreateJobGrouped(ctx context.Context, iterationStart, 
 	}
 
 	groups := ex.groupObjectsByNumber()
+	iterationProgress := (iterationEnd - iterationStart) / 10
 
 	// Phase 2: Execute each group in order
 	for _, grp := range groups {
@@ -480,6 +481,7 @@ func (ex *JobExecutor) runCreateJobGrouped(ctx context.Context, iterationStart, 
 
 		log.Infof("Starting group %d with %d object template(s)", grp.number, len(grp.objects))
 		groupCreatedNamespaces := make(map[string]bool)
+		percent := 1
 
 		// Create all objects for all iterations in this group (iteration-first)
 		for i := iterationStart; i < iterationEnd; i++ {
@@ -489,16 +491,12 @@ func (ex *JobExecutor) runCreateJobGrouped(ctx context.Context, iterationStart, 
 			if ctx.Err() != nil {
 				return []error{ctx.Err()}
 			}
-
-			var ns string
-			if ex.nsRequired {
-				if ex.NamespacedIterations {
-					ns = ex.generateNamespace(i)
-				} else {
-					ns = ex.Namespace
-				}
-				groupCreatedNamespaces[ns] = true
+			if ex.JobIterations > 1 && iterationProgress > 0 && i == iterationStart+iterationProgress*percent {
+				log.Infof("Group %d: %v/%v iterations completed", grp.number, i-iterationStart, iterationEnd-iterationStart)
+				percent++
 			}
+
+			ns := ex.resolveGroupIterationNamespace(i, groupCreatedNamespaces)
 
 			log.Debugf("Group %d: Creating object replicas from iteration %d", grp.number, i)
 			for objectIndex, obj := range grp.objects {
@@ -514,14 +512,7 @@ func (ex *JobExecutor) runCreateJobGrouped(ctx context.Context, iterationStart, 
 					}
 					groupCreatedNamespaces[ns] = true
 				}
-				// Use the global object index (ex.objects) to keep kube-burner.io/index stable.
-				globalIndex := objectIndex
-				for idx, o := range ex.objects {
-					if o == obj {
-						globalIndex = idx
-						break
-					}
-				}
+				globalIndex := ex.findGlobalObjectIndex(obj, objectIndex)
 				kbLabels := map[string]string{
 					config.KubeBurnerLabelUUID:         ex.uuid,
 					config.KubeBurnerLabelJob:          ex.Name,
@@ -585,6 +576,33 @@ func (ex *JobExecutor) runCreateJobGrouped(ctx context.Context, iterationStart, 
 	}
 
 	return waitErrors
+}
+
+// resolveGroupIterationNamespace determines the namespace for a given iteration in grouped execution.
+// Namespaces are pre-created in Phase 1, so this only resolves the name.
+func (ex *JobExecutor) resolveGroupIterationNamespace(i int, groupCreatedNamespaces map[string]bool) string {
+	if ex.nsRequired {
+		var ns string
+		if ex.NamespacedIterations {
+			ns = ex.generateNamespace(i)
+		} else {
+			ns = ex.Namespace
+		}
+		groupCreatedNamespaces[ns] = true
+		return ns
+	}
+	return ""
+}
+
+// findGlobalObjectIndex returns the index of obj in ex.objects to keep kube-burner.io/index
+// stable across grouped and non-grouped execution. Falls back to localIndex if not found.
+func (ex *JobExecutor) findGlobalObjectIndex(obj *object, localIndex int) int {
+	for idx, o := range ex.objects {
+		if o == obj {
+			return idx
+		}
+	}
+	return localIndex
 }
 
 // preCreateNamespaces creates all required namespaces upfront before object creation begins.


### PR DESCRIPTION
Fixes #1264
## Summary
`runCreateJobGrouped` does not log iteration progress during object creation,
unlike `runCreateJobDefault` which logs at every 10% of iterations. This leaves
users with no visibility into how far along each group is during grouped execution.
This adds per-group progress logging that mirrors the existing pattern in
`runCreateJobDefault`, prefixed with the group number for context.
## Changes
- Compute `iterationProgress` step size once before the group loop
- Reset a `percent` counter at the start of each group
- Log `"Group N: X/Y iterations completed"` at each 10% increment
- Extract `resolveGroupIterationNamespace` and `findGlobalObjectIndex` helpers
  to keep cyclomatic complexity within the linter threshold (29, limit is 30)
An `iterationProgress > 0` guard prevents spurious output when the iteration
range is less than 10 (where 10% increments are not meaningful).

## Example output
<img width="719" height="337" alt="image_720" src="https://github.com/user-attachments/assets/c2ecd134-27fc-4697-9a8b-0d2495a995d1" />


## Testing
Validated on a 6-node baremetal cluster running `cudn-density` with 20 iterations
and `--namespaces-per-cudn=5`. Progress messages appear correctly for both groups
with the percent counter resetting between groups.
## Notes
- Non-grouped execution (`runCreateJobDefault`) is completely untouched
- The two extracted helpers are pure logic extractions with no behavioral change
- Churn and incremental callers are unaffected — progress adapts to whatever
  iteration range is provided and silently skips when the range is < 10

/cc @mohit-sheth 