### PR TITLE
Restoring beforeChurn implementation

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -509,6 +509,7 @@ The `when` field specifies at which stage the hook should execute:
 | `beforeJobExecution`     | Before the job starts creating or processing objects                                                 |
 | `onEachIteration`        | At the start of each iteration of a create job                                                       |
 | `afterJobExecution`      | After the job finishes creating or processing objects (before churn, if enabled)                     |
+| `beforeChurn`            | Before churn starts on create jobs with churn enabled                                                |
 | `afterChurn`             | After churn completes on create jobs with churn enabled                                              |
 | `beforeCleanup`          | After the job finishes, before job pause and optional garbage collection                             |
 | `afterCleanup`           | After per-job garbage collection (`gc: true`), or after global GC when `gcMetrics` is enabled        |
@@ -617,7 +618,7 @@ hooks:
 ```yaml
 hooks:
   - cmd: ["/usr/local/bin/collect-churn-metrics.sh"]
-    when: afterJobExecution
+    when: beforeChurn
     background: true
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -509,7 +509,8 @@ The `when` field specifies at which stage the hook should execute:
 | `beforeJobExecution`     | Before the job starts creating or processing objects                                                 |
 | `onEachIteration`        | At the start of each iteration of a create job                                                       |
 | `afterJobExecution`      | After the job finishes creating or processing objects (before churn, if enabled)                     |
-| `beforeChurn`            | Before churn starts on create jobs with churn enabled                                                |
+| `beforeChurn`            | Before churn starts in create jobs with churn enabled. Please note that some actions may occur between afterJobExecution and this phase                                                    
+|
 | `afterChurn`             | After churn completes on create jobs with churn enabled                                              |
 | `beforeCleanup`          | After the job finishes, before job pause and optional garbage collection                             |
 | `afterCleanup`           | After per-job garbage collection (`gc: true`), or after global GC when `gcMetrics` is enabled        |

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -807,6 +807,10 @@ func (ex *JobExecutor) RunCreateJobWithChurn(ctx context.Context) []error {
 	// Cleanup namespaces based on the labels we added to the objects
 	log.Infof("Churning mode: %s", ex.ChurnConfig.Mode)
 	var hookErrors []error
+	// Execute beforeChurn hooks
+	if ex.executeHooksForJobStage(config.HookBeforeChurn, &hookErrors, nil); len(hookErrors) > 0 {
+		log.Errorf("%v", hookErrors)
+	}
 	switch ex.ChurnConfig.Mode {
 	case config.ChurnNamespaces:
 		ex.nsChurning = true // Enable namespace churning flag to prevent non namespaced objects to be churned

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -435,6 +435,7 @@ func HookBeforeWorkload() error {
 	validWhen := map[JobHook]bool{
 		HookBeforeJobExecution: true,
 		HookAfterJobExecution:  true,
+		HookBeforeChurn:        true,
 		HookAfterChurn:         true,
 		HookBeforeCleanup:      true,
 		HookAfterCleanup:       true,

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -28,6 +28,7 @@ type JobHook string
 const (
 	HookBeforeJobExecution JobHook = "beforeJobExecution"
 	HookAfterJobExecution  JobHook = "afterJobExecution"
+	HookBeforeChurn        JobHook = "beforeChurn"
 	HookAfterChurn         JobHook = "afterChurn"
 	HookBeforeCleanup      JobHook = "beforeCleanup"
 	HookAfterCleanup       JobHook = "afterCleanup"

--- a/test/k8s/kube-burner-hooks.yml
+++ b/test/k8s/kube-burner-hooks.yml
@@ -31,6 +31,10 @@ jobs:
         when: onEachIteration
         background: true
       
+      - cmd: ["/bin/bash", "../hooks/simple-hook.sh", "beforeChurn"]
+        when: beforeChurn
+        background: true
+
       - cmd: ["/bin/bash", "../hooks/simple-hook.sh", "afterChurn"]
         when: afterChurn
         background: true


### PR DESCRIPTION
## Type of change

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation
- CI

## Description
Restore batch churn implementation as it supports workload than need chaos to be created during churning a workload.

## Related Tickets & Documents
This will be useful for special case where we have a lot of chaos going on the cluster during the churn phase.

## Testing
Tested and verified in local in integration with ocp-wrapper.
[kube-burner-ocp-6deb8d11-3af4-4aad-877b-47e479b759e1.log](https://github.com/user-attachments/files/31614863/kube-burner-ocp-6deb8d11-3af4-4aad-877b-47e479b759e1.log)

Able to reproduce spiky behavior in api-server thread usage
<img width="1512" height="982" alt="Screenshot 2026-08-30 at 10 18 23 AM" src="https://github.com/user-attachments/assets/92d8b2fd-f09b-441b-82f6-e8cb970e75e4" />