### PR TITLE
Tarball create and import fixes

### DIFF
--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -65,7 +65,8 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 	if scraperConfig.MetricsEndpoint != "" {
 		scraperConfig.ConfigSpec.MetricsEndpoints = DecodeMetricsEndpoint(scraperConfig.MetricsEndpoint)
 	}
-	for pos, metricsEndpoint := range scraperConfig.ConfigSpec.MetricsEndpoints {
+	for pos := range scraperConfig.ConfigSpec.MetricsEndpoints {
+		metricsEndpoint := &scraperConfig.ConfigSpec.MetricsEndpoints[pos]
 		indexer = nil
 		if metricsEndpoint.Type != "" {
 			if metricsEndpoint.Alias == "" {

--- a/pkg/util/metrics/metrics_test.go
+++ b/pkg/util/metrics/metrics_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+)
+
+func TestProcessMetricsScraperConfigResolvesMetricsDirectory(t *testing.T) {
+	uuid := "test-uuid-1234"
+	configSpec := &config.Spec{
+		GlobalConfig: config.GlobalConfig{
+			UUID: uuid,
+		},
+		MetricsEndpoints: []config.MetricsEndpoint{
+			{
+				IndexerConfig: indexers.IndexerConfig{
+					Type:             indexers.LocalIndexer,
+					MetricsDirectory: "collected-metrics-{{.UUID}}",
+					TarballName:      "tarball.tgz",
+				},
+			},
+		},
+	}
+
+	ProcessMetricsScraperConfig(ScraperConfig{
+		ConfigSpec: configSpec,
+	})
+
+	got := configSpec.MetricsEndpoints[0].MetricsDirectory
+	want := "collected-metrics-" + uuid
+
+	if got != want {
+		t.Errorf("MetricsDirectory not resolved in original configSpec:\n  got:  %q\n  want: %q", got, want)
+	}
+}

--- a/pkg/util/metrics/tarball.go
+++ b/pkg/util/metrics/tarball.go
@@ -23,7 +23,9 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/cloud-bulldozer/go-commons/v2/indexers"
 	log "github.com/sirupsen/logrus"
@@ -44,9 +46,6 @@ func CreateTarball(indexerConfig indexers.IndexerConfig) error {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
-			return nil
-		}
 		info, err := d.Info()
 		if err != nil {
 			return fmt.Errorf("could not get file info for %s: %v", path, err)
@@ -61,9 +60,15 @@ func CreateTarball(indexerConfig indexers.IndexerConfig) error {
 		}
 		// Keep nested directory structure in the tarball.
 		hdr.Name = filepath.ToSlash(relPath)
+		if d.IsDir() {
+			hdr.Name += "/"
+		}
 		err = tarWriter.WriteHeader(hdr)
 		if err != nil {
 			return fmt.Errorf("could not write file header into tarball: %v", err)
+		}
+		if d.IsDir() {
+			return nil
 		}
 		m, err := os.Open(path)
 		if err != nil {
@@ -85,7 +90,6 @@ func CreateTarball(indexerConfig indexers.IndexerConfig) error {
 
 func ImportTarball(tarball string, indexer *indexers.Indexer) error {
 	log.Infof("Importing tarball: %v", tarball)
-	var rawData bytes.Buffer
 	tarballFile, err := os.Open(tarball)
 	if err != nil {
 		return fmt.Errorf("could not open tarball file: %v", err)
@@ -96,12 +100,21 @@ func ImportTarball(tarball string, indexer *indexers.Indexer) error {
 		return fmt.Errorf("could not create gzip reader: %v", err)
 	}
 	tr := tar.NewReader(gzipReader)
+	return readTarDir(tr, indexer)
+}
+
+func readTarDir(tr *tar.Reader, indexer *indexers.Indexer) error {
+	var rawData bytes.Buffer
 	for {
 		var metrics []any
 		hdr, err := tr.Next()
 		// io.EOF returned at the end of file
 		if err == io.EOF {
 			break
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			readTarDir(tr, indexer)
+			continue
 		}
 		_, err = io.Copy(&rawData, tr)
 		json.Unmarshal(rawData.Bytes(), &metrics)
@@ -110,7 +123,10 @@ func ImportTarball(tarball string, indexer *indexers.Indexer) error {
 			return fmt.Errorf("tarball read error: %v", err)
 		}
 		log.Infof("Reading metrics from %s", hdr.Name)
-		resp, err := (*indexer).Index(metrics, indexers.IndexingOpts{})
+		cleanedName := path.Clean(hdr.Name)
+		fileName := path.Base(cleanedName)
+		metricName := strings.Split(fileName, ".json")[0]
+		resp, err := (*indexer).Index(metrics, indexers.IndexingOpts{MetricName: metricName})
 		if err != nil {
 			return err
 		}

--- a/pkg/util/metrics/tarball_test.go
+++ b/pkg/util/metrics/tarball_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTarball(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tarball Suite")
+}
+
+type mockIndexer struct {
+	indexed map[string][]any
+}
+
+func newMockIndexer() *mockIndexer {
+	return &mockIndexer{indexed: make(map[string][]any)}
+}
+
+func (m *mockIndexer) Index(docs []interface{}, opts indexers.IndexingOpts) (string, error) {
+	m.indexed[opts.MetricName] = docs
+	return "indexed", nil
+}
+
+func writeJSONFile(dir, name string, data any) {
+	b, err := json.Marshal(data)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(dir, name), b, 0o644)).To(Succeed())
+}
+
+var _ = Describe("CreateTarball", func() {
+	It("creates tarball from flat directory", func() {
+		tmpDir := GinkgoT().TempDir()
+		metricsDir := filepath.Join(tmpDir, "metrics")
+		tarballPath := filepath.Join(tmpDir, "out.tar.gz")
+
+		writeJSONFile(metricsDir, "cpu.json", []map[string]any{{"value": 42}})
+		writeJSONFile(metricsDir, "mem.json", []map[string]any{{"value": 99}})
+
+		err := CreateTarball(indexers.IndexerConfig{
+			MetricsDirectory: metricsDir,
+			TarballName:      tarballPath,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		info, err := os.Stat(tarballPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Size()).To(BeNumerically(">", 0))
+	})
+
+	It("creates tarball from nested directories", func() {
+		tmpDir := GinkgoT().TempDir()
+		metricsDir := filepath.Join(tmpDir, "metrics")
+		nestedDir := filepath.Join(metricsDir, "sub", "deep")
+		tarballPath := filepath.Join(tmpDir, "out.tar.gz")
+
+		writeJSONFile(metricsDir, "top.json", []map[string]any{{"a": 1}})
+		writeJSONFile(nestedDir, "nested.json", []map[string]any{{"b": 2}})
+
+		err := CreateTarball(indexers.IndexerConfig{
+			MetricsDirectory: metricsDir,
+			TarballName:      tarballPath,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		info, err := os.Stat(tarballPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Size()).To(BeNumerically(">", 0))
+	})
+
+	It("returns error for missing metrics directory", func() {
+		tmpDir := GinkgoT().TempDir()
+		err := CreateTarball(indexers.IndexerConfig{
+			MetricsDirectory: filepath.Join(tmpDir, "nope"),
+			TarballName:      filepath.Join(tmpDir, "out.tar.gz"),
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("CreateTarball and ImportTarball round-trip", func() {
+	It("round-trips flat files", func() {
+		tmpDir := GinkgoT().TempDir()
+		metricsDir := filepath.Join(tmpDir, "metrics")
+		tarballPath := filepath.Join(tmpDir, "out.tar.gz")
+
+		writeJSONFile(metricsDir, "cpu.json", []map[string]any{{"cpu": 0.5}, {"cpu": 0.7}})
+		writeJSONFile(metricsDir, "mem.json", []map[string]any{{"mem": 1024}})
+
+		Expect(CreateTarball(indexers.IndexerConfig{
+			MetricsDirectory: metricsDir,
+			TarballName:      tarballPath,
+		})).To(Succeed())
+
+		mock := newMockIndexer()
+		var idx indexers.Indexer = mock
+		Expect(ImportTarball(tarballPath, &idx)).To(Succeed())
+
+		Expect(mock.indexed).To(HaveLen(2))
+		Expect(mock.indexed).To(HaveKey("cpu"))
+		Expect(mock.indexed).To(HaveKey("mem"))
+		Expect(mock.indexed["cpu"]).To(HaveLen(2))
+		Expect(mock.indexed["mem"]).To(HaveLen(1))
+	})
+
+	It("round-trips nested files", func() {
+		tmpDir := GinkgoT().TempDir()
+		metricsDir := filepath.Join(tmpDir, "metrics")
+		nestedDir := filepath.Join(metricsDir, "subdir")
+		tarballPath := filepath.Join(tmpDir, "out.tar.gz")
+
+		writeJSONFile(metricsDir, "top.json", []map[string]any{{"x": 1}})
+		writeJSONFile(nestedDir, "deep.json", []map[string]any{{"y": 2}})
+
+		Expect(CreateTarball(indexers.IndexerConfig{
+			MetricsDirectory: metricsDir,
+			TarballName:      tarballPath,
+		})).To(Succeed())
+
+		mock := newMockIndexer()
+		var idx indexers.Indexer = mock
+		var err = ImportTarball(tarballPath, &idx)
+		Expect(err).To(Succeed())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(mock.indexed).To(HaveLen(2))
+		Expect(mock.indexed).To(HaveKey("top"))
+		Expect(mock.indexed).To(HaveKey("deep"))
+	})
+})
+
+var _ = Describe("ImportTarball", func() {
+	It("returns error for nonexistent file", func() {
+		mock := newMockIndexer()
+		var idx indexers.Indexer = mock
+		err := ImportTarball("/nonexistent/path.tar.gz", &idx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("could not open tarball file"))
+	})
+})

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -165,9 +165,8 @@ teardown_file() {
   sleep 1m # Sleep is required to prevent collecting metrics right after spinning up the cluster, which can lead to missing datapoints
   run_cmd ${KUBE_BURNER} index --uuid=${UUID} -u http://localhost:9090 -m "metrics-profile.yaml,metrics-profile.yaml" --tarball-name=metrics.tgz --start="$(date -d "-30 seconds" +%s)" --metrics-directory=${METRICS_FOLDER}
   check_file_list ${METRICS_FOLDER}/top2PrometheusCPU.json ${METRICS_FOLDER}/top2PrometheusCPU-start.json ${METRICS_FOLDER}/prometheusRSS.json
-  run_cmd ${KUBE_BURNER} import --tarball=metrics.tgz --es-server=${ES_SERVER} --es-index=${ES_INDEX} --metrics-directory ${METRICS_FOLDER}
   rm -rf ${METRICS_FOLDER:?}/*
-  run_cmd ${KUBE_BURNER} index --uuid=${UUID} -e metrics-endpoints.yaml --es-server=${ES_SERVER} --es-index=${ES_INDEX} --start="$(date -d "-30 seconds" +%s)" --metrics-directory ${METRICS_FOLDER}
+  run_cmd ${KUBE_BURNER} import --tarball=metrics.tgz --metrics-directory ${METRICS_FOLDER}
   check_file_list ${METRICS_FOLDER}/top2PrometheusCPU.json ${METRICS_FOLDER}/prometheusRSS.json ${METRICS_FOLDER}/prometheusRSS.json
   rm -rf ${METRICS_FOLDER:?}/*
 }


### PR DESCRIPTION
## Type of change

- Bug fix
- Enhancement

## Description

A few issues around local indexing and tarball behavior. All to enable `kube-burner import` to be able process a tarball that was created by hand from a local indexing dir, e.g. `tar -czf collected-metrics-UUID.tgz collected-metrics-$UUID/`

Metrics dir with local indexer was updating a MetricsEndpoint copy instead of the original object, so default overwrite was not persisted. This is fix for #1272. While it is an independent fix, it is encountered in the create > import loop to test this PR, so it has also been fixed here.

The bats test was obscuring behavior with the second run of 'index', which recreated the local metrics dir prior to the final verification. Instead, running import ensures they are extracted from the tarball and verified. This scenario has also been added as a ginkgo test that run quickly and don't require cluster access.

CreateTarball now creates a header for the directory, which allows the tests to catch the dir detection in `readTarDir`.

## Related Tickets & Documents

- Closes #1273