### PR TITLE
Scrape metrics between incremental steps

### DIFF
--- a/pkg/burner/executor.go
+++ b/pkg/burner/executor.go
@@ -17,10 +17,12 @@ package burner
 import (
 	"context"
 	"sync"
+	"time"
 
 	"maps"
 
 	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/kube-burner/kube-burner/v2/pkg/prometheus"
 	"github.com/kube-burner/kube-burner/v2/pkg/util"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/fileutils"
 	log "github.com/sirupsen/logrus"
@@ -155,4 +157,41 @@ func (ex *JobExecutor) renderTemplateForObjectMultiple(obj *object, iteration, r
 
 	objects, gvks := yamlToUnstructuredMultiple(obj.ObjectTemplate, renderedObj)
 	return objects, gvks
+}
+
+// JobOption configures a prometheus.Job
+type JobOption func(*prometheus.Job)
+
+// WithEnd sets end timestamp
+func WithEnd(end time.Time) JobOption {
+	return func(j *prometheus.Job) {
+		j.End = end
+	}
+}
+
+// WithIncrementalUUID sets incremental step UUID
+func WithIncrementalUUID(uuid string) JobOption {
+	return func(j *prometheus.Job) {
+		j.IncrementalLoadUUID = uuid
+	}
+}
+
+// WithGCJob overrides config with garbage collection job
+func WithGCJob() JobOption {
+	return func(j *prometheus.Job) {
+		j.JobConfig = config.Job{Name: garbageCollectionJob}
+	}
+}
+
+// newScrapeJob creates prometheus.Job with options
+func (ex *JobExecutor) newScrapeJob(start time.Time, opts ...JobOption) prometheus.Job {
+	job := prometheus.Job{
+		Start:     start,
+		JobConfig: ex.Job,
+		UUID:      ex.uuid,
+	}
+	for _, opt := range opts {
+		opt(&job)
+	}
+	return job
 }

--- a/pkg/burner/executor_test.go
+++ b/pkg/burner/executor_test.go
@@ -1,0 +1,297 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/kube-burner/kube-burner/v2/pkg/prometheus"
+)
+
+// TestNewScrapeJobBasic verifies basic job creation with defaults
+func TestNewScrapeJobBasic(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := &JobExecutor{
+		Job: config.Job{
+			Name:      jobName,
+			Namespace: "test-ns",
+		},
+		uuid: testUUID,
+	}
+
+	start := time.Now().UTC()
+	job := ex.newScrapeJob(start)
+
+	if job.Start != start {
+		t.Errorf("expected start=%v, got %v", start, job.Start)
+	}
+	if job.JobConfig.Name != jobName {
+		t.Errorf("expected jobConfig.Name=%q, got %q", jobName, job.JobConfig.Name)
+	}
+	if job.UUID != testUUID {
+		t.Errorf("expected UUID=%q, got %q", testUUID, job.UUID)
+	}
+	if !job.End.IsZero() {
+		t.Errorf("expected End to be zero, got %v", job.End)
+	}
+	if job.IncrementalLoadUUID != "" {
+		t.Errorf("expected IncrementalLoadUUID empty, got %q", job.IncrementalLoadUUID)
+	}
+}
+
+// TestNewScrapeJobWithEnd verifies WithEnd option
+func TestNewScrapeJobWithEnd(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := &JobExecutor{
+		Job:  config.Job{Name: jobName},
+		uuid: testUUID,
+	}
+
+	start := time.Now().UTC()
+	end := start.Add(30 * time.Second)
+	job := ex.newScrapeJob(start, WithEnd(end))
+
+	if job.Start != start {
+		t.Errorf("expected start=%v, got %v", start, job.Start)
+	}
+	if job.End != end {
+		t.Errorf("expected end=%v, got %v", end, job.End)
+	}
+	if job.UUID != testUUID {
+		t.Errorf("expected UUID=%q, got %q", testUUID, job.UUID)
+	}
+}
+
+// TestNewScrapeJobWithIncrementalUUID verifies WithIncrementalUUID option
+func TestNewScrapeJobWithIncrementalUUID(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := &JobExecutor{
+		Job:  config.Job{Name: jobName},
+		uuid: testUUID,
+	}
+
+	stepUUID := "step-12345"
+	start := time.Now().UTC()
+	end := start.Add(15 * time.Second)
+
+	job := ex.newScrapeJob(start, WithEnd(end), WithIncrementalUUID(stepUUID))
+
+	if job.IncrementalLoadUUID != stepUUID {
+		t.Errorf("expected IncrementalLoadUUID=%q, got %q", stepUUID, job.IncrementalLoadUUID)
+	}
+	if job.UUID != testUUID {
+		t.Errorf("expected UUID=%q, got %q", testUUID, job.UUID)
+	}
+	if job.End != end {
+		t.Errorf("expected end=%v, got %v", end, job.End)
+	}
+}
+
+// TestNewScrapeJobWithGCJob verifies WithGCJob option
+func TestNewScrapeJobWithGCJob(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := &JobExecutor{
+		Job:  config.Job{Name: jobName},
+		uuid: testUUID,
+	}
+
+	start := time.Now().UTC()
+	end := start.Add(5 * time.Second)
+
+	job := ex.newScrapeJob(start, WithEnd(end), WithGCJob())
+
+	if job.JobConfig.Name != garbageCollectionJob {
+		t.Errorf("expected JobConfig.Name=%q, got %q", garbageCollectionJob, job.JobConfig.Name)
+	}
+	if job.UUID != testUUID {
+		t.Errorf("expected UUID=%q (from executor), got %q", testUUID, job.UUID)
+	}
+}
+
+// TestNewScrapeJobAllOptions verifies combining all options
+func TestNewScrapeJobAllOptions(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := &JobExecutor{
+		Job:  config.Job{Name: jobName},
+		uuid: testUUID,
+	}
+
+	stepUUID := "gc-step-789"
+	start := time.Now().UTC()
+	end := start.Add(10 * time.Second)
+
+	job := ex.newScrapeJob(start, WithEnd(end), WithIncrementalUUID(stepUUID), WithGCJob())
+
+	if job.Start != start {
+		t.Errorf("expected start=%v, got %v", start, job.Start)
+	}
+	if job.End != end {
+		t.Errorf("expected end=%v, got %v", end, job.End)
+	}
+	if job.IncrementalLoadUUID != stepUUID {
+		t.Errorf("expected IncrementalLoadUUID=%q, got %q", stepUUID, job.IncrementalLoadUUID)
+	}
+	if job.JobConfig.Name != garbageCollectionJob {
+		t.Errorf("expected JobConfig.Name=%q, got %q", garbageCollectionJob, job.JobConfig.Name)
+	}
+	if job.UUID != testUUID {
+		t.Errorf("expected UUID=%q, got %q", testUUID, job.UUID)
+	}
+}
+
+// TestNewScrapeJobMultipleInvocations verifies independent job creation
+func TestNewScrapeJobMultipleInvocations(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := &JobExecutor{
+		Job:  config.Job{Name: jobName},
+		uuid: testUUID,
+	}
+
+	start1 := time.Now().UTC()
+	start2 := start1.Add(20 * time.Second)
+	end1 := start1.Add(10 * time.Second)
+
+	job1 := ex.newScrapeJob(start1, WithEnd(end1), WithIncrementalUUID("step-1"))
+	job2 := ex.newScrapeJob(start2, WithGCJob())
+
+	// Verify job1 unchanged after creating job2
+	if job1.Start != start1 {
+		t.Errorf("job1 start changed, expected %v, got %v", start1, job1.Start)
+	}
+	if job1.End != end1 {
+		t.Errorf("job1 end changed, expected %v, got %v", end1, job1.End)
+	}
+	if job1.IncrementalLoadUUID != "step-1" {
+		t.Errorf("job1 incrementalUUID changed, got %q", job1.IncrementalLoadUUID)
+	}
+	if job1.JobConfig.Name != jobName {
+		t.Errorf("job1 jobConfig changed, got %q", job1.JobConfig.Name)
+	}
+
+	// Verify job2 has correct values
+	if job2.Start != start2 {
+		t.Errorf("job2 start wrong, expected %v, got %v", start2, job2.Start)
+	}
+	if !job2.End.IsZero() {
+		t.Errorf("job2 end should be zero, got %v", job2.End)
+	}
+	if job2.JobConfig.Name != garbageCollectionJob {
+		t.Errorf("job2 should be GC job, got %q", job2.JobConfig.Name)
+	}
+	if job2.IncrementalLoadUUID != "" {
+		t.Errorf("job2 incrementalUUID should be empty, got %q", job2.IncrementalLoadUUID)
+	}
+}
+
+// TestJobCreationEquivalence verifies refactored code produces same jobs as original
+func TestJobCreationEquivalence(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := &JobExecutor{
+		Job: config.Job{
+			Name:      jobName,
+			Namespace: "perf-ns",
+		},
+		uuid: testUUID,
+	}
+
+	start := time.Now().UTC()
+	end := start.Add(25 * time.Second)
+	stepUUID := "step-xyz"
+
+	// New refactored approach
+	newJob := ex.newScrapeJob(start, WithEnd(end), WithIncrementalUUID(stepUUID))
+
+	// Equivalent to old approach (manual construction)
+	oldJob := prometheus.Job{
+		Start:               start,
+		End:                 end,
+		JobConfig:           ex.Job,
+		UUID:                testUUID,
+		IncrementalLoadUUID: stepUUID,
+	}
+
+	// Verify all fields match
+	if newJob.Start != oldJob.Start {
+		t.Errorf("start mismatch: new=%v old=%v", newJob.Start, oldJob.Start)
+	}
+	if newJob.End != oldJob.End {
+		t.Errorf("end mismatch: new=%v old=%v", newJob.End, oldJob.End)
+	}
+	if newJob.UUID != oldJob.UUID {
+		t.Errorf("UUID mismatch: new=%q old=%q", newJob.UUID, oldJob.UUID)
+	}
+	if newJob.IncrementalLoadUUID != oldJob.IncrementalLoadUUID {
+		t.Errorf("IncrementalLoadUUID mismatch: new=%q old=%q", newJob.IncrementalLoadUUID, oldJob.IncrementalLoadUUID)
+	}
+	if newJob.JobConfig.Name != oldJob.JobConfig.Name {
+		t.Errorf("JobConfig.Name mismatch: new=%q old=%q", newJob.JobConfig.Name, oldJob.JobConfig.Name)
+	}
+	if newJob.JobConfig.Namespace != oldJob.JobConfig.Namespace {
+		t.Errorf("JobConfig.Namespace mismatch: new=%q old=%q", newJob.JobConfig.Namespace, oldJob.JobConfig.Namespace)
+	}
+}
+
+// TestGCJobCreationEquivalence verifies GC job creation matches original
+func TestGCJobCreationEquivalence(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := &JobExecutor{
+		Job:  config.Job{Name: jobName},
+		uuid: testUUID,
+	}
+
+	gcStart := time.Now().UTC()
+	gcEnd := gcStart.Add(3 * time.Second)
+	stepUUID := "step-456"
+
+	// New refactored approach
+	newGCJob := ex.newScrapeJob(gcStart, WithEnd(gcEnd), WithIncrementalUUID(stepUUID), WithGCJob())
+
+	// Equivalent to old approach
+	oldGCJob := prometheus.Job{
+		Start: gcStart,
+		End:   gcEnd,
+		JobConfig: config.Job{
+			Name: garbageCollectionJob,
+		},
+		UUID:                testUUID,
+		IncrementalLoadUUID: stepUUID,
+	}
+
+	if newGCJob.Start != oldGCJob.Start {
+		t.Errorf("GC start mismatch: new=%v old=%v", newGCJob.Start, oldGCJob.Start)
+	}
+	if newGCJob.End != oldGCJob.End {
+		t.Errorf("GC end mismatch: new=%v old=%v", newGCJob.End, oldGCJob.End)
+	}
+	if newGCJob.UUID != oldGCJob.UUID {
+		t.Errorf("GC UUID mismatch: new=%q old=%q", newGCJob.UUID, oldGCJob.UUID)
+	}
+	if newGCJob.IncrementalLoadUUID != oldGCJob.IncrementalLoadUUID {
+		t.Errorf("GC IncrementalLoadUUID mismatch: new=%q old=%q", newGCJob.IncrementalLoadUUID, oldGCJob.IncrementalLoadUUID)
+	}
+	if newGCJob.JobConfig.Name != garbageCollectionJob {
+		t.Errorf("expected GC job name, got %q", newGCJob.JobConfig.Name)
+	}
+}

