### PR TITLE
Adding global hooks support from PR#1193

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -44,6 +44,7 @@ In this section is described global job configuration, it holds the following pa
 | `timeout` | Global benchmark timeout                                             | Duration        | 4hr      |
 | `functionTemplates` | Function template files to render at runtime                                             | List        | []      |
 | `deletionStrategy` | Global deletion strategy to apply, `default` or `gvr` (where `default` deletes entire namespaces and `gvr` deletes objects within namespaces)   | String   | default  |
+| `hooks`            | List of global hooks to execute before/after all jobs. See [hooks section](#hooks)                      | List     | []       |
 
 !!! note
     The precedence order to wait on resources is Global.waitWhenFinished > Job.waitWhenFinished > Job.podWait
@@ -488,11 +489,14 @@ This will create both the Gateway and VirtualService for each iteration, with pr
 
 ### Hooks
 
-Hooks allow you to execute external commands at various stages of job execution. They support both foreground (blocking) and background (non-blocking) execution modes.
+Hooks allow you to execute external commands at various stages of execution. They support both foreground (blocking) and background (non-blocking) execution modes. Kube-burner supports two types of hooks:
+
+- **Global hooks**: Run before/after all jobs, configured in the `global` section
+- **Job-level hooks**: Run at specific stages of individual job execution
 
 #### Hook Configuration
 
-Hooks are configured as a list under the `hooks` field in a job:
+Hooks are configured as a list under the `hooks` field:
 
 | Option       | Description                                                                                          | Type     | Default |
 |--------------|------------------------------------------------------------------------------------------------------|----------|---------|
@@ -503,6 +507,15 @@ Hooks are configured as a list under the `hooks` field in a job:
 #### Supported Hook Stages
 
 The `when` field specifies at which stage the hook should execute:
+
+**Global Hook Stages** (configured in `global.hooks`):
+
+| Stage            | Description                                                                 |
+|------------------|-----------------------------------------------------------------------------|
+| `beforeAllJobs`  | Before any job or measurement starts                                         |
+| `afterAllJobs`   | After the benchmark execution regardless of test success or failure         |
+
+**Job-Level Hook Stages** (configured in `jobs[].hooks`):
 
 | Stage                    | Description                                                                                          |
 |--------------------------|------------------------------------------------------------------------------------------------------|
@@ -562,6 +575,35 @@ Local files always take precedence over embedded scripts. This allows workload a
 
 #### Example Configuration
 
+**Global hooks example:**
+
+```yaml
+global:
+  hooks:
+    # Run setup script before any job starts
+    - cmd: ["/scripts/cluster-setup.sh"]
+      when: beforeAllJobs
+      background: false
+
+    # Start monitoring in background for entire benchmark
+    - cmd: ["/scripts/collect-metrics.sh", "--output=/data"]
+      when: beforeAllJobs
+      background: true
+
+    # Run cleanup after all jobs complete
+    - cmd: ["/scripts/final-cleanup.sh"]
+      when: afterAllJobs
+      background: false
+
+jobs:
+  - name: job-1
+    # ...
+  - name: job-2
+    # ...
+```
+
+**Job-level hooks example:**
+
 ```yaml
 jobs:
   - name: my-workload
@@ -596,6 +638,16 @@ jobs:
 ```
 
 #### Use Cases
+
+**Global benchmark setup and teardown:**
+```yaml
+global:
+  hooks:
+    - cmd: ["/scripts/prepare-cluster.sh"]
+      when: beforeAllJobs
+    - cmd: ["/scripts/generate-report.sh"]
+      when: afterAllJobs
+```
 
 **Long-running background monitoring:**
 ```yaml

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -98,6 +98,17 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 		var innerRC int
 		measurementsFactory := measurements.NewMeasurementsFactory(configSpec, metricsScraper.MetricsMetadata, additionalMeasurementFactoryMap)
 		jobExecutors = newExecutorList(configSpec, kubeClientProvider, embedCfg)
+
+		// Execute global beforeAllJobs hooks
+		if len(globalConfig.Hooks) > 0 {
+			globalHookManager := NewHookManager(ctx, len(globalConfig.Hooks), embedCfg)
+			if err := globalHookManager.executeHooks(globalConfig.Hooks, config.HookBeforeAllJobs); err != nil {
+				log.Errorf("Error executing global beforeAllJobs hooks: %v", err)
+				errs = append(errs, err)
+				innerRC = 1
+			}
+		}
+
 		if err := handlePreloadImages(ctx, jobExecutors, kubeClientProvider); err != nil {
 			log.Error(err.Error())
 			return
@@ -308,6 +319,17 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 			returnMap[job.JobConfig.Name] = returnPair{innerRC: innerRC, executionErrors: executionErrors}
 		}
 		indexMetrics(uuid, executedJobs, returnMap, metricsScraper, configSpec, true, "", false)
+
+		// Execute global afterAllJobs hooks (after metrics indexing)
+		if len(globalConfig.Hooks) > 0 {
+			globalHookManager := NewHookManager(ctx, len(globalConfig.Hooks), embedCfg)
+			if err := globalHookManager.executeHooks(globalConfig.Hooks, config.HookAfterAllJobs); err != nil {
+				log.Errorf("Error executing global afterAllJobs hooks: %v", err)
+				errs = append(errs, err)
+				innerRC = 1
+			}
+		}
+
 		log.Infof("Finished execution with UUID: %s", uuid)
 		res <- innerRC
 	}()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -34,6 +34,9 @@ const (
 	HookBeforeGC           JobHook = "beforeGC"
 	HookAfterGC            JobHook = "afterGC"
 	HookOnEachIteration    JobHook = "onEachIteration"
+	// Global hooks - not tied to any specific job
+	HookBeforeAllJobs JobHook = "beforeAllJobs"
+	HookAfterAllJobs  JobHook = "afterAllJobs"
 )
 
 // JobType type of job
@@ -115,6 +118,8 @@ type GlobalConfig struct {
 	FunctionTemplates []string `yaml:"functionTemplates"`
 	// DeletionStrategy global deletion strategy for all created objects
 	DeletionStrategy string `yaml:"deletionStrategy" json:"deletionStrategy,omitempty"`
+	// Hooks global hooks to execute before/after all jobs
+	Hooks []Hook `yaml:"hooks" json:"hooks,omitempty"`
 }
 
 // ObjectGroup controls grouping and per-object lifecycle behavior within grouped execution


### PR DESCRIPTION
Allow running hooks that are not tied to any specific job. Global hooks are configured in the 'global' section and execute before any job starts or after all jobs complete.

This helps networking workloads to setup test envrionment (like external server, port forwarding, frr) before running the jobs and avoid over dependency on measurement code to acheieve the same

Pair programmed looking at: https://github.com/kube-burner/kube-burner/pull/1193