### PR TITLE
Pprof replicas

### DIFF
--- a/docs/measurements/index.md
+++ b/docs/measurements/index.md
@@ -1020,6 +1020,8 @@ And the quantiles document has the structure:
 This measurement can be used to collect Golang profiling information from processes running in the cluster. To do so, kube-burner connects to pods labeled with `labelSelector` and running in `namespace`. This measurement uses an implementation similar to `kubectl exec`, and as soon as it connects to one pod it executes the command `curl <pprofURL>` to get the pprof data.
 Profiling information is collected when the measurement starts and stops, but it's possible to collect it in a regular basis by setting the parameter `pprofInterval`. The collected pprof files are downloaded from the pods to the local directory configured by the parameter `pprofDirectory`, by default is `pprof`.
 
+Each `pprofTarget` accepts an optional `replicas` field that limits how many matching instances are collected. The default is `0`, which means collect from all matching pods (or DaemonSet pods for node targets).
+
 As some components require authentication to get profiling information, `kube-burner` provides two different modalities to address it:
 
 - **Bearer token authentication**: This modality is configured by the variable `bearerToken`, which holds a valid Bearer token that will be used by cURL to get pprof data. This method is usually valid with kube-apiserver and kube-controller-managers components
@@ -1042,12 +1044,14 @@ An example of how to configure this measurement to collect pprof HEAP and CPU pr
     - name: kube-apiserver-heap
       namespace: "openshift-kube-apiserver"
       labelSelector: {app: openshift-kube-apiserver}
+      replicas: 1 # collect from a single apiserver instance
       bearerToken: thisIsNotAValidToken
       url: https://localhost:6443/debug/pprof/heap
 
     - name: etcd-heap
       namespace: "openshift-etcd"
       labelSelector: {app: etcd}
+      # replicas omitted or 0 → collect from all etcd pods
       certFile: etcd-peer-pert.crt
       keyFile: etcd-peer-pert.key
       url: https://localhost:2379/debug/pprof/heap
@@ -1072,6 +1076,7 @@ Find below a configuration snippet to collect pprof HEAP profiling data from kub
       node-role.kubernetes.io/worker: ""
     pprofTargets:
     - name: kubelet-heap
