### PR TITLE
Upgrade crun on GitHub Actions runners

### DIFF
--- a/.github/workflows/builders.yml
+++ b/.github/workflows/builders.yml
@@ -20,6 +20,19 @@ jobs:
     - name: Build code
       run: make build
 
+    - name: Upgrade crun (actions/runner-images#14473)
+      run: |
+        CRUN_VERSION=1.28
+        CRUN_URL=https://github.com/containers/crun/releases/download
+        CRUN_URL="${CRUN_URL}/${CRUN_VERSION}"
+        CRUN_SHA256=2aa6b7024a9c9f153895c0d11ae233d3758f54844011c3a039e3e89048d01d42
+        curl -fsSL \
+          "${CRUN_URL}/crun-${CRUN_VERSION}-linux-amd64" \
+          -o /tmp/crun
+        echo "${CRUN_SHA256}  /tmp/crun" | sha256sum --check
+        sudo install -m 0755 /tmp/crun /usr/bin/crun
+        crun --version
+
     - name: Build container images
       run: make images
       env:

--- a/.github/workflows/image-upload.yml
+++ b/.github/workflows/image-upload.yml
@@ -23,6 +23,19 @@ jobs:
       - name: Install dependencies required for multi-arch builds
         run: sudo apt-get update && sudo apt-get install qemu-user-static podman fuse-overlayfs
 
+      - name: Upgrade crun (actions/runner-images#14473)
+        run: |
+          CRUN_VERSION=1.28
+          CRUN_URL=https://github.com/containers/crun/releases/download
+          CRUN_URL="${CRUN_URL}/${CRUN_VERSION}"
+          CRUN_SHA256=2aa6b7024a9c9f153895c0d11ae233d3758f54844011c3a039e3e89048d01d42
+          curl -fsSL \
+            "${CRUN_URL}/crun-${CRUN_VERSION}-linux-amd64" \
+            -o /tmp/crun
+          echo "${CRUN_SHA256}  /tmp/crun" | sha256sum --check
+          sudo install -m 0755 /tmp/crun /usr/bin/crun
+          crun --version
+
       - name: Set up Go 1.25
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/test-k8s.yml
+++ b/.github/workflows/test-k8s.yml
@@ -71,6 +71,19 @@ jobs:
         detik-install: false
         file-install: false
 
+    - name: Upgrade crun (actions/runner-images#14473)
+      run: |
+        CRUN_VERSION=1.28
+        CRUN_URL=https://github.com/containers/crun/releases/download
+        CRUN_URL="${CRUN_URL}/${CRUN_VERSION}"
+        CRUN_SHA256=2aa6b7024a9c9f153895c0d11ae233d3758f54844011c3a039e3e89048d01d42
+        curl -fsSL \
+          "${CRUN_URL}/crun-${CRUN_VERSION}-linux-amd64" \
+          -o /tmp/crun
+        echo "${CRUN_SHA256}  /tmp/crun" | sha256sum --check
+        sudo install -m 0755 /tmp/crun /usr/bin/crun
+        crun --version
+
     - name: Execute Tests
       run: |
         make test-k8s


### PR DESCRIPTION
The `ubuntu-latest` runner image 20260726.254 upgraded Podman from 4.9.3 to 5.8.4 but left crun 1.14.1 at `/usr/bin/crun`, the path Podman uses. Podman 5.8 generates an OCI runtime spec version that crun 1.14 does not understand, so every container build fails with `crun: unknown version specified` regardless of base image. This is tracked in [actions/runner-images#14473](https://github.com/actions/runner-images/issues/14473) and occurred in [#1283's build check](https://github.com/kube-burner/kube-burner/actions/runs/30584661831/job/91013091662).

Install the official crun 1.28 static amd64 binary before containers start in `builders.yml`, `image-upload.yml`, and the matrix job in `test-k8s.yml`. The Bats suite uses Podman directly to start service containers, so it needs the same workaround even though it does not run `make images`. Verify the published SHA-256 before installing the binary.

The release workflow continues to use QEMU for foreign-architecture execution; crun remains the amd64 host runtime for every matrix target. The fetch-only Kubernetes job does not start containers and remains unchanged.

The self-hosted PowerPC workflow keeps its distro-managed runtime because it does not use the affected Ubuntu runner stack. This workaround can be removed once the runner image pairs Podman with a compatible crun.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation
- [x] CI

## Description

- Pin crun 1.28 and verify its official release digest.
- Upgrade crun before containers start in Ubuntu CI, test, and release jobs.
- Leave the self-hosted PowerPC image build unchanged.

## Testing

- Parsed all three changed workflows with `yq`.
- Downloaded the pinned release asset and verified its SHA-256.
- Executed the downloaded binary and confirmed `crun version 1.28`.

`test-k8s.yml` uses `pull_request_target`, so pull request runs execute the workflow definition from the base branch even though they check out the pull request head. The new matrix step therefore becomes active after this change merges; this pull request's matrix run cannot exercise the added step itself.

## Related Tickets & Documents

- Workaround for actions/runner-images#14473
- Unblocks #1283
