### PR TITLE
Bugfix metrics directory config persistence upon using local indexer

### DIFF
--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -76,11 +76,12 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 			if util.IsLocalIndexer(metricsEndpoint.Type) {
 				if metricsEndpoint.MetricsDirectory == "collected-metrics-{{.UUID}}" {
 					if metricsDirectoryFlag != "" && metricsDirectoryFlag != "collected-metrics-{{.UUID}}" {
-						metricsEndpoint.MetricsDirectory = metricsDirectoryFlag
+						scraperConfig.ConfigSpec.MetricsEndpoints[pos].MetricsDirectory = metricsDirectoryFlag
 					} else {
 						// Default value from config.go unmarshalYAML
-						metricsEndpoint.MetricsDirectory = fmt.Sprintf("collected-metrics-%s", scraperConfig.ConfigSpec.GlobalConfig.UUID)
+						scraperConfig.ConfigSpec.MetricsEndpoints[pos].MetricsDirectory = fmt.Sprintf("collected-metrics-%s", scraperConfig.ConfigSpec.GlobalConfig.UUID)
 					}
+					metricsEndpoint = scraperConfig.ConfigSpec.MetricsEndpoints[pos]
 				}
 			}
 			log.Infof("📁 Creating %s indexer: %s", metricsEndpoint.Type, indexerAlias)


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Bug fix
- Optimization

## Description

In the [line 68](https://github.com/kube-burner/kube-burner/blob/d158217dc94a157c5477b1136fc5c4ba9e1a388f/pkg/util/metrics/metrics.go#L68)  `for ... range` loop variable `metricsEndpoint` is a copy of the slice element. When you assign to `metricsEndpoint.MetricsDirectory` , you only mutate the local copy, not `scraperConfig.ConfigSpec.MetricsEndpoints[pos]`.

## Related Tickets & Documents

- Related Issue #
- Closes #1272 
