### PR TITLE
Propagate file write errors during workload extraction

### DIFF
--- a/pkg/util/createfile_test.go
+++ b/pkg/util/createfile_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateFile(t *testing.T) {
+	fileName := filepath.Join(t.TempDir(), "workload.yml")
+	fileContent := []byte("kind: Pod\n")
+
+	if err := CreateFile(fileName, fileContent); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("unexpected error reading %s: %v", fileName, err)
+	}
+	if string(content) != string(fileContent) {
+		t.Fatalf("file content is %q, want %q", content, fileContent)
+	}
+}
+
+func TestCreateFileReturnsWriteError(t *testing.T) {
+	// Writes to /dev/full always fail with ENOSPC
+	if _, err := os.Stat("/dev/full"); err != nil {
+		t.Skip("/dev/full is not available")
+	}
+	if err := CreateFile("/dev/full", []byte("kind: Pod\n")); err == nil {
+		t.Fatal("CreateFile returned no error, want a write error")
+	}
+}

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -128,6 +128,6 @@ func CreateFile(fileName string, fileContent []byte) error {
 		return err
 	}
 	defer fd.Close()
-	fd.Write(fileContent)
-	return nil
+	_, err = fd.Write(fileContent)
+	return err
 }

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -133,7 +133,9 @@ func extractDirectory(subFS fs.FS, dirPath string) error {
 			if err != nil {
 				return err
 			}
-			extractDirectory(subFS, path.Join(dirPath, f.Name()))
+			if err := extractDirectory(subFS, path.Join(dirPath, f.Name())); err != nil {
+				return err
+			}
 			continue
 		}
 		filePath := path.Join(dirPath, f.Name())
@@ -141,7 +143,7 @@ func extractDirectory(subFS fs.FS, dirPath string) error {
 		if err != nil {
 			return err
 		}
-		if util.CreateFile(filePath, fileContent) != nil {
+		if err := util.CreateFile(filePath, fileContent); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

`util.CreateFile` was ignoring the error returned by `fd.Write`, so a failed write could still be reported as successful. `extractDirectory` also had an error-handling issue where the write error was lost, and errors from recursive calls were ignored.

This PR fixes both issues and adds tests for `CreateFile`, including a failed write using `/dev/full`.

I also verified the old behaviour with `/dev/full`, where `CreateFile` returned `<nil>` even though the write failed with `ENOSPC`.

`ExtractWorkload` has no callers in this repo and is exported for downstream users, so there should be no in-tree behaviour changes.
