### PR TITLE
Use bash rather than sh for hooks

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -540,7 +540,7 @@ The `when` field specifies at which stage the hook should execute:
 
 #### Embedded Script Support
 
-When using kube-burner-ocp or any application with an embedded filesystem, hooks can reference scripts stored in the embedded `scripts` directory.
+When using kube-burner-ocp or any application with an embedded filesystem, hooks can reference scripts stored in that filesystem. The directory name is configured by the wrapper when it calls `workloads.NewWorkloadHelper()` (commonly `scripts`; see [wrappers](../wrappers/wrappers.md)).
 
 Set `cmd` to the script name followed by any arguments. Do not prefix the command with `bash` or `sh`; kube-burner runs embedded scripts with `/bin/bash`:
 
@@ -556,7 +556,7 @@ kube-burner resolves the first element of `cmd` as follows:
 
 1. If the path is absolute, execute the command directly as given
 2. If a matching file exists in the current working directory, execute the command directly as given
-3. Otherwise, load the script from the embedded filesystem's `scripts` directory and execute it with `/bin/bash -s -`. Remaining `cmd` entries are passed as positional arguments (`$1`, `$2`, ...)
+3. Otherwise, load the script from the embedded scripts directory configured by the wrapper and execute it with `/bin/bash -s -`. Remaining `cmd` entries are passed as positional arguments (`$1`, `$2`, ...)
 
 Local files always take precedence over embedded scripts. This allows workload authors to bundle scripts with their configurations without requiring users to extract them.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -494,26 +494,26 @@ Hooks allow you to execute external commands at various stages of job execution.
 
 Hooks are configured as a list under the `hooks` field in a job:
 
