### PR TITLE
Skip stopping measurements that failed to start

### DIFF
--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -37,6 +37,7 @@ type MeasurementsFactory struct {
 
 type Measurements struct {
 	MeasurementsMap map[string]Measurement
+	failedStarts    sync.Map // map[string]error
 }
 
 type MeasurementFactory interface {
@@ -143,12 +144,24 @@ func (msf *MeasurementsFactory) NewMeasurements(jobConfig *config.Job, kubeClien
 
 // Start starts registered measurements
 func (ms *Measurements) Start() {
-	var wg sync.WaitGroup
-	for _, measurement := range ms.MeasurementsMap {
-		wg.Add(1)
-		go measurement.Start(&wg)
+	var measurementWg sync.WaitGroup
+	var startResultWg sync.WaitGroup
+	for name, measurement := range ms.MeasurementsMap {
+		ms.failedStarts.Delete(name)
+		measurementWg.Add(1)
+		startResultWg.Add(1)
+		go func(name string, measurement Measurement) {
+			defer startResultWg.Done()
+			if err := measurement.Start(&measurementWg); err != nil {
+				log.Errorf("Failed to start measurement [%s]: %v", name, err)
+				ms.failedStarts.Store(name, err)
+			}
+		}(name, measurement)
 	}
-	wg.Wait()
+	// Preserve the existing Measurement.Start WaitGroup contract for downstream
+	// implementations, then wait for wrappers to record returned errors.
+	measurementWg.Wait()
+	startResultWg.Wait()
 }
 
 func (ms *Measurements) Collect() {
@@ -165,6 +178,10 @@ func (ms *Measurements) Collect() {
 func (ms *Measurements) Stop() error {
 	errs := []error{}
 	for name, measurement := range ms.MeasurementsMap {
+		if startErr, failed := ms.failedStarts.Load(name); failed {
+			log.Warnf("Skipping measurement [%s] because it failed to start: %v", name, startErr)
+			continue
+		}
 		log.Infof("Stopping measurement: %s", name)
 		errs = append(errs, measurement.Stop())
 	}

--- a/pkg/measurements/factory_test.go
+++ b/pkg/measurements/factory_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package measurements
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	log "github.com/sirupsen/logrus"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+type fakeMeasurement struct {
+	startErr     error
+	startCalls   atomic.Int32
+	stopCalls    atomic.Int32
+	collectCalls atomic.Int32
+	metrics      sync.Map
+}
+
+func (f *fakeMeasurement) Start(measurementWg *sync.WaitGroup) error {
+	defer measurementWg.Done()
+	f.startCalls.Add(1)
+	return f.startErr
+}
+
+func (f *fakeMeasurement) Stop() error {
+	f.stopCalls.Add(1)
+	return nil
+}
+
+func (f *fakeMeasurement) Collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+	f.collectCalls.Add(1)
+}
+
+func (f *fakeMeasurement) IsCompatible() bool {
+	return true
+}
+
+func (f *fakeMeasurement) Index(string, map[string]indexers.Indexer) {
+}
+
+func (f *fakeMeasurement) GetMetrics() *sync.Map {
+	return &f.metrics
+}
+
+func TestMeasurementsStopSkipsFailedStarts(t *testing.T) {
+	var logOutput bytes.Buffer
+	logger := log.StandardLogger()
+	previousOutput := logger.Out
+	logger.SetOutput(&logOutput)
+	t.Cleanup(func() {
+		logger.SetOutput(previousOutput)
+	})
+
+	failed := &fakeMeasurement{startErr: errors.New("discovery unavailable")}
+	started := &fakeMeasurement{}
+	ms := Measurements{
+		MeasurementsMap: map[string]Measurement{
+			"failed":  failed,
+			"started": started,
+		},
+	}
+
+	ms.Start()
+	if err := ms.Stop(); err != nil {
+		t.Fatalf("unexpected stop error: %v", err)
+	}
+
+	if failed.startCalls.Load() != 1 {
+		t.Fatalf("failed measurement Start() called %d times, want 1", failed.startCalls.Load())
+	}
+	if failed.stopCalls.Load() != 0 {
+		t.Fatalf("failed measurement Stop() called %d times, want 0", failed.stopCalls.Load())
+	}
+	if started.stopCalls.Load() != 1 {
+		t.Fatalf("started measurement Stop() called %d times, want 1", started.stopCalls.Load())
+	}
+	if !strings.Contains(logOutput.String(), "Failed to start measurement [failed]: discovery unavailable") {
+		t.Fatalf("startup failure was not logged: %s", logOutput.String())
+	}
+	if !strings.Contains(logOutput.String(), "Skipping measurement [failed] because it failed to start: discovery unavailable") {
+		t.Fatalf("failed measurement skip was not logged: %s", logOutput.String())
+	}
+}
+
+func TestMeasurementsStopWithoutStart(t *testing.T) {
+	measurement := &fakeMeasurement{}
+	ms := Measurements{
+		MeasurementsMap: map[string]Measurement{
+			"collect-only": measurement,
+		},
+	}
+
+	ms.Collect()
+	if err := ms.Stop(); err != nil {
+		t.Fatalf("unexpected stop error: %v", err)
+	}
+
+	if measurement.collectCalls.Load() != 1 {
+		t.Fatalf("measurement Collect() called %d times, want 1", measurement.collectCalls.Load())
+	}
+	if measurement.stopCalls.Load() != 1 {
+		t.Fatalf("measurement Stop() called %d times, want 1", measurement.stopCalls.Load())
+	}
+}
+
+func TestMeasurementStopHandlesUninitializedChannels(t *testing.T) {
+	jobConfig := &config.Job{
+		Name:            "test",
+		NamespaceLabels: map[string]string{},
+	}
+	clientSet := k8sfake.NewSimpleClientset()
+
+	originalPortForwarder := proxyPortForwarder
+	originalConnections := connections
+	proxyPortForwarder = nil
+	connections = make(map[string][]connection)
+	t.Cleanup(func() {
+		proxyPortForwarder = originalPortForwarder
+		connections = originalConnections
+	})
+
+	tests := map[string]Measurement{
+		"podLatency": &podLatency{
+			BaseMeasurement: BaseMeasurement{JobConfig: jobConfig},
+		},
+		"serviceLatency": &serviceLatency{
+			BaseMeasurement: BaseMeasurement{
+				JobConfig: jobConfig,
+				ClientSet: clientSet,
+			},
+		},
+		"pprof": &pprof{
+			BaseMeasurement: BaseMeasurement{JobConfig: jobConfig},
+		},
+		"netpolLatency": &netpolLatency{
+			BaseMeasurement: BaseMeasurement{
+				JobConfig: jobConfig,
+				ClientSet: clientSet,
+			},
+		},
+	}
+
+	for name, measurement := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := measurement.Stop(); err != nil {
+				t.Fatalf("unexpected stop error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/measurements/netpol_latency.go
+++ b/pkg/measurements/netpol_latency.go
@@ -579,7 +579,9 @@ func (n *netpolLatency) Stop() error {
 	if len(connections) > 0 {
 		n.processResults()
 	}
-	proxyPortForwarder.CancelPodPortForwarder()
+	if proxyPortForwarder != nil {
+		proxyPortForwarder.CancelPodPortForwarder()
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer func() {
 		cancel()

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -326,7 +326,9 @@ func (p *podLatency) Collect(measurementWg *sync.WaitGroup) {
 
 // Stop stops podLatency measurement
 func (p *podLatency) Stop() error {
-	defer close(p.eventInformerCh)
+	if p.eventInformerCh != nil {
+		defer close(p.eventInformerCh)
+	}
 	return p.StopMeasurement(p.normalizeMetrics, p.getLatency)
 }
 

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -84,12 +84,12 @@ func (p *pprof) Start(measurementWg *sync.WaitGroup) error {
 			return fmt.Errorf("error waiting for DaemonSet to be ready: %v", err)
 		}
 	}
-	p.stopChannel = make(chan bool)
 	if err := p.copyCerts(); err != nil {
 		return fmt.Errorf("error copying certificates: %v", err)
 	}
 	p.getPProf(&wg, fmt.Sprintf("%s-start", p.JobConfig.Name))
 	wg.Wait()
+	p.stopChannel = make(chan bool)
 	go func() {
 		defer close(p.stopChannel)
 		var ticker *time.Ticker
@@ -272,7 +272,9 @@ func (p *pprof) Collect(measurementWg *sync.WaitGroup) {
 }
 
 func (p *pprof) Stop() error {
-	p.stopChannel <- true
+	if p.stopChannel != nil {
+		p.stopChannel <- true
+	}
 	var wg sync.WaitGroup
 	p.getPProf(&wg, fmt.Sprintf("%s-end", p.JobConfig.Name))
 	wg.Wait()

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -249,7 +249,9 @@ func (s *serviceLatency) Stop() error {
 	defer func() {
 		cancel()
 		s.stopWatchers()
-		close(s.stopInformerCh)
+		if s.stopInformerCh != nil {
+			close(s.stopInformerCh)
+		}
 	}()
 	kutil.CleanupNamespacesByLabel(ctx, s.ClientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", types.SvcLatencyNs))
 	s.normalizeMetrics()


### PR DESCRIPTION
Measurements.Start() discarded the error returned by each measurement's
Start(), and Stop() unconditionally stopped every registered measurement. An
early Start() failure (e.g. pod GVR discovery) left
podLatency.eventInformerCh nil, and the subsequent Stop() panicked with "close
of nil channel".

Record failed starts in the factory, log them, and skip those measurements
during Stop(). Add defensive shutdown guards to podLatency, serviceLatency,
pprof and netpolLatency, and create the pprof stop channel only after all
error-returning initialization so a non-nil channel implies a running
receiver.

## Type of change

- [x] Bug fix

## Description

The failure was observed in OpenShift CI run `2082910433362055168`.
With the effective client-go v0.34.3 dependency, informer cache synchronization
retries indefinitely during API failures and returns false only when its stop
channel closes. Pod GVR discovery, before the informer channel exists, is
therefore the reachable early error in this failure chain.

`Collect()` followed by `Stop()` without `Start()` remains supported and is
covered by a regression test. Startup failures are now logged but do not change
the command exit status; propagating them to command return codes is deferred.

Validation:

- `go test ./pkg/measurements/...`
- `go test -race ./pkg/measurements/...`
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `golangci-lint run --new-from-rev HEAD`

Full CI log:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/72356/rehearse-72356-pull-ci-openshift-eng-ocp-qe-perfscale-ci-main-microshift-metal-selfsched-4.22-candidate-x86-node-density/2082910433362055168

## Related Tickets & Documents

- Related Issue #1282
- Closes #1281