--- a/pkg/burner/helpers_test.go
+++ b/pkg/burner/helpers_test.go
@@ -1,0 +1,21 @@
+package burner
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/google/uuid"
+)
+
+var testWords = []string{"quick", "lazy", "happy", "brave", "swift", "smart", "bold", "calm", "dark", "damp", "early", "fast", "glad", "high", "kind", "light", "neat", "open", "proud", "quiet", "sharp", "tiny", "vast", "warm", "wide"}
+
+func randomJobName() string {
+	w1 := testWords[rand.Intn(len(testWords))]
+	w2 := testWords[rand.Intn(len(testWords))]
+	w3 := testWords[rand.Intn(len(testWords))]
+	return fmt.Sprintf("%s-%s-%s", w1, w2, w3)
+}
+
+func randomUUID() string {
+	return uuid.New().String()
+}

--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/cloud-bulldozer/go-commons/v2/version"
 	"github.com/google/uuid"
 	"github.com/kube-burner/kube-burner/v2/pkg/config"
 	"github.com/kube-burner/kube-burner/v2/pkg/measurements"
@@ -270,17 +271,19 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 			}
 		}
 
-		log.Infof("Running garbage collection for job %s (uuid=%s) after incremental step", ex.Name, ex.uuid)
-		ex.gc(ctx, nil)
-
 		stepEnd := time.Now().UTC()
-		stepJobs = append(stepJobs, prometheus.Job{
-			Start:               stepStart,
-			End:                 stepEnd,
-			JobConfig:           ex.Job,
-			UUID:                originalUUID,
-			IncrementalLoadUUID: stepRunID,
-		})
+		workJob := ex.newScrapeJob(stepStart, WithEnd(stepEnd), WithIncrementalUUID(stepRunID))
+		scrapeAndAppendStepJob(ex, &stepJobs, workJob, stepMetadata, metricsScraper, end)
+
+		log.Infof("Running garbage collection for job %s (uuid=%s) after incremental step", ex.Name, ex.uuid)
+		gcStart := time.Now().UTC()
+		ex.gc(ctx, nil)
+		gcEnd := time.Now().UTC()
+
+		if configSpec.GlobalConfig.GCMetrics {
+			gcJob := ex.newScrapeJob(gcStart, WithEnd(gcEnd), WithIncrementalUUID(stepRunID), WithGCJob())
+			scrapeAndAppendStepJob(ex, &stepJobs, gcJob, stepMetadata, metricsScraper, end)
+		}
 
 		if stepDelay > 0 {
 			log.Infof("Sleeping %v before next step", stepDelay)
@@ -288,6 +291,52 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 		}
 
 		current = end
+	}
+}
+
+// scrapeAndAppendStepJob preserves the result of per-step scraping in the job list.
+// prometheus.Job is a value type, so appending before scrapeStepMetrics would retain
+// a copy with MetricsScraped set to false and cause a second summary and scrape later.
+func scrapeAndAppendStepJob(ex *JobExecutor, stepJobs *[]prometheus.Job, job prometheus.Job, stepMetadata map[string]any, metricsScraper metrics.Scraper, iterations int) {
+	scrapeStepMetrics(ex, &job, stepMetadata, metricsScraper, iterations)
+	*stepJobs = append(*stepJobs, job)
+}
+
+// scrapeStepMetrics handles per-step prometheus scraping and jobSummary indexing.
+func scrapeStepMetrics(ex *JobExecutor, job *prometheus.Job, stepMetadata map[string]any, metricsScraper metrics.Scraper, iterations int) {
+	if !ex.IncrementalLoad.ScrapeMetricsPerStep {
+		return
+	}
+
+	if len(metricsScraper.PrometheusClients) > 0 {
+		scrapeOK := true
+		log.Infof("Scraping prometheus metrics for incremental step (total iterations=%d)", iterations)
+		for _, prometheusClient := range metricsScraper.PrometheusClients {
+			if err := prometheusClient.ScrapeJobsMetrics(*job); err != nil {
+				scrapeOK = false
+				log.Warnf("Error scraping metrics for incremental step: %v", err)
+			}
+		}
+		job.MetricsScraped = scrapeOK
+	}
+
+	if !ex.SkipIndexing {
+		elapsedTime := job.End.Sub(job.Start).Round(time.Second).Seconds()
+		stepSummary := JobSummary{
+			UUID:                job.UUID,
+			IncrementalLoadUUID: job.IncrementalLoadUUID,
+			Timestamp:           job.Start,
+			EndTimestamp:        job.End,
+			ElapsedTime:         elapsedTime,
+			JobConfig:           job.JobConfig,
+			Metadata:            stepMetadata,
+			Passed:              true,
+			Version:             fmt.Sprintf("%v@%v", version.Version, version.GitCommit),
+			MetricName:          jobSummaryMetric,
+		}
+		for _, indexer := range metricsScraper.IndexerList {
+			IndexJobSummary([]JobSummary{stepSummary}, indexer)
+		}
 	}
 }
 

--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -274,13 +274,25 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 		ex.gc(ctx, nil)
 
 		stepEnd := time.Now().UTC()