-| Option       | Description                                             | Type     | Default |
-|--------------|---------------------------------------------------------|----------|---------|
-| `cmd`        | Command and arguments to execute                        | List     | []      |
-| `when`       | Execution stage for the hook                            | String   | ""      |
-| `background` | Run hook in background (non-blocking)                   | Boolean  | false   |
+| Option       | Description                                                                                          | Type     | Default |
+|--------------|------------------------------------------------------------------------------------------------------|----------|---------|
+| `cmd`        | Command and arguments to execute. For [embedded scripts](#embedded-script-support), the first element is the script name and the rest are script arguments. | List     | []      |
+| `when`       | Execution stage for the hook                                                                         | String   | ""      |
+| `background` | Run hook in background (non-blocking)                                                                | Boolean  | false   |
 
 #### Supported Hook Stages
 
 The `when` field specifies at which stage the hook should execute:
 
-| Stage                    | Description                                           |
-|--------------------------|-------------------------------------------------------|
-| `beforeJobExecution`     | Before job objects are created                        |
-| `onEachIteration`        | On each job iteration                                 |
-| `afterJobExecution`      | After job objects are created (before churning)       |
-| `afterChurn`             | After churn operation completes                       |
-| `beforeCleanup`          | Before cleanup/deletion begins                        |
-| `afterCleanup`           | After cleanup/deletion completes                      |
-| `beforeGC`               | Before garbage collection                             |
-| `afterGC`                | After garbage collection                              |
+| Stage                    | Description                                                                                          |
+|--------------------------|------------------------------------------------------------------------------------------------------|
+| `beforeJobExecution`     | Before the job starts creating or processing objects                                                 |
+| `onEachIteration`        | At the start of each iteration of a create job                                                       |
+| `afterJobExecution`      | After the job finishes creating or processing objects (before churn, if enabled)                     |
+| `afterChurn`             | After churn completes on create jobs with churn enabled                                              |
+| `beforeCleanup`          | After the job finishes, before job pause and optional garbage collection                             |
+| `afterCleanup`           | After per-job garbage collection (`gc: true`), or after global GC when `gcMetrics` is enabled        |
+| `beforeGC`               | Before cleanup of leftover namespaces from previous runs (job `cleanup: true`)                       |
+| `afterGC`                | After cleanup of leftover namespaces from previous runs (job `cleanup: true`)                        |
 
 #### Execution Behavior
 
@@ -522,41 +522,43 @@ The `when` field specifies at which stage the hook should execute:
 - Execute sequentially in the order defined
 - Block job execution until completion
 - No timeout by default (respects parent context cancellation only)
-- Errors cause job to fail
+- Errors cause the job to fail immediately
 
 **Background Hooks** (`background: true`):
 
 - All background hooks for a stage start in parallel
-- Job execution continues immediately
-- Results are collected at the end of the job execution
-- Errors are reported but don't block execution
+- Job execution continues immediately without waiting for them
+- Results are collected after all hook stages of the job complete
+- Errors do not interrupt the running job; they are reported at the end and included in the return code
 - Properly cleaned up when parent context is cancelled
 
 **Execution Order:**
 
 1. All background hooks for the stage start in parallel
 2. Foreground hooks execute sequentially after background hooks start
-3. Background hooks are waited on before proceeding to the next major phase
+3. The job continues without waiting for background hooks. They are waited on after all stages of the job complete
 
 #### Embedded Script Support
 
-When using kube-burner-ocp or any application with an embedded filesystem, hooks can reference scripts stored in the embedded `scripts` directory. When a hook command invokes `bash` or `sh` with a script file (e.g., `["bash", "my-script.sh", "arg1"]`), kube-burner will:
+When using kube-burner-ocp or any application with an embedded filesystem, hooks can reference scripts stored in the embedded `scripts` directory.
 
-1. If the script path is absolute, execute it directly
-2. If the script exists in the current working directory, execute it directly
-3. If not found locally, look for it in the embedded filesystem's scripts directory
-
-This allows workload authors to bundle scripts with their configurations without requiring users to manually extract or copy them. Local scripts always take precedence over embedded scripts.
-
-Example using an embedded script:
+Set `cmd` to the script name followed by any arguments. Do not prefix the command with `bash` or `sh`; kube-burner runs embedded scripts with `/bin/bash`:
 
 ```yaml
 jobs:
   - name: my-workload
     hooks:
-      - cmd: ["bash", "setup-environment.sh", "--config", "production"]
+      - cmd: ["setup-environment.sh", "--config", "production"]
         when: beforeJobExecution
 ```
+
+kube-burner resolves the first element of `cmd` as follows:
+
+1. If the path is absolute, execute the command directly as given
+2. If a matching file exists in the current working directory, execute the command directly as given
+3. Otherwise, load the script from the embedded filesystem's `scripts` directory and execute it with `/bin/bash -s -`. Remaining `cmd` entries are passed as positional arguments (`$1`, `$2`, ...)
+
+Local files always take precedence over embedded scripts. This allows workload authors to bundle scripts with their configurations without requiring users to extract them.
 
 #### Example Configuration
 
@@ -566,28 +568,28 @@ jobs:
     jobType: create
     jobIterations: 100
     namespace: workload-ns
-    
+
     hooks:
       # Background monitoring hook - runs throughout deployment
-      - cmd: ["/bin/bash", "/scripts/monitor-resources.sh"]
+      - cmd: ["/bin/bash", "/usr/local/bin/monitor-resources.sh"]
         when: beforeJobExecution
         background: true
-      
+
       # Foreground setup hook - blocks until complete
       - cmd: ["/usr/bin/setup-environment.sh", "--mode=production"]
         when: beforeJobExecution
         background: false
-      
+
       # Per-iteration hook
-      - cmd: ["/bin/bash", "/scripts/log-iteration.sh"]
+      - cmd: ["/bin/bash", "/usr/local/bin/log-iteration.sh"]
         when: onEachIteration
         background: false
-      
+
       # Cleanup verification
-      - cmd: ["/scripts/verify-cleanup.sh"]
+      - cmd: ["/usr/local/bin/verify-cleanup.sh"]
         when: afterCleanup
         background: false
-    
+
     objects:
       - objectTemplate: deployment.yml
         replicas: 10
@@ -606,7 +608,7 @@ hooks:
 **VM provisioning and readiness:**
 ```yaml
 hooks:
-  - cmd: ["/scripts/provision-vm.sh", "--wait-ready"]
+  - cmd: ["/usr/local/bin/provision-vm.sh", "--wait-ready"]
     when: beforeJobExecution
     background: false  # No timeout, waits as long as needed
 ```
@@ -614,7 +616,7 @@ hooks:
 **Data collection during churn:**
 ```yaml
 hooks:
-  - cmd: ["/scripts/collect-churn-metrics.sh"]
+  - cmd: ["/usr/local/bin/collect-churn-metrics.sh"]
     when: afterJobExecution
     background: true
 ```
@@ -622,24 +624,24 @@ hooks:
 **Sequential cleanup verification:**
 ```yaml
 hooks:
-  - cmd: ["/scripts/check-resources.sh"]
+  - cmd: ["/usr/local/bin/check-resources.sh"]
     when: afterCleanup
     background: false
 ```
 
 #### Best Practices
 
-1. **Use background hooks for monitoring** - Start monitoring/data collection in the background while workload runs
+1. **Use background hooks for monitoring** - Start monitoring/data collection in the background while the workload runs
 2. **Use foreground hooks for setup** - Block execution for critical setup steps
-3. **Handle errors appropriately** - Foreground hook failures will fail the job
-4. **Use absolute paths** - Specify full paths to executables and scripts
-5. **Keep hooks lightweight for `onEachIteration`** - This runs for every iteration
+3. **Handle errors appropriately** - Foreground hook failures fail the job immediately; background hook failures fail it after the job completes
+4. **Choose the right path form** - Use absolute paths for local executables. Use a relative script name (without `bash`/`sh`) for scripts bundled in an embedded filesystem
+5. **Keep hooks lightweight for `onEachIteration`** - This runs at the start of every create-job iteration
 
 #### Error Handling
 
 - **Foreground hooks**: Errors stop job execution and are reported immediately
 - **Background hooks**: Errors are collected and reported after job completion
-- All hook errors are included in job summary and return code
+- All hook errors are included in the job summary and return code
 
 ## Job types
 

--- a/docs/wrappers/wrappers.md
+++ b/docs/wrappers/wrappers.md
@@ -13,6 +13,8 @@ wh := workloads.NewWorkloadHelper(config.Config, embedFS, "workloads", "metrics"
 returnCode := wh.Run("workload.yaml")
 ```
 
+The four string arguments after `embedFS` are the paths within the embedded filesystem for workloads, metrics, alerts, and scripts. The scripts directory is used to resolve [hook scripts](../reference/configuration.md#embedded-script-support) and `healthCheckScript` files that are not found locally. It can be any path in the embedded filesystem; `scripts` is only a convention.
+
 ## Customizing template rendering
 
 It's possible to provide custom template rendering functions from a wrapper, this can be done by calling the function `AddRenderingFunction()` of the util package. For example:

--- a/pkg/burner/hooks.go
+++ b/pkg/burner/hooks.go
@@ -112,13 +112,13 @@ func (hm *HookManager) prepareCommand(hook config.Hook) (*exec.Cmd, io.ReadClose
 		}
 		scriptReader = reader
 
-		// Build command: sh -s - <args...>
+		// Build command: bash -s - <args...>
 		// Script is read from stdin; positional params start at hook.Cmd[1].
 		args := []string{"-s", "-"}
 		if len(hook.Cmd) > 1 {
 			args = append(args, hook.Cmd[1:]...)
 		}
-		cmd = exec.CommandContext(hm.ctx, "/bin/sh", args...)
+		cmd = exec.CommandContext(hm.ctx, "/bin/bash", args...)
 		cmd.Stdin = scriptReader
 		log.Debugf("Reading script %s from embedded filesystem", scriptPath)
 


### PR DESCRIPTION
 /bin/sh on Ubuntu 24 is dash, not bash

* Changed the command used in `prepareCommand` in `pkg/burner/hooks.go` to use `/bin/bash` instead of `/bin/sh` for running embedded scripts, improving compatibility with Bash-specific syntax.

Should fix CI issues observed at https://github.com/kube-burner/kube-burner-ocp/pull/480