### PR TITLE
Fix DeleteCollection failure for cluster-scoped resources that don't …

### DIFF
--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kube-burner/kube-burner/v2/pkg/config"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
@@ -56,7 +57,8 @@ func CleanupNamespacedResourcesByLabel(ctx context.Context, ex JobExecutor, obj 
 	}
 }
 
-// Cleanup non-namespaced resources using executor list
+// Cleanup non-namespaced resources using executor list.
+// Falls back to individual deletion when DeleteCollection is not supported (e.g. Namespaces).
 func CleanupClusterScopedResourcesByLabel(ctx context.Context, ex JobExecutor, object *object, labelSelector string) {
 	resourceInterface := ex.dynamicClient.Resource(object.gvr)
 	err := resourceInterface.DeleteCollection(ctx,
@@ -64,7 +66,29 @@ func CleanupClusterScopedResourcesByLabel(ctx context.Context, ex JobExecutor, o
 		metav1.ListOptions{LabelSelector: labelSelector},
 	)
 	if err != nil {
+		if errors.IsMethodNotSupported(err) {
+			log.Debugf("DeleteCollection not supported for %v, falling back to individual deletion", object.gvr.Resource)
+			deleteClusterScopedResourcesIndividually(ctx, ex, object, labelSelector)
+			return
+		}
 		log.Errorf("Error deleting cluster-scoped %v labeled with %s: %v", object.gvr.Resource, labelSelector, err)
+	}
+}
+
+func deleteClusterScopedResourcesIndividually(ctx context.Context, ex JobExecutor, object *object, labelSelector string) {
+	resourceInterface := ex.dynamicClient.Resource(object.gvr)
+	itemList, err := resourceInterface.List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		log.Errorf("Error listing cluster-scoped %v labeled with %s: %v", object.gvr.Resource, labelSelector, err)
+		return
+	}
+	for _, item := range itemList.Items {
+		log.Debugf("Deleting cluster-scoped %v/%v", object.gvr.Resource, item.GetName())
+		if err := resourceInterface.Delete(ctx, item.GetName(), metav1.DeleteOptions{
+			PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
+		}); err != nil && !errors.IsNotFound(err) {
+			log.Errorf("Error deleting cluster-scoped %v %v: %v", object.gvr.Resource, item.GetName(), err)
+		}
 	}
 }
 

--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -83,11 +83,12 @@ func deleteClusterScopedResourcesIndividually(ctx context.Context, ex JobExecuto
 		return
 	}
 	for _, item := range itemList.Items {
+		ex.limiter.Wait(ctx)
 		log.Debugf("Deleting cluster-scoped %v/%v", object.gvr.Resource, item.GetName())
 		if err := resourceInterface.Delete(ctx, item.GetName(), metav1.DeleteOptions{
 			PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
 		}); err != nil && !errors.IsNotFound(err) {
-			log.Errorf("Error deleting cluster-scoped %v %v: %v", object.gvr.Resource, item.GetName(), err)
+			log.Errorf("Error deleting cluster-scoped %v/%v: %v", object.gvr.Resource, item.GetName(), err)
 		}
 	}
 }


### PR DESCRIPTION
…support it

The Kubernetes API does not support DeleteCollection on certain cluster-scoped resources like Namespaces, returning HTTP 405. This caused GC to fail with "the server does not allow this method on the requested resource" when running delete jobs that target Namespaces. Fall back to listing and deleting resources individually when DeleteCollection returns MethodNotSupported.

Fixes kube-burner-ocp#479

With the fix, now I have 
time="2026-07-01 16:01:00" level=info msg="Triggering job: cudn-density-cleanup-namespaces" file="job.go:146"
time="2026-07-01 16:01:00" level=info msg="Found 5 namespaces with selector kube-burner.io/job=cudn-density; patching them" file="utils.go:269"
time="2026-07-01 16:01:00" level=debug msg="Removing Namespace/cudn-density-4" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Removing Namespace/cudn-density-1" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Removing Namespace/cudn-density-2" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Removing Namespace/cudn-density-0" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Removing Namespace/cudn-density-3" file="delete.go:56"
time="2026-07-01 16:01:00" level=info msg="Job cudn-density-cleanup-namespaces took 0s" file="job.go:224"
time="2026-07-01 16:01:00" level=info msg="Initializing measurements for job: cudn-density-cleanup-cudns" file="factory.go:104"
time="2026-07-01 16:01:00" level=info msg="Triggering job: cudn-density-cleanup-cudns" file="job.go:146"
time="2026-07-01 16:01:00" level=info msg="Found 5 clusteruserdefinednetworks with selector kube-burner.io/job=cudn-density; patching them" file="utils.go:269"
time="2026-07-01 16:01:00" level=debug msg="Removing ClusterUserDefinedNetwork/cudn-4" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Removing ClusterUserDefinedNetwork/cudn-3" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Removing ClusterUserDefinedNetwork/cudn-2" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Removing ClusterUserDefinedNetwork/cudn-1" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Removing ClusterUserDefinedNetwork/cudn-0" file="delete.go:56"
time="2026-07-01 16:01:00" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:02" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:04" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:06" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:08" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:10" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:12" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:14" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:16" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:18" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:20" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:22" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:24" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:26" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:28" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:30" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:32" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:34" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:36" level=debug msg="Waiting for 5 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:38" level=debug msg="Waiting for 3 clusteruserdefinednetworks labeled with kube-burner.io/job=cudn-density to be deleted" file="delete.go:76"
time="2026-07-01 16:01:40" level=info msg="Job cudn-density-cleanup-cudns took 40s" file="job.go:224"
time="2026-07-01 16:01:40" level=info msg="Finished execution with UUID: 2bee9ed1-a854-4f64-97e9-f5f193840a30" file="job.go:305"
time="2026-07-01 16:01:40" level=info msg="Waiting for garbage collection to finish" file="job.go:330"
time="2026-07-01 16:01:40" level=debug msg="DeleteCollection not supported for namespaces, falling back to individual deletion" file="namespaces.go:70"
time="2026-07-01 16:01:40" level=info msg="Deleting 5 namespaces with label: kube-burner.io/job=cudn-density" file="namespaces.go:63"
time="2026-07-01 16:01:40" level=debug msg="Waiting for 5 namespaces labeled with kube-burner.io/job=cudn-density to be deleted" file="namespaces.go:86"
time="2026-07-01 16:01:41" level=debug msg="Waiting for 5 namespaces labeled with kube-burner.io/job=cudn-density to be deleted" file="namespaces.go:86"
time="2026-07-01 16:01:42" level=debug msg="Waiting for 5 namespaces labeled with kube-burner.io/job=cudn-density to be deleted" file="namespaces.go:86"
time="2026-07-01 16:01:43" level=debug msg="Waiting for 5 namespaces labeled with kube-burner.io/job=cudn-density to be deleted" file="namespaces.go:86"
time="2026-07-01 16:01:44" level=debug msg="Waiting for 5 namespaces labeled with kube-burner.io/job=cudn-density to be deleted" file="namespaces.go:86"
time="2026-07-01 16:01:45" level=debug msg="Waiting for 1 namespaces labeled with kube-burner.io/job=cudn-density to be deleted" file="namespaces.go:86"
time="2026-07-01 16:01:46" level=info msg="👋 kube-burner run completed with rc 0 for UUID 2bee9ed1-a854-4f64-97e9-f5f193840a30" file="helpers.go:101"