-		stepJobs = append(stepJobs, prometheus.Job{
+		stepJob := prometheus.Job{
 			Start:               stepStart,
 			End:                 stepEnd,
 			JobConfig:           ex.Job,
 			UUID:                originalUUID,
 			IncrementalLoadUUID: stepRunID,
-		})
+		}
+
+		if ex.IncrementalLoad.ScrapeMetricsPerStep && len(metricsScraper.PrometheusClients) > 0 {
+			log.Infof("Scraping prometheus metrics for incremental step (total iterations=%d)", end)
+			for _, prometheusClient := range metricsScraper.PrometheusClients {
+				if err := prometheusClient.ScrapeJobsMetrics(stepJob); err != nil {
+					log.Errorf("Error scraping metrics for incremental step: %v", err)
+				}
+			}
+			stepJob.MetricsScraped = true
+		}
+
+		stepJobs = append(stepJobs, stepJob)
 
 		if stepDelay > 0 {
 			log.Infof("Sleeping %v before next step", stepDelay)

--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/cloud-bulldozer/go-commons/v2/version"
 	"github.com/google/uuid"
 	"github.com/kube-burner/kube-burner/v2/pkg/config"
 	"github.com/kube-burner/kube-burner/v2/pkg/measurements"
@@ -29,7 +30,6 @@ import (
 	"github.com/kube-burner/kube-burner/v2/pkg/util"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/fileutils"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/metrics"
-	"github.com/cloud-bulldozer/go-commons/v2/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -290,8 +290,6 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 					log.Errorf("Error scraping metrics for incremental step: %v", err)
 				}
 			}
-			stepJob.MetricsScraped = true
-
 			if !ex.SkipIndexing {
 				elapsedTime := stepEnd.Sub(stepStart).Round(time.Second).Seconds()
 				stepSummary := JobSummary{
@@ -310,6 +308,7 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 					IndexJobSummary([]JobSummary{stepSummary}, indexer)
 				}
 			}
+			stepJob.MetricsScraped = true
 		}
 
 		stepJobs = append(stepJobs, stepJob)

--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kube-burner/kube-burner/v2/pkg/util"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/fileutils"
 	"github.com/kube-burner/kube-burner/v2/pkg/util/metrics"
+	"github.com/cloud-bulldozer/go-commons/v2/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -290,6 +291,25 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 				}
 			}
 			stepJob.MetricsScraped = true
+
+			if !ex.SkipIndexing {
+				elapsedTime := stepEnd.Sub(stepStart).Round(time.Second).Seconds()
+				stepSummary := JobSummary{
+					UUID:                originalUUID,
+					IncrementalLoadUUID: stepRunID,
+					Timestamp:           stepStart,
+					EndTimestamp:        stepEnd,
+					ElapsedTime:         elapsedTime,
+					JobConfig:           ex.Job,
+					Metadata:            stepMetadata,
+					Passed:              true,
+					Version:             fmt.Sprintf("%v@%v", version.Version, version.GitCommit),
+					MetricName:          jobSummaryMetric,
+				}
+				for _, indexer := range metricsScraper.IndexerList {
+					IndexJobSummary([]JobSummary{stepSummary}, indexer)
+				}
+			}
 		}
 
 		stepJobs = append(stepJobs, stepJob)

--- a/pkg/burner/incremental.go
+++ b/pkg/burner/incremental.go
@@ -271,11 +271,8 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 			}
 		}
 
-		log.Infof("Running garbage collection for job %s (uuid=%s) after incremental step", ex.Name, ex.uuid)
-		ex.gc(ctx, nil)
-
 		stepEnd := time.Now().UTC()
-		stepJob := prometheus.Job{
+		workJob := prometheus.Job{
 			Start:               stepStart,
 			End:                 stepEnd,
 			JobConfig:           ex.Job,
@@ -283,35 +280,27 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 			IncrementalLoadUUID: stepRunID,
 		}
 
-		if ex.IncrementalLoad.ScrapeMetricsPerStep && len(metricsScraper.PrometheusClients) > 0 {
-			log.Infof("Scraping prometheus metrics for incremental step (total iterations=%d)", end)
-			for _, prometheusClient := range metricsScraper.PrometheusClients {
-				if err := prometheusClient.ScrapeJobsMetrics(stepJob); err != nil {
-					log.Errorf("Error scraping metrics for incremental step: %v", err)
-				}
-			}
-			if !ex.SkipIndexing {
-				elapsedTime := stepEnd.Sub(stepStart).Round(time.Second).Seconds()
-				stepSummary := JobSummary{
-					UUID:                originalUUID,
-					IncrementalLoadUUID: stepRunID,
-					Timestamp:           stepStart,
-					EndTimestamp:        stepEnd,
-					ElapsedTime:         elapsedTime,
-					JobConfig:           ex.Job,
-					Metadata:            stepMetadata,
-					Passed:              true,
-					Version:             fmt.Sprintf("%v@%v", version.Version, version.GitCommit),
-					MetricName:          jobSummaryMetric,
-				}
-				for _, indexer := range metricsScraper.IndexerList {
-					IndexJobSummary([]JobSummary{stepSummary}, indexer)
-				}
-			}
-			stepJob.MetricsScraped = true
-		}
+		scrapeStepMetrics(ex, &workJob, stepMetadata, metricsScraper, end)
+		stepJobs = append(stepJobs, workJob)
 
-		stepJobs = append(stepJobs, stepJob)
+		log.Infof("Running garbage collection for job %s (uuid=%s) after incremental step", ex.Name, ex.uuid)
+		gcStart := time.Now().UTC()
+		ex.gc(ctx, nil)
+		gcEnd := time.Now().UTC()
+
+		if configSpec.GlobalConfig.GCMetrics {
+			gcJob := prometheus.Job{
+				Start: gcStart,
+				End:   gcEnd,
+				JobConfig: config.Job{
+					Name: garbageCollectionJob,
+				},
+				UUID:                originalUUID,
+				IncrementalLoadUUID: stepRunID,
+			}
+			scrapeStepMetrics(ex, &gcJob, stepMetadata, metricsScraper, end)
+			stepJobs = append(stepJobs, gcJob)
+		}
 
 		if stepDelay > 0 {
 			log.Infof("Sleeping %v before next step", stepDelay)
@@ -319,6 +308,42 @@ func (ex *JobExecutor) RunIncrementalCreateJob(
 		}
 
 		current = end
+	}
+}
+
+// scrapeStepMetrics handles per-step prometheus scraping and jobSummary indexing.
+func scrapeStepMetrics(ex *JobExecutor, job *prometheus.Job, stepMetadata map[string]any, metricsScraper metrics.Scraper, iterations int) {
+	if !ex.IncrementalLoad.ScrapeMetricsPerStep {
+		return
+	}
+
+	if len(metricsScraper.PrometheusClients) > 0 {
+		log.Infof("Scraping prometheus metrics for incremental step (total iterations=%d)", iterations)
+		for _, prometheusClient := range metricsScraper.PrometheusClients {
+			if err := prometheusClient.ScrapeJobsMetrics(*job); err != nil {
+				log.Errorf("Error scraping metrics for incremental step: %v", err)
+			}
+		}
+		job.MetricsScraped = true
+	}
+
+	if !ex.SkipIndexing {
+		elapsedTime := job.End.Sub(job.Start).Round(time.Second).Seconds()
+		stepSummary := JobSummary{
+			UUID:                job.UUID,
+			IncrementalLoadUUID: job.IncrementalLoadUUID,
+			Timestamp:           job.Start,
+			EndTimestamp:        job.End,
+			ElapsedTime:         elapsedTime,
+			JobConfig:           ex.Job,
+			Metadata:            stepMetadata,
+			Passed:              true,
+			Version:             fmt.Sprintf("%v@%v", version.Version, version.GitCommit),
+			MetricName:          jobSummaryMetric,
+		}
+		for _, indexer := range metricsScraper.IndexerList {
+			IndexJobSummary([]JobSummary{stepSummary}, indexer)
+		}
 	}
 }
 

