### PR TITLE
Fixing Link Checker workflow

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,5 +1,5 @@
 # External GitHub URLs that get rate-limited (429) during CI checks
 https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md#conditions
 
-# Slack invite/channel URLs require auth and return 403/404 to crawlers
+# Slack invite/channel URLs require auth and return 403/404
 https://kubernetes.slack.com/.*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,4 +2,4 @@
 https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md#conditions
 
 # Slack invite/channel URLs require auth and return 403/404 to crawlers
-#https://kubernetes.slack.com/.*
+https://kubernetes.slack.com/.*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,5 @@
 # External GitHub URLs that get rate-limited (429) during CI checks
 https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md#conditions
+
+# Slack invite/channel URLs require auth and return 403/404 to crawlers
+https://kubernetes.slack.com/.*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,4 +2,4 @@
 https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md#conditions
 
 # Slack invite/channel URLs require auth and return 403/404 to crawlers
-https://kubernetes.slack.com/.*
+#https://kubernetes.slack.com/.*


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->
- Bug fix

## Description

The release artifacts didn't get published as the link checker [failed](https://github.com/kube-burner/kube-burner/actions/runs/32268234731/job/96117932126)

The slack [kubernetes slack](https://kubernetes.slack.com/messages/kube-burner).
) is returning 403: so added it to ignore

## Testing
Tested it locally with act and running the workflow: .github/workflows/check-docs-links.yml 