### PR TITLE
Fix crash when user data file is empty or invalid

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -261,11 +261,11 @@ func ParseWithUserdata(uuid string, timeout time.Duration, configFileReader, use
 	}
 
 	inputData, err := getInputData(userDataFileReader, additionalVars)
-	inputData["UUID"] = uuid
-	configSpec.GlobalConfig.UUID = uuid
 	if err != nil {
 		return configSpec, err
 	}
+	inputData["UUID"] = uuid
+	configSpec.GlobalConfig.UUID = uuid
 	templateOptions := util.MissingKeyError
 	if allowMissingKeys {
 		templateOptions = util.MissingKeyZero


### PR DESCRIPTION
## Type of change
- Bug fix

## Description
Found this while testing `--user-data` with a bad file — instead of a proper error, I got a raw panic.

`ParseWithUserdata()` in `pkg/config/config.go` was writing to the map returned by `getInputData()` before checking if it had an error. When `--user-data` failed to load, was empty, or had bad YAML, `getInputData()` returned nil. Writing `inputData["UUID"] = uuid` on a nil map caused a panic instead of returning the actual error.

Fix is simple — just check the error from `getInputData()` before writing to the map.

This also makes the existing "user data file is empty" error actually show up, since before it could never be reached because the panic happened first.

No change to the working path — `getInputData()` never returns a valid map along with an error, so this only changes what happens when it fails.

**Testing**
- Tested on main (81f2218) with an empty `--user-data` file and one with bad YAML — both crashed at `config.go:264`.
- After the fix, the empty file gives the "user data file is empty" message instead of crashing.
- Bad YAML now shows the proper parse error instead of crashing.
- Checked that a normal `--user-data` file still works fine and renders the template variables like before.
- `make lint` passes.
