### PR TITLE
Fix ci issues

### DIFF
--- a/.github/workflows/builders.yml
+++ b/.github/workflows/builders.yml
@@ -30,11 +30,3 @@ jobs:
 
     - name: Build documentation
       run: mkdocs build
-
-    - name: Install
-      run: sudo make install
-
-    - uses: actions/upload-artifact@v7
-      with:
-        name: kube-burner
-        path: /usr/bin/kube-burner

--- a/.github/workflows/test-k8s.yml
+++ b/.github/workflows/test-k8s.yml
@@ -1,5 +1,5 @@
 # test-k8s.yml
-name: Execute tests on k8s and OCP
+name: Execute tests on k8s
 on:
   pull_request_target:
     branches:
@@ -54,11 +54,13 @@ jobs:
       # This tells Git about origin/main (or master) without downloading the whole repo
       run: git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
 
-    - name: Download kube-burner binary
-      uses: actions/download-artifact@v8
+    - name: Set up Go 1.25
+      uses: actions/setup-go@v7
       with:
-        name: kube-burner
-        path: /tmp/
+        go-version: "1.25"
+
+    - name: Build code
+      run: sudo make build install
 
     - name: Install bats
       uses: bats-core/bats-action@4.0.0
@@ -71,7 +73,6 @@ jobs:
 
     - name: Execute Tests
       run: |
-        chmod +x /tmp/kube-burner
         make test-k8s
       env:
         TERM: linux
@@ -79,4 +80,4 @@ jobs:
         KIND_VERSION: v0.19.0
         K8S_VERSION: ${{matrix.k8s-version}}
         PERFSCALE_PROD_ES_SERVER: ${{ secrets.PERFSCALE_PROD_ES_SERVER }}
-        TEST_BINARY: /tmp/kube-burner
+        TEST_BINARY: /usr/bin/kube-burner


### PR DESCRIPTION
Since the test-k8s workflow is runs independently, we need to build kube-burner from there rather than downloading the artifact.

Tested at https://github.com/rsevilla87/kube-burner/pull/60