+      replicas: 2 # collect from two worker nodes; 0 means all
       url: https://localhost:10250/debug/pprof/heap
     - name: crio-heap
       url: http://localhost/debug/pprof/heap

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -159,8 +159,7 @@ func (p *pprof) copyCerts() error {
 func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 	var pods []corev1.Pod
 	// If DaemonSet is deployed and no explicit label selector is provided, use DaemonSet pods
-	pprofNodeTargets := p.getPprofNodeTargets(target)
-	if pprofNodeTargets != nil { // Node target
+	if pprofNodeTargets := p.getPprofNodeTargets(target); pprofNodeTargets != nil { // Node target
 		labelSelector := labels.Set(pprofNodeTargets).String()
 		podList, err := p.ClientSet.CoreV1().Pods(types.PprofNamespace).List(context.TODO(),
 			metav1.ListOptions{
@@ -186,8 +185,7 @@ func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 	if target.Replicas > 0 && target.Replicas < len(pods) {
 		log.Debugf("Limiting %s pprof collection to %d/%d instances", target.Name, target.Replicas, len(pods))
 		pods = pods[:target.Replicas]
-	}
-	if target.Replicas < 0 {
+	} else {
 		log.Debugf("Limiting %s pprof collection to all instances", target.Name)
 	}
 	sort.Slice(pods, func(i, j int) bool {

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -156,6 +157,7 @@ func (p *pprof) copyCerts() error {
 }
 
 func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
+	var pods []corev1.Pod
 	// If DaemonSet is deployed and no explicit label selector is provided, use DaemonSet pods
 	if p.getPprofNodeTargets(target) != nil { // Node target
 		labelSelector := labels.Set(p.getPprofNodeTargets(target)).String()
@@ -165,14 +167,23 @@ func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 		if err != nil {
 			return []corev1.Pod{}, fmt.Errorf("error listing DaemonSet pods: %v", err)
 		}
-		return podList.Items, nil
+		pods = podList.Items
+	} else {
+		labelSelector := labels.Set(target.LabelSelector).String()
+		podList, err := p.ClientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return []corev1.Pod{}, fmt.Errorf("error listing pods labeled with %s: %v", labelSelector, err)
+		}
+		pods = podList.Items
 	}
-	labelSelector := labels.Set(target.LabelSelector).String()
-	podList, err := p.ClientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
-	if err != nil {
-		return []corev1.Pod{}, fmt.Errorf("error listing pods labeled with %s: %v", labelSelector, err)
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	if target.Replicas > 0 && len(pods) > target.Replicas {
+		log.Infof("Limiting %s pprof collection to %d/%d instances", target.Name, target.Replicas, len(pods))
+		pods = pods[:target.Replicas]
 	}
-	return podList.Items, nil
+	return pods, nil
 }
 
 func (p *pprof) getPProf(wg *sync.WaitGroup, suffix string) {

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -185,8 +185,8 @@ func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 	sort.Slice(pods, func(i, j int) bool {
 		return pods[i].Name < pods[j].Name
 	})
-	if target.Replicas > 0 && len(pods) > target.Replicas {
-		log.Infof("Limiting %s pprof collection to %d/%d instances", target.Name, target.Replicas, len(pods))
+	if target.Replicas > 0 && target.Replicas < len(pods) {
+		log.Debugf("Limiting %s pprof collection to %d/%d instances", target.Name, target.Replicas, len(pods))
 		pods = pods[:target.Replicas]
 	}
 	return pods, nil

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -159,8 +159,9 @@ func (p *pprof) copyCerts() error {
 func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 	var pods []corev1.Pod
 	// If DaemonSet is deployed and no explicit label selector is provided, use DaemonSet pods
-	if p.getPprofNodeTargets(target) != nil { // Node target
-		labelSelector := labels.Set(p.getPprofNodeTargets(target)).String()
+	pprofNodeTargets := p.getPprofNodeTargets(target)
+	if pprofNodeTargets != nil { // Node target
+		labelSelector := labels.Set(pprofNodeTargets).String()
 		podList, err := p.ClientSet.CoreV1().Pods(types.PprofNamespace).List(context.TODO(),
 			metav1.ListOptions{
 				LabelSelector: labelSelector,

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -188,8 +188,6 @@ func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 			return pods[i].Name < pods[j].Name
 		})
 		pods = pods[:target.Replicas]
-	} else {
-		log.Debugf("Limiting %s pprof collection to all instances", target.Name)
 	}
 	return pods, nil
 }

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -184,13 +184,13 @@ func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 	}
 	if target.Replicas > 0 && target.Replicas < len(pods) {
 		log.Debugf("Limiting %s pprof collection to %d/%d instances", target.Name, target.Replicas, len(pods))
+		sort.Slice(pods, func(i, j int) bool {
+			return pods[i].Name < pods[j].Name
+		})
 		pods = pods[:target.Replicas]
 	} else {
 		log.Debugf("Limiting %s pprof collection to all instances", target.Name)
 	}
-	sort.Slice(pods, func(i, j int) bool {
-		return pods[i].Name < pods[j].Name
-	})
 	return pods, nil
 }
 

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -161,16 +161,22 @@ func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 	// If DaemonSet is deployed and no explicit label selector is provided, use DaemonSet pods
 	if p.getPprofNodeTargets(target) != nil { // Node target
 		labelSelector := labels.Set(p.getPprofNodeTargets(target)).String()
-		podList, err := p.ClientSet.CoreV1().Pods(types.PprofNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector,
-			FieldSelector: "status.phase=Running",
-		})
+		podList, err := p.ClientSet.CoreV1().Pods(types.PprofNamespace).List(context.TODO(),
+			metav1.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: "status.phase=Running",
+			})
 		if err != nil {
 			return []corev1.Pod{}, fmt.Errorf("error listing DaemonSet pods: %v", err)
 		}
 		pods = podList.Items
 	} else {
 		labelSelector := labels.Set(target.LabelSelector).String()
-		podList, err := p.ClientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+		podList, err := p.ClientSet.CoreV1().Pods(target.Namespace).List(context.TODO(),
+			metav1.ListOptions{
+				LabelSelector: labelSelector,
+				FieldSelector: "status.phase=Running",
+			})
 		if err != nil {
 			return []corev1.Pod{}, fmt.Errorf("error listing pods labeled with %s: %v", labelSelector, err)
 		}

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -183,13 +183,16 @@ func (p *pprof) getPods(target types.PProftarget) ([]corev1.Pod, error) {
 		}
 		pods = podList.Items
 	}
-	sort.Slice(pods, func(i, j int) bool {
-		return pods[i].Name < pods[j].Name
-	})
 	if target.Replicas > 0 && target.Replicas < len(pods) {
 		log.Debugf("Limiting %s pprof collection to %d/%d instances", target.Name, target.Replicas, len(pods))
 		pods = pods[:target.Replicas]
 	}
+	if target.Replicas < 0 {
+		log.Debugf("Limiting %s pprof collection to all instances", target.Name)
+	}
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
 	return pods, nil
 }
 

--- a/pkg/measurements/types/types.go
+++ b/pkg/measurements/types/types.go
@@ -76,6 +76,8 @@ type PProftarget struct {
 	Namespace string `yaml:"namespace"`
 	// LabelSelector get pprof from pods with these labels
 	LabelSelector map[string]string `yaml:"labelSelector"`
+	// Replicas number of target instances to collect from; 0 means all
+	Replicas int `yaml:"replicas"`
 	// BearerToken bearer token
 	BearerToken string `yaml:"bearerToken"`
 	// URL target URL

--- a/test/k8s/kube-burner-measure.yml
+++ b/test/k8s/kube-burner-measure.yml
@@ -11,4 +11,5 @@ global:
        kubernetes.io/os: linux
      pprofTargets:
        - name: kubelet-heap
+         replicas: 1
          url: https://localhost:10250/debug/pprof/heap


### PR DESCRIPTION
This pull request introduces a new `replicas` field for pprof target configuration, allowing users to limit the number of pod instances from which profiling data is collected. T

**Key changes:**

#### Feature: Limit pprof collection with `replicas`

* Added an optional `replicas` field to the `PProftarget` struct in `types.go`, allowing users to specify how many matching pods to collect profiling data from; `0` (default) means all pods are included.
* Updated the logic in `pprof.go` to sort matching pods by name and select only the first N pods according to the `replicas` value, logging when limiting is applied. [[1]](diffhunk://#diff-8f29187dcd65305ccf3c06a9baaa4aa9635fa84b159631ea17c7052b73f1dd74R160) [[2]](diffhunk://#diff-8f29187dcd65305ccf3c06a9baaa4aa9635fa84b159631ea17c7052b73f1dd74L168-R186)
* Updated documentation in `docs/measurements/index.md` to describe the new `replicas` field, including usage notes and configuration examples for different components. [[1]](diffhunk://#diff-2253f73e9477212fbf76e586b07956f9e70b15c804dca04c0014dff104f1e8e6R1023-R1024) [[2]](diffhunk://#diff-2253f73e9477212fbf76e586b07956f9e70b15c804dca04c0014dff104f1e8e6R1047-R1054) [[3]](diffhunk://#diff-2253f73e9477212fbf76e586b07956f9e70b15c804dca04c0014dff104f1e8e6R1079)
* Added `replicas` to example measurement configurations, including `kube-burner-measure.yml`, to demonstrate limiting collection to a subset of pods.