### PR TITLE
Add tokenFile support for Prometheus token refresh

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -342,7 +342,7 @@ func measureCmd() *cobra.Command {
 func indexCmd() *cobra.Command {
 	var url, metricsEndpoint, metricsProfile, jobName string
 	var start, end int64
-	var username, password, uuid, token, userMetadata string
+	var username, password, uuid, token, tokenFile, userMetadata string
 	var esServer, esIndex, metricsDirectory string
 	var configSpec config.Spec
 	var skipTLSVerify, skipLogFile bool
@@ -375,6 +375,7 @@ func indexCmd() *cobra.Command {
 				Username:      username,
 				Password:      password,
 				Token:         token,
+				TokenFile:     tokenFile,
 				Step:          prometheusStep,
 				Endpoint:      url,
 				Metrics:       metricsProfiles,
@@ -427,6 +428,7 @@ func indexCmd() *cobra.Command {
 	cmd.Flags().StringVar(&uuid, "uuid", "", "Benchmark UUID (generated automatically if not provided)")
 	cmd.Flags().StringVarP(&url, "prometheus-url", "u", "", "Prometheus URL")
 	cmd.Flags().StringVarP(&token, "token", "t", "", "Prometheus Bearer token")
+	cmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to a file containing the Prometheus Bearer token (re-read on each request for token rotation)")
 	cmd.Flags().StringVar(&username, "username", "", "Prometheus username for authentication")
 	cmd.Flags().StringVarP(&password, "password", "p", "", "Prometheus password for basic authentication")
 	cmd.Flags().StringVarP(&metricsProfile, "metrics-profile", "m", "metrics.yml", "comma-separated list of metric profiles")
@@ -489,7 +491,7 @@ func importCmd() *cobra.Command {
 func alertCmd() *cobra.Command {
 	var configSpec config.Spec
 	var err error
-	var url, alertProfile, username, password, uuid, token string
+	var url, alertProfile, username, password, uuid, token, tokenFile string
 	var esServer, esIndex, metricsDirectory string
 	var start, end int64
 	var skipTLSVerify bool
@@ -531,6 +533,7 @@ func alertCmd() *cobra.Command {
 				Username:      username,
 				Password:      password,
 				Token:         token,
+				TokenFile:     tokenFile,
 				SkipTLSVerify: skipTLSVerify,
 			}
 			p, err := prometheus.NewPrometheusClient(configSpec, url, auth, prometheusStep, nil, indexer)
@@ -554,6 +557,7 @@ func alertCmd() *cobra.Command {
 	cmd.Flags().StringVar(&uuid, "uuid", "", "Benchmark UUID (generated automatically if not provided)")
 	cmd.Flags().StringVarP(&url, "prometheus-url", "u", "", "Prometheus URL")
 	cmd.Flags().StringVarP(&token, "token", "t", "", "Prometheus Bearer token")
+	cmd.Flags().StringVar(&tokenFile, "token-file", "", "Path to a file containing the Prometheus Bearer token (re-read on each request for token rotation)")
 	cmd.Flags().StringVar(&username, "username", "", "Prometheus username for authentication")
 	cmd.Flags().StringVarP(&password, "password", "p", "", "Prometheus password for basic authentication")
 	cmd.Flags().StringVarP(&alertProfile, "alert-profile", "a", "alerts.yaml", "Alert profile file or URL")

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -52,6 +52,8 @@ This is the main subcommand; it triggers a new kube-burner benchmark and it supp
 
 !!! Note "Prometheus authentication"
     Both basic and token authentication methods need permissions able to query the given Prometheus endpoint.
+    For long-running workloads where the bearer token may expire, use `tokenFile` instead of `token` in the metrics endpoint configuration.
+    The token is re-read from the file on every Prometheus request, allowing an external process to rotate it without restarting kube-burner.
 
 With the above, running a kube-burner benchmark would be as simple as:
 
@@ -91,6 +93,9 @@ A metrics-endpoints.yaml file with valid keys for the `init` command would look 
   username: foo
   password: bar
   alerts: [alert-profile.yaml]
+- endpoint: http://anotherhost:9090
+  tokenFile: /path/to/token  # Token is re-read on every request for automatic refresh
+  metrics: [metrics.yaml]
 ```
 
 ### Exit codes

--- a/docs/observability/alerting.md
+++ b/docs/observability/alerting.md
@@ -46,6 +46,8 @@ It is possible to look for alerts without triggering a kube-burner workload by u
 
 ```shell
 $ kube-burner check-alerts -u https://prometheus.url.com -t ${token} -a alert-profile.yml
+# Or use --token-file for automatic token refresh:
+# kube-burner check-alerts -u https://prometheus.url.com --token-file /path/to/token -a alert-profile.yml
 INFO[2020-12-10 11:47:23] 👽 Initializing prometheus client
 INFO[2020-12-10 11:47:24] 🔔 Initializing alert manager
 INFO[2020-12-10 11:47:24] Evaluating expression: 'avg_over_time(histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))[5m:]) > 0.01'

--- a/docs/observability/indexing.md
+++ b/docs/observability/indexing.md
@@ -12,6 +12,7 @@ The logic to configure metric collection and indexing is established by the `met
 | `username` | Prometheus username (Basic auth) | `username` |
 | `password` | Prometheus password (Basic auth) | `topSecret` |
 | `token` | Prometheus bearer token (Bearer auth) | `yourTokenDefinition` |
+| `tokenFile` | Path to a file containing the bearer token. The token is re-read on every request, allowing external token rotation for long-running workloads. Takes precedence over `token` if both are set | `/path/to/token` |
 | `step` | Prometheus step size, used when scraping it, by default `30s` | `1m` |
 | `skipTLSVerify` | Skip TLS certificate verification, `true` by default | `true` |
 | `metrics` | List of metrics files | `[metrics.yml, more-metrics.yml]` |
@@ -101,6 +102,8 @@ Example `tsdb` indexer configuration:
 metricsEndpoints:
   - endpoint: https://remote-endpoint:9090
     token: <token>
+    # Or use tokenFile for automatic token refresh:
+    # tokenFile: /path/to/token
     metrics:
     - metrics-profile.yaml
     indexer:
@@ -201,7 +204,7 @@ A valid file provided to the `--metrics-endpoint` looks like this:
   indexer:
     type: local
 - endpoint: http://remotehost:9090 # Another Prometheus endpoint
-  token: <token>
+  tokenFile: /path/to/token # Token is re-read on every request for automatic refresh
   alerts: [alerts.yaml] # Alert profile, when metrics is not defined, defining an indexer is optional
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	dario.cat/mergo v1.0.1
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/cloud-bulldozer/go-commons/v2 v2.3.2
+	github.com/cloud-bulldozer/go-commons/v2 v2.3.8
 	github.com/google/uuid v1.6.0
 	github.com/itchyny/gojq v0.12.16
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObk
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloud-bulldozer/go-commons/v2 v2.3.2 h1:Lw6N4tlp+5oIgOQ5Uk4uQLSpXRqK7i2nPEQYmhjypR0=
-github.com/cloud-bulldozer/go-commons/v2 v2.3.2/go.mod h1:UJt/nJdrpuSQjWNQyou1OmDP1DEFHZx7frNxnNawloY=
+github.com/cloud-bulldozer/go-commons/v2 v2.3.8 h1:q9HdNFTnlbCdA6/y6UGd1jg0HImd6j8K4y9CFFrzQsg=
+github.com/cloud-bulldozer/go-commons/v2 v2.3.8/go.mod h1:UJt/nJdrpuSQjWNQyou1OmDP1DEFHZx7frNxnNawloY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -84,6 +84,7 @@ type MetricsEndpoint struct {
 	Step                   time.Duration `yaml:"step"`
 	SkipTLSVerify          bool          `yaml:"skipTLSVerify"`
 	Token                  string        `yaml:"token"`
+	TokenFile              string        `yaml:"tokenFile"`
 	Username               string        `yaml:"username"`
 	Password               string        `yaml:"password"`
 	Alias                  string        `yaml:"alias"`

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"os"
 	"text/template"
 	"time"
 
@@ -44,7 +45,18 @@ func NewPrometheusClient(configSpec config.Spec, url string, auth Auth, step tim
 		metadata:   metadata,
 	}
 	log.Infof("👽 Initializing prometheus client with URL: %s", url)
-	p.Client, err = prometheus.NewClient(url, auth.Token, auth.Username, auth.Password, auth.SkipTLSVerify)
+	if auth.TokenFile != "" {
+		if _, statErr := os.Stat(auth.TokenFile); statErr != nil {
+			return nil, fmt.Errorf("token file %s does not exist or is not readable: %w", auth.TokenFile, statErr)
+		}
+		if auth.Token != "" {
+			log.Warn("Both 'token' and 'tokenFile' are set; 'tokenFile' takes precedence")
+		}
+		log.Infof("Using token file %s for prometheus authentication", auth.TokenFile)
+		p.Client, err = prometheus.NewClientWithTokenFile(url, auth.TokenFile, auth.Username, auth.Password, auth.SkipTLSVerify)
+	} else {
+		p.Client, err = prometheus.NewClient(url, auth.Token, auth.Username, auth.Password, auth.SkipTLSVerify)
+	}
 	return &p, err
 }
 

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -26,6 +26,7 @@ type Auth struct {
 	Username      string
 	Password      string
 	Token         string
+	TokenFile     string
 	SkipTLSVerify bool
 }
 

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -95,6 +95,7 @@ func ProcessMetricsScraperConfig(scraperConfig ScraperConfig) Scraper {
 				Username:      metricsEndpoint.Username,
 				Password:      metricsEndpoint.Password,
 				Token:         metricsEndpoint.Token,
+				TokenFile:     metricsEndpoint.TokenFile,
 				SkipTLSVerify: metricsEndpoint.SkipTLSVerify,
 			}
 			p, err := prometheus.NewPrometheusClient(*scraperConfig.ConfigSpec, metricsEndpoint.Endpoint, auth, metricsEndpoint.Step, scraperConfig.MetricsMetadata, indexer)

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -85,6 +85,7 @@ func (wh *WorkloadHelper) Run(configFile string) int {
 	for pos := range ConfigSpec.MetricsEndpoints {
 		ConfigSpec.MetricsEndpoints[pos].Endpoint = wh.PrometheusURL
 		ConfigSpec.MetricsEndpoints[pos].Token = wh.PrometheusToken
+		ConfigSpec.MetricsEndpoints[pos].TokenFile = wh.PrometheusTokenFile
 	}
 	metricsScraper := metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
 		ConfigSpec:      &ConfigSpec,

--- a/pkg/workloads/types.go
+++ b/pkg/workloads/types.go
@@ -28,8 +28,9 @@ type Config struct {
 	Timeout         time.Duration
 	MetricsEndpoint string
 	UserMetadata    string
-	PrometheusURL   string
-	PrometheusToken string
+	PrometheusURL       string
+	PrometheusToken     string
+	PrometheusTokenFile string
 }
 
 type WorkloadHelper struct {


### PR DESCRIPTION
## Description

The Prometheus bearer token is set once at startup and never refreshed. For Some providers like GKE/Azure - long-running workloads (>1 hour), the token can expire mid-run causing 401 errors. This adds a tokenFile config field that points to a file re-read on every Prometheus HTTP request, allowing an external process to rotate the token without restarting kube-burner.

- Add tokenFile field to MetricsEndpoint config and Auth struct
- Define PrometheusClient interface (Query/QueryRange) so the Client field can hold either the go-commons static-token client or the new token-file-aware client
- Add tokenFileTransport RoundTripper that reads the token from disk on each request
- Add --token-file CLI flag to index and check-alerts commands
- Wire tokenFile through workloads helper for kube-burner-ocp consumers
- Add unit tests for tokenFileTransport


Explanation of how it works:-

1. kube-burner (pkg/prometheus/prometheus.go) calls prometheus.NewClientWithTokenFile(...) — that's a one-time setup
2. go-commons (prometheus/prometheus.go) stores the tokenFile path in the authTransport struct
3. go-commons authTransport.RoundTrip() — this is the key. It implements http.RoundTripper, which means it runs on every HTTP request the Prometheus client makes

Every time kube-burner does a Query() or QueryRange(), Go's HTTP client calls RoundTrip(), which does:

  if bat.tokenFile != "" {
      tokenBytes, err := os.ReadFile(bat.tokenFile)
      token := strings.TrimSpace(string(tokenBytes))
      req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
  }

  So the file is read fresh on every single Prometheus API call — not cached. That's how the external refresh script's updated token gets picked up automatically.

## Type of change

- New feature