--- a/pkg/burner/incremental_test.go
+++ b/pkg/burner/incremental_test.go
@@ -1,0 +1,373 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/kube-burner/kube-burner/v2/pkg/prometheus"
+	"github.com/kube-burner/kube-burner/v2/pkg/util/metrics"
+)
+
+func newTestExecutor(name string, uuid string) JobExecutor {
+	return JobExecutor{
+		Job: config.Job{
+			Name:            name,
+			IncrementalLoad: &config.IncrementalLoad{},
+		},
+		uuid: uuid,
+	}
+}
+
+// TestScrapeStepMetricsDisabled verifies no scraping or indexing when disabled
+func TestScrapeStepMetricsDisabled(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := newTestExecutor(jobName, testUUID)
+
+	mockIdx := &mockIndexer{}
+	scraper := metrics.Scraper{
+		IndexerList: map[string]indexers.Indexer{"mock": mockIdx},
+	}
+
+	start := time.Now().UTC()
+	job := &prometheus.Job{
+		Start:     start,
+		End:       start.Add(10 * time.Second),
+		JobConfig: ex.Job,
+		UUID:      testUUID,
+	}
+
+	scrapeStepMetrics(&ex, job, map[string]any{}, scraper, 100)
+
+	if len(mockIdx.indexed) != 0 {
+		t.Errorf("expected no indexing when scraping disabled, got %d indexes", len(mockIdx.indexed))
+	}
+}
+
+// TestScrapeStepMetricsIndexesJobSummary verifies indexing when enabled with no prometheus
+func TestScrapeStepMetricsIndexesJobSummary(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := newTestExecutor(jobName, testUUID)
+	ex.IncrementalLoad.ScrapeMetricsPerStep = true
+
+	mockIdx := &mockIndexer{}
+	scraper := metrics.Scraper{
+		IndexerList: map[string]indexers.Indexer{"mock": mockIdx},
+	}
+
+	start := time.Now().UTC()
+	end := start.Add(15 * time.Second)
+	stepUUID := "step-abc"
+
+	job := &prometheus.Job{
+		Start:               start,
+		End:                 end,
+		JobConfig:           ex.Job,
+		UUID:                testUUID,
+		IncrementalLoadUUID: stepUUID,
+	}
+
+	scrapeStepMetrics(&ex, job, map[string]any{"custom": "metadata"}, scraper, 150)
+
+	if len(mockIdx.indexed) != 1 {
+		t.Fatalf("expected 1 index call, got %d", len(mockIdx.indexed))
+	}
+	if mockIdx.indexed[0].MetricName != jobSummaryMetric {
+		t.Errorf("expected metricName %q, got %q", jobSummaryMetric, mockIdx.indexed[0].MetricName)
+	}
+
+	if len(mockIdx.docs[0]) != 1 {
+		t.Fatalf("expected 1 document indexed, got %d", len(mockIdx.docs[0]))
+	}
+
+	doc := mockIdx.docs[0][0].(map[string]any)
+	if doc["uuid"] != testUUID {
+		t.Errorf("expected uuid %q, got %v", testUUID, doc["uuid"])
+	}
+	if doc["incrementalLoadUUID"] != stepUUID {
+		t.Errorf("expected incrementalLoadUUID %q, got %v", stepUUID, doc["incrementalLoadUUID"])
+	}
+	if doc["custom"] != "metadata" {
+		t.Errorf("expected custom metadata in doc, got %v", doc["custom"])
+	}
+	if doc["passed"] != true {
+		t.Errorf("expected passed=true, got %v", doc["passed"])
+	}
+	if doc["elapsedTime"] != 15.0 {
+		t.Errorf("expected elapsedTime=15, got %v", doc["elapsedTime"])
+	}
+}
+
+// TestScrapeStepMetricsSkipIndexing verifies no indexing when SkipIndexing=true
+func TestScrapeStepMetricsSkipIndexing(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := newTestExecutor(jobName, testUUID)
+	ex.IncrementalLoad.ScrapeMetricsPerStep = true
+	ex.SkipIndexing = true
+
+	mockIdx := &mockIndexer{}
+	scraper := metrics.Scraper{
+		IndexerList: map[string]indexers.Indexer{"mock": mockIdx},
+	}
+
+	start := time.Now().UTC()
+	job := &prometheus.Job{
+		Start:     start,
+		End:       start.Add(5 * time.Second),
+		JobConfig: ex.Job,
+		UUID:      testUUID,
+	}
+
+	scrapeStepMetrics(&ex, job, map[string]any{}, scraper, 50)
+
+	if len(mockIdx.indexed) != 0 {
+		t.Errorf("expected no indexing with SkipIndexing=true, got %d indexes", len(mockIdx.indexed))
+	}
+}
+
+// TestScrapeStepMetricsNoPrometheusClients verifies MetricsScraped stays false with no clients
+func TestScrapeStepMetricsNoPrometheusClients(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := newTestExecutor(jobName, testUUID)
+	ex.IncrementalLoad.ScrapeMetricsPerStep = true
+
+	mockIdx := &mockIndexer{}
+	scraper := metrics.Scraper{
+		IndexerList: map[string]indexers.Indexer{"mock": mockIdx},
+	}
+
+	start := time.Now().UTC()
+	job := &prometheus.Job{
+		Start:     start,
+		End:       start.Add(7 * time.Second),
+		JobConfig: ex.Job,
+		UUID:      testUUID,
+	}
+
+	scrapeStepMetrics(&ex, job, map[string]any{}, scraper, 70)
+
+	if job.MetricsScraped {
+		t.Error("expected job.MetricsScraped=false when no prometheus clients")
+	}
+
+	// Indexing should still happen
+	if len(mockIdx.indexed) != 1 {
+		t.Errorf("expected indexing even without prometheus, got %d", len(mockIdx.indexed))
+	}
+}
+
+func TestRunIncrementalCreateJobPreservesPerStepScrapeState(t *testing.T) {
+	ex := newTestExecutor(randomJobName(), randomUUID())
+	ex.IncrementalLoad = &config.IncrementalLoad{
+		StartIterations:      1,
+		TotalIterations:      1,
+		ScrapeMetricsPerStep: true,
+		Pattern: config.LoadPattern{
+			Type:   config.LinearPattern,
+			Linear: &config.LinearLoadConfig{StepSize: 1},
+		},
+	}
+	provider := newTestKubeClientProvider(t)
+	ex.clientSet, _ = provider.DefaultClientSet()
+	ex.createdNamespaces = make(map[string]bool)
+	mockIdx := &mockIndexer{}
+	scraper := metrics.Scraper{
+		IndexerList:       map[string]indexers.Indexer{"mock": mockIdx},
+		PrometheusClients: []*prometheus.Prometheus{{}},
+	}
+
+	configSpec := config.Spec{GlobalConfig: config.GlobalConfig{GCMetrics: true}}
+	_, jobs := ex.RunIncrementalCreateJob(context.Background(), NewIterationCalculator(ex), nil, provider, nil, ex.Name, scraper, configSpec)
+	indexMetrics(ex.uuid, jobs, map[string]returnPair{}, scraper, config.Spec{}, true, "", false)
+
+	if len(jobs) != 2 {
+		t.Fatalf("expected incremental work and GC jobs, got %d", len(jobs))
+	}
+	for _, job := range jobs {
+		if !job.MetricsScraped {
+			t.Errorf("%s job was appended before its scrape result was recorded", job.JobConfig.Name)
+		}
+	}
+
+	var summaryCount int
+	for _, docs := range mockIdx.docs {
+		summaryCount += len(docs)
+	}
+	if summaryCount != 2 {
+		t.Errorf("expected only the two per-step job summaries, got %d", summaryCount)
+	}
+}
+
+func newTestKubeClientProvider(t *testing.T) *config.KubeClientProvider {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/version":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"gitVersion":"v1.30.0"}`))
+		case "/healthz":
+			_, _ = w.Write([]byte("ok"))
+		case "/api/v1/nodes":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"apiVersion":"v1","kind":"NodeList","items":[]}`))
+		case "/api/v1/namespaces":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"apiVersion":"v1","kind":"NamespaceList","items":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	kubeconfig := fmt.Sprintf("apiVersion: v1\nclusters:\n- cluster:\n    server: %s\n    insecure-skip-tls-verify: true\n  name: test\ncontexts:\n- context:\n    cluster: test\n    user: test\n  name: test\ncurrent-context: test\nkind: Config\nusers:\n- name: test\n  user: {}\n", server.URL)
+	configPath := t.TempDir() + "/kubeconfig"
+	if err := os.WriteFile(configPath, []byte(kubeconfig), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	return config.NewKubeClientProvider(configPath, "")
+}
+
+// TestIncrementalStepJobsEquivalence verifies refactored step job creation matches original
+func TestIncrementalStepJobsEquivalence(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := newTestExecutor(jobName, testUUID)
+
+	stepStart := time.Now().UTC()
+	stepEnd := stepStart.Add(30 * time.Second)
+	stepRunID := "step-run-123"
+
+	// New: using newScrapeJob with options (as in current code)
+	workJob := ex.newScrapeJob(stepStart, WithEnd(stepEnd), WithIncrementalUUID(stepRunID))
+
+	// Old: manual construction (as in code before this branch)
+	oldJob := prometheus.Job{
+		Start:               stepStart,
+		End:                 stepEnd,
+		JobConfig:           ex.Job,
+		UUID:                testUUID,
+		IncrementalLoadUUID: stepRunID,
+	}
+
+	assertJobsEqual(t, "work", workJob, oldJob)
+}
+
+// TestIncrementalGCJobsEquivalence verifies refactored GC job creation matches original
+func TestIncrementalGCJobsEquivalence(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := newTestExecutor(jobName, testUUID)
+
+	gcStart := time.Now().UTC()
+	gcEnd := gcStart.Add(5 * time.Second)
+	stepRunID := "step-run-456"
+
+	// New: using newScrapeJob with options
+	gcJob := ex.newScrapeJob(gcStart, WithEnd(gcEnd), WithIncrementalUUID(stepRunID), WithGCJob())
+
+	// Old: manual construction
+	oldGCJob := prometheus.Job{
+		Start: gcStart,
+		End:   gcEnd,
+		JobConfig: config.Job{
+			Name: garbageCollectionJob,
+		},
+		UUID:                testUUID,
+		IncrementalLoadUUID: stepRunID,
+	}
+
+	assertJobsEqual(t, "gc", gcJob, oldGCJob)
+}
+
+// TestIncrementalStepJobsAppendOrder verifies append order matches original pattern
+func TestIncrementalStepJobsAppendOrder(t *testing.T) {
+	jobName := randomJobName()
+	testUUID := randomUUID()
+	ex := newTestExecutor(jobName, testUUID)
+
+	now := time.Now().UTC()
+	var stepJobs []prometheus.Job
+
+	// Simulate two incremental steps with GC
+	for i := range 2 {
+		stepStart := now.Add(time.Duration(i*60) * time.Second)
+		stepEnd := stepStart.Add(30 * time.Second)
+		stepRunID := "step-" + string(rune('a'+i))
+
+		workJob := ex.newScrapeJob(stepStart, WithEnd(stepEnd), WithIncrementalUUID(stepRunID))
+		stepJobs = append(stepJobs, workJob)
+
+		gcStart := stepEnd
+		gcEnd := gcStart.Add(5 * time.Second)
+		gcJob := ex.newScrapeJob(gcStart, WithEnd(gcEnd), WithIncrementalUUID(stepRunID), WithGCJob())
+		stepJobs = append(stepJobs, gcJob)
+	}
+
+	if len(stepJobs) != 4 {
+		t.Fatalf("expected 4 step jobs (2 work + 2 gc), got %d", len(stepJobs))
+	}
+
+	// Verify ordering: work, gc, work, gc
+	if stepJobs[0].JobConfig.Name != jobName {
+		t.Errorf("job[0] should be work job, got %q", stepJobs[0].JobConfig.Name)
+	}
+	if stepJobs[1].JobConfig.Name != garbageCollectionJob {
+		t.Errorf("job[1] should be gc job, got %q", stepJobs[1].JobConfig.Name)
+	}
+	if stepJobs[2].JobConfig.Name != jobName {
+		t.Errorf("job[2] should be work job, got %q", stepJobs[2].JobConfig.Name)
+	}
+	if stepJobs[3].JobConfig.Name != garbageCollectionJob {
+		t.Errorf("job[3] should be gc job, got %q", stepJobs[3].JobConfig.Name)
+	}
+
+	// All should share UUID
+	for i, j := range stepJobs {
+		if j.UUID != testUUID {
+			t.Errorf("job[%d] UUID mismatch: expected %q, got %q", i, testUUID, j.UUID)
+		}
+	}
+}
+
+func assertJobsEqual(t *testing.T, label string, got, want prometheus.Job) {
+	t.Helper()
+	if got.Start != want.Start {
+		t.Errorf("%s: Start mismatch: got=%v want=%v", label, got.Start, want.Start)
+	}
+	if got.End != want.End {
+		t.Errorf("%s: End mismatch: got=%v want=%v", label, got.End, want.End)
+	}
+	if got.UUID != want.UUID {
+		t.Errorf("%s: UUID mismatch: got=%q want=%q", label, got.UUID, want.UUID)
+	}
+	if got.IncrementalLoadUUID != want.IncrementalLoadUUID {
+		t.Errorf("%s: IncrementalLoadUUID mismatch: got=%q want=%q", label, got.IncrementalLoadUUID, want.IncrementalLoadUUID)
+	}
+	if got.JobConfig.Name != want.JobConfig.Name {
+		t.Errorf("%s: JobConfig.Name mismatch: got=%q want=%q", label, got.JobConfig.Name, want.JobConfig.Name)
+	}
+}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -128,11 +128,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 			if jobExecutor.JobType == config.CreationJob && config.IsGroupedEnabled(jobExecutor.Job) {
 				jobExecutor.GroupWindows = &[]config.GroupWindow{}
 			}
-			executedJobs = append(executedJobs, prometheus.Job{
-				Start:     time.Now().UTC(),
-				JobConfig: jobExecutor.Job,
-				UUID:      jobExecutor.uuid,
-			})
+			executedJobs = append(executedJobs, jobExecutor.newScrapeJob(time.Now().UTC()))
 			watcherManager := watchers.NewWatcherManager(restConfig, rate.NewLimiter(rate.Limit(jobExecutor.QPS), jobExecutor.Burst))
 			for idx, watcher := range jobExecutor.Watchers {
 				for replica := range watcher.Replicas {
@@ -169,11 +165,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 					executedJobs = append(executedJobs, stepJobs...)
 					executedJobs[jobIdx].End = stepJobs[0].Start
 					jobIdx = len(executedJobs)
-					executedJobs = append(executedJobs, prometheus.Job{
-						Start:     stepJobs[len(stepJobs)-1].End,
-						JobConfig: jobExecutor.Job,
-						UUID:      jobExecutor.uuid,
-					})
+					executedJobs = append(executedJobs, jobExecutor.newScrapeJob(stepJobs[len(stepJobs)-1].End))
 				}
 				jobExecutor.executeHooksForJobStage(config.HookAfterJobExecution, &errs, &innerRC)
 
@@ -280,13 +272,9 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 					errs, innerRC = jobExecutor.CollectAndLogBackgroundHookResults(errs, innerRC)
 				}
 				// We add an extra dummy job to executedJobs to index metrics from this stage
-				executedJobs = append(executedJobs, prometheus.Job{
-					Start: cleanupStart,
-					End:   time.Now().UTC(),
-					JobConfig: config.Job{
-						Name: garbageCollectionJob,
-					},
-				})
+				if len(jobExecutors) > 0 {
+					executedJobs = append(executedJobs, jobExecutors[0].newScrapeJob(cleanupStart, WithEnd(time.Now().UTC()), WithGCJob()))
+				}
 			}
 		}
 		// Make sure that measurements have indexed their stuff before we index metrics
@@ -387,7 +375,7 @@ func indexMetrics(uuid string, executedJobs []prometheus.Job, returnMap map[stri
 	var jobSummaries []JobSummary
 
 	for _, job := range executedJobs {
-		if !job.JobConfig.SkipIndexing {
+		if !job.JobConfig.SkipIndexing && !job.MetricsScraped {
 			if value, exists := returnMap[job.JobConfig.Name]; exists && !isTimeout {
 				innerRC = value.innerRC == 0
 				executionErrors = value.executionErrors
@@ -413,9 +401,16 @@ func indexMetrics(uuid string, executedJobs []prometheus.Job, returnMap map[stri
 	for _, indexer := range metricsScraper.IndexerList {
 		IndexJobSummary(jobSummaries, indexer)
 	}
-	// Scrape prometheus metrics for all executed jobs
+	var unscrapedJobs []prometheus.Job
+	for _, job := range executedJobs {
+		if !job.MetricsScraped {
+			unscrapedJobs = append(unscrapedJobs, job)
+		}
+	}
 	for _, prometheusClient := range metricsScraper.PrometheusClients {
-		prometheusClient.ScrapeJobsMetrics(executedJobs...)
+		if err := prometheusClient.ScrapeJobsMetrics(unscrapedJobs...); err != nil {
+			log.Warnf("Error scraping job metrics: %v", err)
+		}
 	}
 	for _, indexer := range configSpec.MetricsEndpoints {
 		if util.IsLocalIndexer(indexer.Type) && indexer.CreateTarball {

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -387,7 +387,7 @@ func indexMetrics(uuid string, executedJobs []prometheus.Job, returnMap map[stri
 	var jobSummaries []JobSummary
 
 	for _, job := range executedJobs {
-		if !job.JobConfig.SkipIndexing {
+		if !job.JobConfig.SkipIndexing && !job.MetricsScraped {
 			if value, exists := returnMap[job.JobConfig.Name]; exists && !isTimeout {
 				innerRC = value.innerRC == 0
 				executionErrors = value.executionErrors

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -413,9 +413,14 @@ func indexMetrics(uuid string, executedJobs []prometheus.Job, returnMap map[stri
 	for _, indexer := range metricsScraper.IndexerList {
 		IndexJobSummary(jobSummaries, indexer)
 	}
-	// Scrape prometheus metrics for all executed jobs
+	var unscrapedJobs []prometheus.Job
+	for _, job := range executedJobs {
+		if !job.MetricsScraped {
+			unscrapedJobs = append(unscrapedJobs, job)
+		}
+	}
 	for _, prometheusClient := range metricsScraper.PrometheusClients {
-		prometheusClient.ScrapeJobsMetrics(executedJobs...)
+		prometheusClient.ScrapeJobsMetrics(unscrapedJobs...)
 	}
 	for _, indexer := range configSpec.MetricsEndpoints {
 		if util.IsLocalIndexer(indexer.Type) && indexer.CreateTarball {

--- a/pkg/burner/metadata_test.go
+++ b/pkg/burner/metadata_test.go
@@ -1,0 +1,267 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/kube-burner/kube-burner/v2/pkg/prometheus"
+	"github.com/kube-burner/kube-burner/v2/pkg/util/metrics"
+)
+
+const testUuid = "test-uuid"
+
+type mockIndexer struct {
+	indexed []indexers.IndexingOpts
+	docs    [][]interface{}
+}
+
+func (m *mockIndexer) Index(docs []interface{}, opts indexers.IndexingOpts) (string, error) {
+	m.indexed = append(m.indexed, opts)
+	m.docs = append(m.docs, docs)
+	return "indexed", nil
+}
+
+func TestIndexJobSummary(t *testing.T) {
+	now := time.Now().UTC()
+	summaries := []JobSummary{
+		{
+			UUID:                testUuid,
+			IncrementalLoadUUID: "step-uuid-1",
+			Timestamp:           now,
+			EndTimestamp:        now.Add(30 * time.Second),
+			ElapsedTime:         30,
+			JobConfig:           config.Job{Name: "test-job"},
+			Metadata:            map[string]any{"incrementalLoadUUID": "step-uuid-1", "platform": "test"},
+			Passed:              true,
+			Version:             "v1.0@abc123",
+			MetricName:          jobSummaryMetric,
+		},
+	}
+
+	mock := &mockIndexer{}
+	IndexJobSummary(summaries, mock)
+
+	if len(mock.indexed) != 1 {
+		t.Fatalf("expected 1 index call, got %d", len(mock.indexed))
+	}
+	if mock.indexed[0].MetricName != jobSummaryMetric {
+		t.Errorf("expected metricName %q, got %q", jobSummaryMetric, mock.indexed[0].MetricName)
+	}
+	if len(mock.docs[0]) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(mock.docs[0]))
+	}
+
+	doc := mock.docs[0][0].(map[string]any)
+	if doc["uuid"] != testUuid {
+		t.Errorf("expected uuid %q, got %v", testUuid, doc["uuid"])
+	}
+	if doc["incrementalLoadUUID"] != "step-uuid-1" {
+		t.Errorf("expected incrementalLoadUUID %q, got %v", "step-uuid-1", doc["incrementalLoadUUID"])
+	}
+	if doc["metricName"] != jobSummaryMetric {
+		t.Errorf("expected metricName %q, got %v", jobSummaryMetric, doc["metricName"])
+	}
+	if doc["passed"] != true {
+		t.Errorf("expected passed=true, got %v", doc["passed"])
+	}
+	if doc["platform"] != "test" {
+		t.Errorf("expected metadata platform=test, got %v", doc["platform"])
+	}
+	if doc["version"] != "v1.0@abc123" {
+		t.Errorf("expected version %q, got %v", "v1.0@abc123", doc["version"])
+	}
+}
+
+func TestIndexJobSummaryMultipleSteps(t *testing.T) {
+	now := time.Now().UTC()
+	summaries := []JobSummary{
+		{
+			UUID:                testUuid,
+			IncrementalLoadUUID: "step-1",
+			Timestamp:           now,
+			EndTimestamp:        now.Add(10 * time.Second),
+			ElapsedTime:         10,
+			JobConfig:           config.Job{Name: "test-job"},
+			Metadata:            map[string]any{"incrementalLoadUUID": "step-1"},
+			Passed:              true,
+			MetricName:          jobSummaryMetric,
+		},
+		{
+			UUID:                testUuid,
+			IncrementalLoadUUID: "step-2",
+			Timestamp:           now.Add(10 * time.Second),
+			EndTimestamp:        now.Add(25 * time.Second),
+			ElapsedTime:         15,
+			JobConfig:           config.Job{Name: "test-job"},
+			Metadata:            map[string]any{"incrementalLoadUUID": "step-2"},
+			Passed:              true,
+			MetricName:          jobSummaryMetric,
+		},
+	}
+
+	mock := &mockIndexer{}
+	IndexJobSummary(summaries, mock)
+
+	if len(mock.docs[0]) != 2 {
+		t.Fatalf("expected 2 documents, got %d", len(mock.docs[0]))
+	}
+
+	doc1 := mock.docs[0][0].(map[string]any)
+	doc2 := mock.docs[0][1].(map[string]any)
+
+	if doc1["incrementalLoadUUID"] != "step-1" {
+		t.Errorf("doc1: expected incrementalLoadUUID step-1, got %v", doc1["incrementalLoadUUID"])
+	}
+	if doc2["incrementalLoadUUID"] != "step-2" {
+		t.Errorf("doc2: expected incrementalLoadUUID step-2, got %v", doc2["incrementalLoadUUID"])
+	}
+	if doc1["uuid"] != testUuid || doc2["uuid"] != testUuid {
+		t.Error("both docs should share same uuid")
+	}
+}
+
+func TestIndexJobSummaryMetadataMerged(t *testing.T) {
+	summaries := []JobSummary{
+		{
+			UUID:       "uuid-1",
+			Timestamp:  time.Now().UTC(),
+			JobConfig:  config.Job{Name: "job1"},
+			Metadata:   map[string]any{"cluster": "perf-cluster", "incrementalLoadUUID": "step-x"},
+			Passed:     true,
+			MetricName: jobSummaryMetric,
+		},
+	}
+
+	mock := &mockIndexer{}
+	IndexJobSummary(summaries, mock)
+
+	doc := mock.docs[0][0].(map[string]any)
+
+	// Metadata fields merged into top-level doc
+	if doc["cluster"] != "perf-cluster" {
+		t.Errorf("expected metadata field cluster=perf-cluster, got %v", doc["cluster"])
+	}
+	// incrementalLoadUUID from Metadata overwrites the JSON-marshaled field
+	if doc["incrementalLoadUUID"] != "step-x" {
+		t.Errorf("expected incrementalLoadUUID from metadata, got %v", doc["incrementalLoadUUID"])
+	}
+}
+
+func TestIndexMetricsSkipsAlreadyScrapedJobSummary(t *testing.T) {
+	now := time.Now().UTC()
+	mock := &mockIndexer{}
+
+	executedJobs := []prometheus.Job{
+		{
+			Start:               now,
+			End:                 now.Add(10 * time.Second),
+			JobConfig:           config.Job{Name: "job1"},
+			UUID:                "uuid-1",
+			IncrementalLoadUUID: "step-1",
+			MetricsScraped:      true,
+		},
+		{
+			Start:               now.Add(10 * time.Second),
+			End:                 now.Add(20 * time.Second),
+			JobConfig:           config.Job{Name: "job1"},
+			UUID:                "uuid-1",
+			IncrementalLoadUUID: "step-2",
+			MetricsScraped:      false,
+		},
+		{
+			Start:     now,
+			End:       now.Add(20 * time.Second),
+			JobConfig: config.Job{Name: "job1"},
+			UUID:      "uuid-1",
+		},
+	}
+
+	scraper := metrics.Scraper{
+		IndexerList:     map[string]indexers.Indexer{"mock": mock},
+		SummaryMetadata: map[string]any{"platform": "test"},
+	}
+
+	indexMetrics("uuid-1", executedJobs, map[string]returnPair{}, scraper, config.Spec{}, true, "", false)
+
+	if len(mock.indexed) != 1 {
+		t.Fatalf("expected 1 IndexJobSummary call, got %d", len(mock.indexed))
+	}
+
+	docs := mock.docs[0]
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 job summaries (skipping MetricsScraped=true), got %d", len(docs))
+	}
+
+	doc1 := docs[0].(map[string]any)
+	doc2 := docs[1].(map[string]any)
+
+	if doc1["incrementalLoadUUID"] != "step-2" {
+		t.Errorf("first summary should be step-2 (unscraped), got %v", doc1["incrementalLoadUUID"])
+	}
+	if _, has := doc2["incrementalLoadUUID"]; has && doc2["incrementalLoadUUID"] != "" {
+		t.Errorf("second summary should be the parent job with no incrementalLoadUUID, got %v", doc2["incrementalLoadUUID"])
+	}
+}
+
+func TestIndexMetricsSkipsScrapedGCJobSummary(t *testing.T) {
+	now := time.Now().UTC()
+	mock := &mockIndexer{}
+
+	executedJobs := []prometheus.Job{
+		{
+			Start:               now,
+			End:                 now.Add(10 * time.Second),
+			JobConfig:           config.Job{Name: "job1"},
+			UUID:                "uuid-1",
+			IncrementalLoadUUID: "step-1",
+			MetricsScraped:      true,
+		},
+		{
+			Start:               now.Add(10 * time.Second),
+			End:                 now.Add(15 * time.Second),
+			JobConfig:           config.Job{Name: garbageCollectionJob},
+			UUID:                "uuid-1",
+			IncrementalLoadUUID: "step-1",
+			MetricsScraped:      true,
+		},
+		{
+			Start:     now,
+			End:       now.Add(15 * time.Second),
+			JobConfig: config.Job{Name: "job1"},
+			UUID:      "uuid-1",
+		},
+	}
+
+	scraper := metrics.Scraper{
+		IndexerList:     map[string]indexers.Indexer{"mock": mock},
+		SummaryMetadata: map[string]any{"platform": "test"},
+	}
+
+	indexMetrics("uuid-1", executedJobs, map[string]returnPair{}, scraper, config.Spec{}, true, "", false)
+
+	docs := mock.docs[0]
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 job summary (work+gc scraped, only parent remains), got %d", len(docs))
+	}
+
+	doc := docs[0].(map[string]any)
+	if doc["jobConfig"].(map[string]any)["name"] != "job1" {
+		t.Errorf("expected parent job summary for job1, got %v", doc["jobConfig"])
+	}
+}

--- a/pkg/burner/metadata_test.go
+++ b/pkg/burner/metadata_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package burner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloud-bulldozer/go-commons/v2/indexers"
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+)
+
+type mockIndexer struct {
+	indexed []indexers.IndexingOpts
+	docs    [][]interface{}
+}
+
+func (m *mockIndexer) Index(docs []interface{}, opts indexers.IndexingOpts) (string, error) {
+	m.indexed = append(m.indexed, opts)
+	m.docs = append(m.docs, docs)
+	return "indexed", nil
+}
+
+func TestIndexJobSummary(t *testing.T) {
+	now := time.Now().UTC()
+	summaries := []JobSummary{
+		{
+			UUID:                "test-uuid",
+			IncrementalLoadUUID: "step-uuid-1",
+			Timestamp:           now,
+			EndTimestamp:        now.Add(30 * time.Second),
+			ElapsedTime:        30,
+			JobConfig:           config.Job{Name: "test-job"},
+			Metadata:            map[string]any{"incrementalLoadUUID": "step-uuid-1", "platform": "test"},
+			Passed:              true,
+			Version:             "v1.0@abc123",
+			MetricName:          jobSummaryMetric,
+		},
+	}
+
+	mock := &mockIndexer{}
+	IndexJobSummary(summaries, mock)
+
+	if len(mock.indexed) != 1 {
+		t.Fatalf("expected 1 index call, got %d", len(mock.indexed))
+	}
+	if mock.indexed[0].MetricName != jobSummaryMetric {
+		t.Errorf("expected metricName %q, got %q", jobSummaryMetric, mock.indexed[0].MetricName)
+	}
+	if len(mock.docs[0]) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(mock.docs[0]))
+	}
+
+	doc := mock.docs[0][0].(map[string]any)
+	if doc["uuid"] != "test-uuid" {
+		t.Errorf("expected uuid %q, got %v", "test-uuid", doc["uuid"])
+	}
+	if doc["incrementalLoadUUID"] != "step-uuid-1" {
+		t.Errorf("expected incrementalLoadUUID %q, got %v", "step-uuid-1", doc["incrementalLoadUUID"])
+	}
+	if doc["metricName"] != jobSummaryMetric {
+		t.Errorf("expected metricName %q, got %v", jobSummaryMetric, doc["metricName"])
+	}
+	if doc["passed"] != true {
+		t.Errorf("expected passed=true, got %v", doc["passed"])
+	}
+	if doc["platform"] != "test" {
+		t.Errorf("expected metadata platform=test, got %v", doc["platform"])
+	}
+	if doc["version"] != "v1.0@abc123" {
+		t.Errorf("expected version %q, got %v", "v1.0@abc123", doc["version"])
+	}
+}
+
+func TestIndexJobSummaryMultipleSteps(t *testing.T) {
+	now := time.Now().UTC()
+	summaries := []JobSummary{
+		{
+			UUID:                "test-uuid",
+			IncrementalLoadUUID: "step-1",
+			Timestamp:           now,
+			EndTimestamp:        now.Add(10 * time.Second),
+			ElapsedTime:        10,
+			JobConfig:           config.Job{Name: "test-job"},
+			Metadata:            map[string]any{"incrementalLoadUUID": "step-1"},
+			Passed:              true,
+			MetricName:          jobSummaryMetric,
+		},
+		{
+			UUID:                "test-uuid",
+			IncrementalLoadUUID: "step-2",
+			Timestamp:           now.Add(10 * time.Second),
+			EndTimestamp:        now.Add(25 * time.Second),
+			ElapsedTime:        15,
+			JobConfig:           config.Job{Name: "test-job"},
+			Metadata:            map[string]any{"incrementalLoadUUID": "step-2"},
+			Passed:              true,
+			MetricName:          jobSummaryMetric,
+		},
+	}
+
+	mock := &mockIndexer{}
+	IndexJobSummary(summaries, mock)
+
+	if len(mock.docs[0]) != 2 {
+		t.Fatalf("expected 2 documents, got %d", len(mock.docs[0]))
+	}
+
+	doc1 := mock.docs[0][0].(map[string]any)
+	doc2 := mock.docs[0][1].(map[string]any)
+
+	if doc1["incrementalLoadUUID"] != "step-1" {
+		t.Errorf("doc1: expected incrementalLoadUUID step-1, got %v", doc1["incrementalLoadUUID"])
+	}
+	if doc2["incrementalLoadUUID"] != "step-2" {
+		t.Errorf("doc2: expected incrementalLoadUUID step-2, got %v", doc2["incrementalLoadUUID"])
+	}
+	if doc1["uuid"] != "test-uuid" || doc2["uuid"] != "test-uuid" {
+		t.Error("both docs should share same uuid")
+	}
+}
+
+func TestIndexJobSummaryMetadataMerged(t *testing.T) {
+	summaries := []JobSummary{
+		{
+			UUID:       "uuid-1",
+			Timestamp:  time.Now().UTC(),
+			JobConfig:  config.Job{Name: "job1"},
+			Metadata:   map[string]any{"cluster": "perf-cluster", "incrementalLoadUUID": "step-x"},
+			Passed:     true,
+			MetricName: jobSummaryMetric,
+		},
+	}
+
+	mock := &mockIndexer{}
+	IndexJobSummary(summaries, mock)
+
+	doc := mock.docs[0][0].(map[string]any)
+
+	// Metadata fields merged into top-level doc
+	if doc["cluster"] != "perf-cluster" {
+		t.Errorf("expected metadata field cluster=perf-cluster, got %v", doc["cluster"])
+	}
+	// incrementalLoadUUID from Metadata overwrites the JSON-marshalled field
+	if doc["incrementalLoadUUID"] != "step-x" {
+		t.Errorf("expected incrementalLoadUUID from metadata, got %v", doc["incrementalLoadUUID"])
+	}
+}

--- a/pkg/burner/metadata_test.go
+++ b/pkg/burner/metadata_test.go
@@ -20,7 +20,11 @@ import (
 
 	"github.com/cloud-bulldozer/go-commons/v2/indexers"
 	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/kube-burner/kube-burner/v2/pkg/prometheus"
+	"github.com/kube-burner/kube-burner/v2/pkg/util/metrics"
 )
+
+const testUuid = "test-uuid"
 
 type mockIndexer struct {
 	indexed []indexers.IndexingOpts
@@ -37,11 +41,11 @@ func TestIndexJobSummary(t *testing.T) {
 	now := time.Now().UTC()
 	summaries := []JobSummary{
 		{
-			UUID:                "test-uuid",
+			UUID:                testUuid,
 			IncrementalLoadUUID: "step-uuid-1",
 			Timestamp:           now,
 			EndTimestamp:        now.Add(30 * time.Second),
-			ElapsedTime:        30,
+			ElapsedTime:         30,
 			JobConfig:           config.Job{Name: "test-job"},
 			Metadata:            map[string]any{"incrementalLoadUUID": "step-uuid-1", "platform": "test"},
 			Passed:              true,
@@ -64,8 +68,8 @@ func TestIndexJobSummary(t *testing.T) {
 	}
 
 	doc := mock.docs[0][0].(map[string]any)
-	if doc["uuid"] != "test-uuid" {
-		t.Errorf("expected uuid %q, got %v", "test-uuid", doc["uuid"])
+	if doc["uuid"] != testUuid {
+		t.Errorf("expected uuid %q, got %v", testUuid, doc["uuid"])
 	}
 	if doc["incrementalLoadUUID"] != "step-uuid-1" {
 		t.Errorf("expected incrementalLoadUUID %q, got %v", "step-uuid-1", doc["incrementalLoadUUID"])
@@ -88,22 +92,22 @@ func TestIndexJobSummaryMultipleSteps(t *testing.T) {
 	now := time.Now().UTC()
 	summaries := []JobSummary{
 		{
-			UUID:                "test-uuid",
+			UUID:                testUuid,
 			IncrementalLoadUUID: "step-1",
 			Timestamp:           now,
 			EndTimestamp:        now.Add(10 * time.Second),
-			ElapsedTime:        10,
+			ElapsedTime:         10,
 			JobConfig:           config.Job{Name: "test-job"},
 			Metadata:            map[string]any{"incrementalLoadUUID": "step-1"},
 			Passed:              true,
 			MetricName:          jobSummaryMetric,
 		},
 		{
-			UUID:                "test-uuid",
+			UUID:                testUuid,
 			IncrementalLoadUUID: "step-2",
 			Timestamp:           now.Add(10 * time.Second),
 			EndTimestamp:        now.Add(25 * time.Second),
-			ElapsedTime:        15,
+			ElapsedTime:         15,
 			JobConfig:           config.Job{Name: "test-job"},
 			Metadata:            map[string]any{"incrementalLoadUUID": "step-2"},
 			Passed:              true,
@@ -127,7 +131,7 @@ func TestIndexJobSummaryMultipleSteps(t *testing.T) {
 	if doc2["incrementalLoadUUID"] != "step-2" {
 		t.Errorf("doc2: expected incrementalLoadUUID step-2, got %v", doc2["incrementalLoadUUID"])
 	}
-	if doc1["uuid"] != "test-uuid" || doc2["uuid"] != "test-uuid" {
+	if doc1["uuid"] != testUuid || doc2["uuid"] != testUuid {
 		t.Error("both docs should share same uuid")
 	}
 }
@@ -153,8 +157,64 @@ func TestIndexJobSummaryMetadataMerged(t *testing.T) {
 	if doc["cluster"] != "perf-cluster" {
 		t.Errorf("expected metadata field cluster=perf-cluster, got %v", doc["cluster"])
 	}
-	// incrementalLoadUUID from Metadata overwrites the JSON-marshalled field
+	// incrementalLoadUUID from Metadata overwrites the JSON-marshaled field
 	if doc["incrementalLoadUUID"] != "step-x" {
 		t.Errorf("expected incrementalLoadUUID from metadata, got %v", doc["incrementalLoadUUID"])
+	}
+}
+
+func TestIndexMetricsSkipsAlreadyScrapedJobSummary(t *testing.T) {
+	now := time.Now().UTC()
+	mock := &mockIndexer{}
+
+	executedJobs := []prometheus.Job{
+		{
+			Start:               now,
+			End:                 now.Add(10 * time.Second),
+			JobConfig:           config.Job{Name: "job1"},
+			UUID:                "uuid-1",
+			IncrementalLoadUUID: "step-1",
+			MetricsScraped:      true,
+		},
+		{
+			Start:               now.Add(10 * time.Second),
+			End:                 now.Add(20 * time.Second),
+			JobConfig:           config.Job{Name: "job1"},
+			UUID:                "uuid-1",
+			IncrementalLoadUUID: "step-2",
+			MetricsScraped:      false,
+		},
+		{
+			Start:     now,
+			End:       now.Add(20 * time.Second),
+			JobConfig: config.Job{Name: "job1"},
+			UUID:      "uuid-1",
+		},
+	}
+
+	scraper := metrics.Scraper{
+		IndexerList:     map[string]indexers.Indexer{"mock": mock},
+		SummaryMetadata: map[string]any{"platform": "test"},
+	}
+
+	indexMetrics("uuid-1", executedJobs, map[string]returnPair{}, scraper, config.Spec{}, true, "", false)
+
+	if len(mock.indexed) != 1 {
+		t.Fatalf("expected 1 IndexJobSummary call, got %d", len(mock.indexed))
+	}
+
+	docs := mock.docs[0]
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 job summaries (skipping MetricsScraped=true), got %d", len(docs))
+	}
+
+	doc1 := docs[0].(map[string]any)
+	doc2 := docs[1].(map[string]any)
+
+	if doc1["incrementalLoadUUID"] != "step-2" {
+		t.Errorf("first summary should be step-2 (unscraped), got %v", doc1["incrementalLoadUUID"])
+	}
+	if _, has := doc2["incrementalLoadUUID"]; has && doc2["incrementalLoadUUID"] != "" {
+		t.Errorf("second summary should be the parent job with no incrementalLoadUUID, got %v", doc2["incrementalLoadUUID"])
 	}
 }

--- a/pkg/burner/metadata_test.go
+++ b/pkg/burner/metadata_test.go
@@ -218,3 +218,50 @@ func TestIndexMetricsSkipsAlreadyScrapedJobSummary(t *testing.T) {
 		t.Errorf("second summary should be the parent job with no incrementalLoadUUID, got %v", doc2["incrementalLoadUUID"])
 	}
 }
+
+func TestIndexMetricsSkipsScrapedGCJobSummary(t *testing.T) {
+	now := time.Now().UTC()
+	mock := &mockIndexer{}
+
+	executedJobs := []prometheus.Job{
+		{
+			Start:               now,
+			End:                 now.Add(10 * time.Second),
+			JobConfig:           config.Job{Name: "job1"},
+			UUID:                "uuid-1",
+			IncrementalLoadUUID: "step-1",
+			MetricsScraped:      true,
+		},
+		{
+			Start:               now.Add(10 * time.Second),
+			End:                 now.Add(15 * time.Second),
+			JobConfig:           config.Job{Name: garbageCollectionJob},
+			UUID:                "uuid-1",
+			IncrementalLoadUUID: "step-1",
+			MetricsScraped:      true,
+		},
+		{
+			Start:     now,
+			End:       now.Add(15 * time.Second),
+			JobConfig: config.Job{Name: "job1"},
+			UUID:      "uuid-1",
+		},
+	}
+
+	scraper := metrics.Scraper{
+		IndexerList:     map[string]indexers.Indexer{"mock": mock},
+		SummaryMetadata: map[string]any{"platform": "test"},
+	}
+
+	indexMetrics("uuid-1", executedJobs, map[string]returnPair{}, scraper, config.Spec{}, true, "", false)
+
+	docs := mock.docs[0]
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 job summary (work+gc scraped, only parent remains), got %d", len(docs))
+	}
+
+	doc := docs[0].(map[string]any)
+	if doc["jobConfig"].(map[string]any)["name"] != "job1" {
+		t.Errorf("expected parent job summary for job1, got %v", doc["jobConfig"])
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -290,6 +290,8 @@ type IncrementalLoad struct {
 	Pattern LoadPattern `yaml:"pattern" json:"pattern,omitempty"`
 	// HealthCheckScript optional shell script to run as a health check between steps
 	HealthCheckScript string `yaml:"healthCheckScript" json:"healthCheckScript,omitempty"`
+	// ScrapeMetricsPerStep scrape prometheus metrics after each incremental step
+	ScrapeMetricsPerStep bool `yaml:"scrapeMetricsPerStep" json:"scrapeMetricsPerStep,omitempty"`
 }
 
 type LoadPattern struct {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -289,6 +289,8 @@ type IncrementalLoad struct {
 	Pattern LoadPattern `yaml:"pattern" json:"pattern,omitempty"`
 	// HealthCheckScript optional shell script to run as a health check between steps
 	HealthCheckScript string `yaml:"healthCheckScript" json:"healthCheckScript,omitempty"`
+	// ScrapeMetricsPerStep scrape prometheus metrics after each incremental step
+	ScrapeMetricsPerStep bool `yaml:"scrapeMetricsPerStep" json:"scrapeMetricsPerStep,omitempty"`
 }
 
 type LoadPattern struct {

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -49,6 +49,7 @@ type Job struct {
 	JobConfig           config.Job
 	UUID                string
 	IncrementalLoadUUID string
+	MetricsScraped      bool
 }
 
 type metricProfile struct {

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -48,6 +48,7 @@ type Job struct {
 	JobConfig           config.Job
 	UUID                string
 	IncrementalLoadUUID string
+	MetricsScraped      bool
 }
 
 type metricProfile struct {


### PR DESCRIPTION
## Type of change

- New feature

## Description

When using incrementalLoad, scrape prometheus metrics between each incremental step.

This allows us to capture all the data to analyze an environment when we do not know the actual maximum it can support.  In the event that the load breaks the cluster in some way, then we have still indexed all measurements from the previous increment.


## Related Tickets & Documents

- Related Issue #
- Closes #1244
